### PR TITLE
fix: avoid nullptr insertion in view_registry_ for non-existent keys

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/layer/KRRenderLayerHandler.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/layer/KRRenderLayerHandler.cpp
@@ -37,7 +37,7 @@ void KRRenderLayerHandler::CreateRenderView(int tag, const std::string &view_nam
         return;
     }
     auto it = view_registry_.find(tag);
-    if (it == view_registry_.end()) {
+    if (it == view_registry_.end() || it->second == nullptr) {
         auto view = PopViewFromReuseQueue(view_name);
         if (view == nullptr) {
             view = IKRRenderViewExport::CreateView(view_name);


### PR DESCRIPTION
Previously, accessing a non-existent key in view_registry_ using operator[] (before createRenderView) would automatically insert a nullptr entry. This behavior is problematic because it will prevent the view created.