### PR TITLE
feat：iOS支持自定义bundle获取图片等资源URL，适用于自定义资源bundle（非mainBundle的场景）

### DIFF
--- a/core-render-ios/Core/KuiklyContextParam.m
+++ b/core-render-ios/Core/KuiklyContextParam.m
@@ -15,6 +15,7 @@
 
 #import "KuiklyContextParam.h"
 #import "KuiklyRenderFrameworkContextHandler.h"
+#import "KuiklyRenderBridge.h"
 
 const KuiklyContextMode KuiklyContextMode_Framework = 1;
 
@@ -29,9 +30,17 @@ const KuiklyContextMode KuiklyContextMode_Framework = 1;
 }
 
 - (NSURL *)urlForFileName:(NSString *)fileName extension:(NSString *)fileExtension {
-    NSBundle *mainBundle = [NSBundle mainBundle];
-    NSURL *fileURL = [mainBundle URLForResource:fileName withExtension:fileExtension];
-    return fileURL;
+    // 从自定义bundle中获取资源URL
+    if ([[KuiklyRenderBridge componentExpandHandler] respondsToSelector:@selector(hr_customBundleUrlForFileName:extension:)]) {
+        return [[KuiklyRenderBridge componentExpandHandler] hr_customBundleUrlForFileName:fileName
+                                                                                extension:fileExtension];
+    }
+    // 从mainBundle中获取资源URL
+    else {
+        NSBundle *mainBundle = [NSBundle mainBundle];
+        NSURL *fileURL = [mainBundle URLForResource:fileName withExtension:fileExtension];
+        return fileURL;
+    }
 }
 
 - (id<KuiklyRenderContextProtocol>)createContextHandlerWithContextCode:(NSString *)contextCode

--- a/core-render-ios/Extension/BridgeProtocol/KuiklyRenderBridge.h
+++ b/core-render-ios/Extension/BridgeProtocol/KuiklyRenderBridge.h
@@ -60,12 +60,6 @@ typedef void (^KRBundleResponse)(NSString *_Nullable script , NSError *_Nullable
 + (void)registerCacheHandler:(id<KRCacheProtocol>)cacheHandler;
 
 
-/*
- * @brief 注册自定义Cache实现
- */
-+ (void)registerCacheHandler:(id<KRCacheProtocol>)cacheHandler;
-
-
 + (id<KuiklyRenderComponentExpandProtocol>)componentExpandHandler;
 
 @end
@@ -91,6 +85,14 @@ typedef void(^ImageCompletionBlock)(UIImage * _Nullable image, NSError * _Nullab
 
 @optional
 
+
+/*
+ * 从自定义bundle获取图片等资源URL，用于加载图片等资源（适用于自定义资源bundle，非mainBundle的场景）
+ * @param fileName 资源图片文件名
+ * @param extension 资源图片fileExtension
+ * @return 图片等资源URL
+ */
+- (NSURL *)hr_customBundleUrlForFileName:(NSString *)fileName extension:(NSString *)fileExtension;
 
 /*
  * 自定义实现设置图片（带完成回调，优先调用该方法）

--- a/core-render-ios/Extension/KuiklyBaseView.m
+++ b/core-render-ios/Extension/KuiklyBaseView.m
@@ -61,6 +61,16 @@
     [super setFrame:frame];
     [_delegator viewDidLayoutSubviews];
 }
+
+- (void)willMoveToSuperview:(UIView *)newSuperview {
+    [super willMoveToSuperview:newSuperview];
+    if (!newSuperview) {
+        if (_delegator) {
+            _delegator = nil;
+        }
+    }
+}
+
 #pragma mark - public
 /*
  * @brief ViewController的viewWillAppear时机调用该方法.

--- a/core-render-ios/Extension/KuiklyRenderViewControllerBaseDelegator.m
+++ b/core-render-ios/Extension/KuiklyRenderViewControllerBaseDelegator.m
@@ -246,10 +246,10 @@ NSString *const KRPageDataSnapshotKey = @"kr_snapshotKey";
     [self p_disptachDelegatorLifeCycleWithSel:@selector(willFetchContextCode) object:nil];
     [self fetchContextCodeWithResultCallback:^(NSString * _Nullable contextCode, NSError * _Nullable error) {
         if (!weakSelf) {
-            return ;
+            return;
         }
         [weakSelf p_performOnMainThreadWithBlock:^{
-            weakSelf.contextMode = [self createContextMode:contextCode];
+            weakSelf.contextMode = [weakSelf createContextMode:contextCode];
             [weakSelf p_disptachDelegatorLifeCycleWithSel:@selector(didFetchContextCode) object:nil];
             weakSelf.fetchContextCoding = NO;
             [weakSelf p_hideAllStatusView];


### PR DESCRIPTION
feat：iOS支持自定义bundle获取图片等资源URL，适用于自定义资源bundle（非mainBundle的场景）
开发业务为多模块开发，图片等资源根据业务模块打包成bundle，以模块bundle的形式读取，此PR支持该自定义bundle场景读取，业务通过实现`KuiklyRenderComponentExpandProtocol` -`- (NSURL *)hr_customBundleUrlForFileName:(NSString *)fileName extension:(NSString *)fileExtension` 实现代理，读取自定义bundle获取图片等资源URL