### PR TITLE
fix: 修复代码中的拼写错误 (typo)

### DIFF
--- a/core-render-ios/Handler/KuiklyRenderFrameworkContextHandler.m
+++ b/core-render-ios/Handler/KuiklyRenderFrameworkContextHandler.m
@@ -22,7 +22,7 @@
 #define MAX_FRAMEWORK_NAME_LENGTH 100
 
 
-#define KRSafeObject(objcet) objcet?:@""
+#define KRSafeObject(object) object?:@""
 #define KRSafeArrayIndex(array, index)  ((index < array.count)?array[index] : nil)
 
 @protocol KRKuiklyKotlinCoreEntryDelegate

--- a/iosApp/iosApp/Vendor/RIJCategory/NSObject+RIJCategory.m
+++ b/iosApp/iosApp/Vendor/RIJCategory/NSObject+RIJCategory.m
@@ -459,18 +459,18 @@
     return [NSString stringWithFormat:@"%ld",(long)self];
 }
 
-- (RIJDeallocObject *)rij_deallocObjcet{
-    RIJDeallocObject * objcet = objc_getAssociatedObject(self, @selector(rij_deallocObjcet));
-    if (!objcet) {
-        objcet = [RIJDeallocObject new];
-        objcet.obj = [self rij_address];
-        objc_setAssociatedObject(self, @selector(rij_deallocObjcet), objcet, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+- (RIJDeallocObject *)rij_deallocObject{
+    RIJDeallocObject * object = objc_getAssociatedObject(self, @selector(rij_deallocObject));
+    if (!object) {
+        object = [RIJDeallocObject new];
+        object.obj = [self rij_address];
+        objc_setAssociatedObject(self, @selector(rij_deallocObject), object, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
-    return objcet;
+    return object;
 }
 
 -(void)rij_performBlockOnDeallocWithBlock:(IDBlock) block{
-    [[self rij_deallocObjcet] addBlockWithBlock:block];
+    [[self rij_deallocObject] addBlockWithBlock:block];
 }
 
 


### PR DESCRIPTION
## 修复内容
此PR修复了代码中的以下拼写错误：
1. 在 NSObject+RIJCategory.m 文件中：
- 将方法名 rij_deallocObjcet 修正为 rij_deallocObject
- 将变量名 objcet 修正为 object
- 同步修改了所有调用该方法的地方
2. 在 KuiklyRenderFrameworkContextHandler.m 文件中：
- 将宏定义 KRSafeObject(objcet) 修正为 KRSafeObject(object)
## 修复方式
进行了纯文本替换，不涉及任何功能变更。这些修改仅仅是拼写纠正，使代码更符合规范，提高了可读性和一致性。
## 修复影响
这些修改不影响代码的功能执行，纯属拼写错误修复，属于代码清理工作。
## 关联issue
修复 #36