### PR TITLE
feat: add pageName to onUnhandledException callback

### DIFF
--- a/core-render-ios/Core/KuiklyRenderCore.m
+++ b/core-render-ios/Core/KuiklyRenderCore.m
@@ -476,7 +476,10 @@ NSString *const kKuiklyFatalExceptionNotification = @"KuiklyFatalExceptionNotifi
                                           NSString *exceptionName = [components firstObject];
                                           NSString *stackStr = [exception substringFromIndex:exceptionName.length + @"\n".length];
                                           if (weakSelf.onExceptionBlock) {
-                                              weakSelf.onExceptionBlock(exceptionName, stackStr, weakSelf.contextParam.contextMode.modeId);
+                                              weakSelf.onExceptionBlock(exceptionName,
+                                                                        stackStr,
+                                                                        weakSelf.contextParam.pageName,
+                                                                        weakSelf.contextParam.contextMode.modeId);
                                           }
                                        }
                                        return nil;

--- a/core-render-ios/Extension/KuiklyRenderViewControllerBaseDelegator.h
+++ b/core-render-ios/Extension/KuiklyRenderViewControllerBaseDelegator.h
@@ -169,6 +169,18 @@ UIKIT_EXTERN NSString *const KRPageDataSnapshotKey;
                        stack:(NSString *)callstackStr
                         mode:(KuiklyContextMode)mode;
 /*
+ * @brief 发生未处理的kotlin代码异常时回调，回调完后，直接crash
+ * 注意：此回调与 -onUnhandledException:stack:mode:根据需要二者实现其一即可。
+ * @param exReason, 异常原因, 如ThrowArrayIndexOutOfBoundsException
+ * @param callstackStr, 导致异常的kotlin代码堆栈，分隔符: \n
+ * @param pageName, 发送异常的Page名称
+ * @param mode, 当前的产物类型
+ */
+- (void)onUnhandledException:(NSString *)exReason
+                       stack:(NSString *)callstackStr
+                    pageName:(NSString *)pageName
+                        mode:(KuiklyContextMode)mode;
+/*
  * @breif 首屏加载完成回调
  * @param isSucceed 首屏是否正常加载
  * @param error 首屏加载错误

--- a/core-render-ios/Extension/KuiklyRenderViewControllerBaseDelegator.m
+++ b/core-render-ios/Extension/KuiklyRenderViewControllerBaseDelegator.m
@@ -347,11 +347,12 @@ NSString *const KRPageDataSnapshotKey = @"kr_snapshotKey";
 
 - (void)setExceptionBlock:(KuiklyRenderView *)view {
     __weak typeof(self) wself = self;
-    view.onExceptionBlock = ^(NSString *exReason, NSString *callstackStr, KuiklyContextMode mode) {
+    view.onExceptionBlock = ^(NSString *exReason, NSString *callstackStr, NSString *pageName, KuiklyContextMode mode) {
         if (!wself.contentViewDidLoad) {
             NSDictionary *userInfo = @{
-                @"reason": exReason?:@"",
-                @"callStack": callstackStr ?: @""
+                @"reason": exReason ?: @"",
+                @"callStack": callstackStr ?: @"",
+                @"pageName": pageName ?: @""
             };
             NSError *error = [NSError errorWithDomain:KuiklyLoadErrorDomain
                                                  code:KuiklyLoadError_fatalException
@@ -360,6 +361,8 @@ NSString *const KRPageDataSnapshotKey = @"kr_snapshotKey";
         }
         if ([wself.delegate respondsToSelector:@selector(onUnhandledException:stack:mode:)]) {
             [wself.delegate onUnhandledException:exReason stack:callstackStr mode:mode];
+        } else if ([wself.delegate respondsToSelector:@selector(onUnhandledException:stack:pageName:mode:)]) {
+            [wself.delegate onUnhandledException:exReason stack:callstackStr pageName:pageName mode:mode];
         } else if (wself && wself.contextMode.modeId == KuiklyContextMode_Framework) {
             @throw [NSException exceptionWithName:exReason reason:callstackStr userInfo:nil];
         }

--- a/core-render-ios/Protocol/KuiklyRenderContextProtocol.h
+++ b/core-render-ios/Protocol/KuiklyRenderContextProtocol.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class KuiklyContextParam;
 
 typedef NSInteger KuiklyContextMode;
-typedef void(^OnUnhandledExceptionBlock)(NSString *exReason, NSString *callstackStr, KuiklyContextMode mode);
+typedef void(^OnUnhandledExceptionBlock)(NSString *exReason, NSString *callstackStr, NSString *pageName, KuiklyContextMode mode);
 
 /*
  * Native侧调用Kotlin侧方法枚举


### PR DESCRIPTION
`KuiklyRenderViewControllerBaseDelegatorDelegate` 新增以下协议，回调pageName 参数，方便快速定位问题页面，同时保留原`-onUnhandledException:stack:mode:`回调，根据需要二者实现其一即可，避免旧版本升级上来遗漏实现

```
/*
 * @brief 发生未处理的kotlin代码异常时回调，回调完后，直接crash
 * 注意：此回调与 -onUnhandledException:stack:mode:根据需要二者实现其一即可。
 * @param exReason, 异常原因, 如ThrowArrayIndexOutOfBoundsException
 * @param callstackStr, 导致异常的kotlin代码堆栈，分隔符: \n
 * @param pageName, 发送异常的Page名称
 * @param mode, 当前的产物类型
 */
- (void)onUnhandledException:(NSString *)exReason
                       stack:(NSString *)callstackStr
                    pageName:(NSString *)pageName
                        mode:(KuiklyContextMode)mode;
```
