### PR TITLE
fix:修复 Image组件扩展函数代码错误问题。

### DIFF
--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/ImageView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/ImageView.kt
@@ -30,7 +30,7 @@ import kotlin.math.min
 fun ViewContainer<*, *>.Image(init: ImageView.() -> Unit) {
     val imageView = createViewFromRegister(ViewConst.TYPE_IMAGE_CLASS_NAME) as? ImageView
     if (imageView != null) {
-        addChild(ImageView(), init)
+        addChild(imageView, init)
     } else {
         addChild(ImageView(), init)
     }


### PR DESCRIPTION
从源码上看应该是想复用 imageView。但实际代码的预期不是这样的。

错误源码：
![CleanShot 2025-06-13 at 17 27 00](https://github.com/user-attachments/assets/a5f1003e-6751-4d59-abdc-490f9f860589)

修正：
<img width="794" alt="CleanShot 2025-06-13 at 17 27 12@2x" src="https://github.com/user-attachments/assets/3b1edb9c-f448-42cd-b522-da2150ffcf2d" />
