### PR TITLE
fix: ios view backgroundLinearGradient differ from HarmonyOS and Android

### DIFF
--- a/core-render-ios/Extension/Category/UIView+CSS.m
+++ b/core-render-ios/Extension/Category/UIView+CSS.m
@@ -256,6 +256,7 @@
         self.css_gradientLayer = nil;
         if (css_backgroundImage.length) {
             self.css_gradientLayer = [[CSSGradientLayer alloc] initWithLayer:nil cssGradient:css_backgroundImage];
+            self.css_gradientLayer.compositingFilter = @"screenBlendMode";
             [self.layer insertSublayer:self.css_gradientLayer atIndex:0];
             [self.css_gradientLayer setNeedsLayout];
         }


### PR DESCRIPTION
fix: ios view backgroundLinearGradient differs from HarmonyOS and Android