### PR TITLE
docs: 修正 API 文档错误

### DIFF
--- a/docs/API/components/alert-dialog.md
+++ b/docs/API/components/alert-dialog.md
@@ -74,7 +74,7 @@ Alert内容（当title不为空时可选）
 | -- | -- | -- |
 | message | Alert内容 | String |
 
-### message
+### actionButtons
 
 Alert点击的按钮，如取消，确定(必须设置)
 

--- a/docs/API/components/basic-attr-event.md
+++ b/docs/API/components/basic-attr-event.md
@@ -535,7 +535,7 @@ internal class ZIndexPage : BasePager() {
                     size(100f, 100f)
                     backgroundColor(Color.GREEN)
                     absolutePosition(100f, 20f)
-                    zIndex(1) // 将层级太高, 位置View2之上
+                    zIndex(1) // 将层级抬高, 位置在View2之上
                 }
             }
             View { // View2
@@ -561,7 +561,7 @@ internal class ZIndexPage : BasePager() {
 ### overflow方法
 
 当组件的孩子超出组件的大小时，是否要对子组件超出的区域进行裁剪。在Kuikly中默认子组件大小超出父组件时, 父组件默认不会裁剪,
-子组件超出父组件部分能让能够显示
+子组件超出父组件部分能够显示
 
 :::tip 注意
 overflow的默认表现在iOS开发者看来是很正常的，因此iOS默认对子View超出父View的区域是不会裁剪的。

--- a/docs/API/components/input.md
+++ b/docs/API/components/input.md
@@ -136,7 +136,7 @@ internal class TestPage : BasePager() {
 
 | 参数  | 描述     | 类型 |
 |:----|:-------|:--|
-| color | 提示文本颜色  | Long `|` Color |
+| color | 提示文本颜色  | Color |
 
 </div>
 
@@ -183,7 +183,7 @@ internal class TestPage : BasePager() {
 
 | 参数  | 描述     | 类型 |
 |:----|:-------|:--|
-| color | 输入框光标颜色  | Long `|` Color |
+| color | 输入框光标颜色  | Color |
 
 </div>
 
@@ -226,11 +226,11 @@ internal class TestPage : BasePager() {
 
 <div class="table-01">
 
-**tintColor方法**
+**maxTextLength方法**
 
 | 参数  | 描述     | 类型 |
 |:----|:-------|:--|
-| color | 输入框光标颜色  | Long `|` Color |
+| maxLength | 最长字符长度 | Int |
 
 </div>
 

--- a/docs/API/components/text.md
+++ b/docs/API/components/text.md
@@ -62,7 +62,7 @@ internal class TextViewPage : BasePager() {
 
 | 参数  | 描述     | 类型 |
 |:----|:-------|:--|
-| color | 字体颜色  | Long `|` Color |
+| color | 字体颜色  | Color or Long |
 
 </div>
 
@@ -699,7 +699,7 @@ internal class TestPage : BasePager() {
 
 @tab:active 示例
 
-```kotlin{13}
+```kotlin{16}
 @Page("demo_page")
 internal class TestPage : BasePager() {
     override fun body(): ViewBuilder {


### PR DESCRIPTION
修正以下 API 文档错误
- AlertDialog 组件属性的 actionButtons 误标为 message
- Input 组件属性的 maxTextLength 方法
- “基础属性和事件”的错别字
- 几处参数 Color 类型，代码 Attr 里并未提供 Long 参数的重载
- \`|\` 在这里文档表格显示异常
- Text 组件属性的 textShadow方法 示例代码高亮行数标错