### PR TITLE
feat:support RefreshView in Scroller use

### DIFF
--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/RefreshView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/RefreshView.kt
@@ -21,12 +21,13 @@ import com.tencent.kuikly.core.layout.undefined
 import com.tencent.kuikly.core.timer.setTimeout
 
 /**
- * 在 ListView 中添加一个 RefreshView 实例。
+ * 在 Scroller 中添加一个 RefreshView 实例。
  * @param init 一个 RefreshView.() -> Unit 函数，用于初始化 RefreshView 的属性和子视图。
  */
-fun ListView<*, *>.Refresh(init: RefreshView.() -> Unit) {
+fun ScrollerView<*, *>.Refresh(init: RefreshView.() -> Unit) {
     addChild(RefreshView(), init)
 }
+
 
 class RefreshAttr : ContainerAttr() {
     var refreshEnable = true
@@ -68,7 +69,7 @@ class RefreshView : ViewContainer<RefreshAttr, RefreshEvent>(), IListViewEventOb
     fun beginRefresh(animated: Boolean = true) {
         performTaskWhenRenderViewDidLoad {
             if (refreshState != RefreshViewState.REFRESHING) {
-                listView?.setContentOffset(0f, -flexNode.layoutFrame.height, animated = animated)
+                scrollerView?.setContentOffset(0f, -flexNode.layoutFrame.height, animated = animated)
                 refreshState = RefreshViewState.REFRESHING
             }
         }
@@ -83,17 +84,17 @@ class RefreshView : ViewContainer<RefreshAttr, RefreshEvent>(), IListViewEventOb
         }
     }
 
-    private val listView: ListView<*, *>?
-        get() = (parent?.parent as? ListView<*, *>)
+    private val scrollerView: ScrollerView<*, *>?
+        get() = (parent?.parent as? ScrollerView<*, *>)
 
     private var contentInsetTop: Float = 0f
         set(value) {
-            listView?.setContentInset(top = value, animated = true)
+            scrollerView?.setContentInset(top = value, animated = true)
         }
 
     var contentInsetTopWhenEndDrag: Float = 0f
         set(value) {
-            listView?.setContentInsetWhenEndDrag(top = value)
+            scrollerView?.setContentInsetWhenEndDrag(top = value)
         }
 
     var refreshState: RefreshViewState = RefreshViewState.IDLE
@@ -116,12 +117,12 @@ class RefreshView : ViewContainer<RefreshAttr, RefreshEvent>(), IListViewEventOb
 
     override fun didMoveToParentView() {
         super.didMoveToParentView()
-        listView?.addScrollerViewEventObserver(this)
+        scrollerView?.addScrollerViewEventObserver(this)
     }
 
     override fun willRemoveFromParentView() {
         super.willRemoveFromParentView()
-        listView?.removeScrollerViewEventObserver(this)
+        scrollerView?.removeScrollerViewEventObserver(this)
     }
 
     override fun createAttr(): RefreshAttr {
@@ -186,7 +187,7 @@ class RefreshView : ViewContainer<RefreshAttr, RefreshEvent>(), IListViewEventOb
         if (newState == RefreshViewState.IDLE && oldState == RefreshViewState.REFRESHING) {
             contentInsetTop = 0f
             contentInsetTopWhenEndDrag = 0f
-            if ((listView?.curOffsetY ?: 0f) >= 0) { // 分发状态变化
+            if ((scrollerView?.curOffsetY ?: 0f) >= 0) { // 分发状态变化
                 dispatchRefreshStateChanged(RefreshViewState.IDLE)
             } else {
                 setTimeout(200) {

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/kit_demo/DeclarativeDemo/ScrollerRefreshExamplePage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/kit_demo/DeclarativeDemo/ScrollerRefreshExamplePage.kt
@@ -1,0 +1,137 @@
+package com.tencent.kuikly.demo.pages.demo.kit_demo.DeclarativeDemo
+
+import com.tencent.kuikly.demo.pages.base.BasePager
+import com.tencent.kuikly.core.annotations.Page
+import com.tencent.kuikly.core.base.Color
+import com.tencent.kuikly.core.base.ViewBuilder
+import com.tencent.kuikly.core.base.ViewRef
+import com.tencent.kuikly.core.directives.vfor
+import com.tencent.kuikly.core.reactive.handler.observable
+import com.tencent.kuikly.core.reactive.handler.observableList
+import com.tencent.kuikly.core.timer.setTimeout
+import com.tencent.kuikly.core.views.Refresh
+import com.tencent.kuikly.core.views.RefreshView
+import com.tencent.kuikly.core.views.RefreshViewState
+import com.tencent.kuikly.core.views.Scroller
+import com.tencent.kuikly.core.views.Text
+import kotlin.math.max
+import kotlin.random.Random
+
+
+internal data class ScrollerItem(
+    var title: String
+)
+
+@Page("AnyRefreshExamplePage")
+internal class AnyRefreshExamplePage : BasePager() {
+
+    private val randomHelper = Random.Default
+
+    private val items by observableList<ScrollerItem>()
+
+    private var refreshText by observable("")
+
+    /**
+     * 刷新次数
+     */
+    private var refreshCount: Int = 0
+
+
+    private var refreshRef: ViewRef<RefreshView>? = null
+
+    override fun pageDidAppear() {
+        super.pageDidAppear()
+        val items = mutableListOf<ScrollerItem>()
+        for (i in 0..50) {
+            items.add(ScrollerItem("AnyRefreshExamplePage,refreshCount:$refreshCount index:$i"))
+        }
+        this.items.addAll(items)
+    }
+    
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            Scroller {
+                attr {
+                    flex(1f)
+                    margin(left = 16f, top = ctx.pageData.statusBarHeight, right = 16f, bottom = 4f)
+                    showScrollerIndicator(true)
+                    flexDirectionColumn()
+                    alignItemsCenter()
+                    backgroundColor(Color(0xFFF9F9F9))
+                }
+                Refresh {
+                    ref {
+                        ctx.refreshRef = it
+                    }
+                    attr {
+                        height(50f)
+                        allCenter()
+                    }
+                    event {
+                        refreshStateDidChange {
+                            when(it) {
+                                RefreshViewState.REFRESHING -> {
+                                    ctx.refreshText = "正在刷新"
+                                    ctx.refreshData {
+                                        ctx.refreshRef?.view?.endRefresh()
+                                        ctx.refreshText = "刷新成功"
+                                    }
+                                }
+                                RefreshViewState.IDLE -> ctx.refreshText = "下拉刷新"
+                                RefreshViewState.PULLING -> ctx.refreshText = "松手即可刷新"
+                            }
+                        }
+                    }
+                    Text {
+                        attr {
+                            color(Color.BLACK)
+                            text(ctx.refreshText)
+                        }
+                    }
+                }
+
+                vfor({ctx.items}){
+                    Text {
+                        attr {
+                            height(50f)
+                            text(it.title)
+                            fontSize(16f)
+                            backgroundColor(ctx.randomColor())
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun refreshData(block: () -> Unit){
+        setTimeout(1500){
+            this.items.clear()
+            refreshCount++
+            val items = mutableListOf<ScrollerItem>()
+            for (i in 0..50) {
+                items.add(ScrollerItem("AnyRefreshExamplePage,refreshCount:$refreshCount index:$i"))
+            }
+            this.items.addAll(items)
+            block.invoke()
+
+        }
+    }
+
+    private fun randomColor(): Color {
+        var rgbValue: Long = 0xE9000000L
+        var totalRGBValue = randomHelper.nextInt() % 64 + 192
+        var r = randomHelper.nextInt(499999, 999999)
+        var g = randomHelper.nextInt(499999, 999999)
+        var b = randomHelper.nextInt(499999, 999999)
+        var totalRGB = max(max(r, g), b)
+        r = r * totalRGBValue / totalRGB
+        g = g * totalRGBValue / totalRGB
+        b = b * totalRGBValue / totalRGB
+        rgbValue += (r * 0x00010000L)
+        rgbValue += (g * 0x00000100L)
+        rgbValue += (b * 0x00000001L)
+        return Color(rgbValue)
+    }
+}


### PR DESCRIPTION
#138  
背景：如部分页面是一个可滚动+可下拉刷新的页面，但这个页面不是一个标准的ListView。

所以本PR尝试将Refresh支持到 Scroller 级别。并新增 Scroller+Refresh Demo。
由于不确定之前为什么不支持到 Scroller 。可能有其他顾虑？所以辛苦看看是否有遗漏的考虑。