### PR TITLE
Fix：修复KuiklyBaseView 、KuiklyRenderViewControllerBaseDelegator内存泄漏

### DIFF
--- a/core-render-ios/Extension/KuiklyBaseView.m
+++ b/core-render-ios/Extension/KuiklyBaseView.m
@@ -61,6 +61,16 @@
     [super setFrame:frame];
     [_delegator viewDidLayoutSubviews];
 }
+
+- (void)willMoveToSuperview:(UIView *)newSuperview {
+    [super willMoveToSuperview:newSuperview];
+    if (!newSuperview) {
+        if (_delegator) {
+            _delegator = nil;
+        }
+    }
+}
+
 #pragma mark - public
 /*
  * @brief ViewController的viewWillAppear时机调用该方法.

--- a/core-render-ios/Extension/KuiklyRenderViewControllerBaseDelegator.m
+++ b/core-render-ios/Extension/KuiklyRenderViewControllerBaseDelegator.m
@@ -246,10 +246,10 @@ NSString *const KRPageDataSnapshotKey = @"kr_snapshotKey";
     [self p_disptachDelegatorLifeCycleWithSel:@selector(willFetchContextCode) object:nil];
     [self fetchContextCodeWithResultCallback:^(NSString * _Nullable contextCode, NSError * _Nullable error) {
         if (!weakSelf) {
-            return ;
+            return;
         }
         [weakSelf p_performOnMainThreadWithBlock:^{
-            weakSelf.contextMode = [self createContextMode:contextCode];
+            weakSelf.contextMode = [weakSelf createContextMode:contextCode];
             [weakSelf p_disptachDelegatorLifeCycleWithSel:@selector(didFetchContextCode) object:nil];
             weakSelf.fetchContextCoding = NO;
             [weakSelf p_hideAllStatusView];


### PR DESCRIPTION
Fix：修复KuiklyBaseView内存泄漏
当KuiklyBaseView作为原生VC子视图或者弹窗临时展示时，未声明成属性（如使用静态方法），KuiklyBaseView未配套调用viewDidAppear、viewDidDisappear等，KuiklyBaseView、KuiklyRenderViewControllerBaseDelegator以及KuiklyRenderView之间相互持有，无法释放，造成内存泄露。
可在KuiklyBaseView添加willMoveToSuperview，移除KuiklyBaseView的delegator，当KuiklyBaseView被移除时自动释放，无需再配套调用viewDidAppear、viewDidDisappear等，方便KuiklyBaseView未被声明成属性的一些场景中调用


Fix：修复KuiklyRenderViewControllerBaseDelegator-fetchContextCodeWithResultCallback内存泄漏
当初始化KuiklyRenderViewControllerBaseDelegator直接传入frameworkName，而不是使用KuiklyRenderViewControllerBaseDelegatorDelegate实现frameworkName时，导致KuiklyRenderViewControllerBaseDelegator与renderVC或者renderView无法释放，造成内存泄漏