### PR TITLE
feat：iOS支持通过文件名从自定义bundle获取图片等资源URL，适用于自定义资源bundle（非mainBundle）的场景

### DIFF
--- a/core-render-ios/Core/KuiklyContextParam.m
+++ b/core-render-ios/Core/KuiklyContextParam.m
@@ -58,6 +58,16 @@ const KuiklyContextMode KuiklyContextMode_Framework = 1;
 }
 
 - (NSURL *)urlForFileName:(NSString *)fileName extension:(NSString *)fileExtension {
+    // 通过fileName从自定义bundle中获取资源URL
+    if ([[KuiklyRenderBridge componentExpandHandler] respondsToSelector:@selector(hr_customBundleUrlForFileName:extension:)]) {
+        NSURL *url = [[KuiklyRenderBridge componentExpandHandler] hr_customBundleUrlForFileName:fileName
+                                                                                extension:fileExtension];
+        if (url) { //若无有效url，接着走下面逻辑
+            return url;
+        }
+    }
+    
+    // 通过resourceFolderUrl从自定义bundle中获取资源URL
     if (self.resourceFolderUrl) {
         NSURL *rscUrl = [[self.resourceFolderUrl URLByAppendingPathComponent:fileName] URLByAppendingPathExtension:fileExtension];
         return rscUrl;

--- a/core-render-ios/Extension/BridgeProtocol/KuiklyRenderBridge.h
+++ b/core-render-ios/Extension/BridgeProtocol/KuiklyRenderBridge.h
@@ -60,12 +60,6 @@ typedef void (^KRBundleResponse)(NSString *_Nullable script , NSError *_Nullable
 + (void)registerCacheHandler:(id<KRCacheProtocol>)cacheHandler;
 
 
-/*
- * @brief 注册自定义Cache实现
- */
-+ (void)registerCacheHandler:(id<KRCacheProtocol>)cacheHandler;
-
-
 + (id<KuiklyRenderComponentExpandProtocol>)componentExpandHandler;
 
 @end
@@ -91,6 +85,16 @@ typedef void(^ImageCompletionBlock)(UIImage * _Nullable image, NSError * _Nullab
 
 @optional
 
+/*
+ * 通过文件名从自定义bundle获取图片等资源URL，用于加载图片等资源
+ * 适用于模块化、组件化开发，自定义资源bundle（非mainBundle的场景）
+ * 通过传入的fileName（fileName带有模块名），确定该资源所在模块bundle的路径，返回该资源的完整URL
+ * eg：fileName为 XXXModule/XXXPage/btn_back_ic，该模块资源打包成XXXModule.bundle，业务根据fileName确定模块并返回该资源URL
+ * @param fileName 资源图片文件名
+ * @param extension 资源图片fileExtension
+ * @return 图片等资源URL
+ */
+- (NSURL *)hr_customBundleUrlForFileName:(NSString *)fileName extension:(NSString *)fileExtension;
 
 /*
  * 自定义实现设置图片（带完成回调，优先调用该方法）


### PR DESCRIPTION
feat：iOS支持通过文件名从自定义bundle获取图片等资源URL，适用于自定义资源bundle（非mainBundle）的场景

通过文件名从自定义bundle获取图片等资源URL，用于加载图片等资源
适用于模块化、组件化开发，自定义资源bundle（非mainBundle的场景）
通过传入的fileName，确定该资源所在模块bundle的路径，返回该资源的完整URL
开发业务为多模块开发，图片等资源根据业务模块打包成bundle，以模块bundle的形式读取，此PR支持自定义bundle场景读取，业务通过实现KuiklyRenderComponentExpandProtocol -- (NSURL *)hr_customBundleUrlForFileName:(NSString *)fileName extension:(NSString *)fileExtension 协议，读取自定义bundle获取图片等资源URL

2.2.4 新增KuiklyContextParam.resourceFolderUrl实现自定义bundle的资源读取，但通过KuiklyRenderViewControllerBaseDelegatorDelegate-- (NSURL *)resourceFolderUrlForKuikly:(NSString *)pageName协议与页面pageName绑定，并不适用模块化、组件化的开发场景
例如，模块化开发，图片传入fileName为 XXXModule/XXXPage/btn_back_ic，以模块维度将该模块资源打包成XXXModule.bundle，业务根据fileName确定模块并返回该资源URL，并无法与页面pageName绑定
本PR保留原KuiklyContextParam.resourceFolderUrl`逻辑，新增以文件名查找新方式，适用于模块化、组件化的开发场景

另，删除KuiklyRenderComponentExpandProtocol的重复声明 + (void)registerCacheHandler:(id<KRCacheProtocol>)cacheHandler