### PR TITLE
fix: improve ScrollPickerView drag scrolling smoothness by unifying event callbacks

### DIFF
--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/ScrollPickerDemoPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/ScrollPickerDemoPage.kt
@@ -100,7 +100,11 @@ internal class ScrollPickerDemoPage: BasePager() {
                             backgroundColor(Color.WHITE)
                         }
                         event {
-                            dragEndEvent { centerValue, centerItemIndex ->
+                            scrollEvent { centerValue, centerItemIndex ->
+                                ctx.chooseIdx = centerItemIndex
+                                ctx.chooseValue = centerValue
+                            }
+                            scrollEndEvent { centerValue, centerItemIndex ->
                                 ctx.chooseIdx = centerItemIndex
                                 ctx.chooseValue = centerValue
                             }
@@ -148,7 +152,10 @@ internal class ScrollPickerDemoPage: BasePager() {
                             backgroundColor(Color.WHITE)
                         }
                         event {
-                            dragEndEvent { centerValue, centerItemIndex ->
+                            scrollEvent { centerValue, centerItemIndex ->
+                                ctx.hourStr = centerValue
+                            }
+                            scrollEndEvent { centerValue, centerItemIndex ->
                                 ctx.hourStr = centerValue
                             }
                         }
@@ -164,7 +171,10 @@ internal class ScrollPickerDemoPage: BasePager() {
                             backgroundColor(Color.WHITE)
                         }
                         event {
-                            dragEndEvent { centerValue, centerItemIndex ->
+                            scrollEvent { centerValue, centerItemIndex ->
+                                ctx.minuteStr = centerValue
+                            }
+                            scrollEndEvent { centerValue, centerItemIndex ->
                                 ctx.minuteStr = centerValue
                             }
                         }
@@ -219,7 +229,11 @@ internal class ScrollPickerDemoPage: BasePager() {
                             backgroundColor(Color.WHITE)
                         }
                         event {
-                            dragEndEvent { centerValue, centerItemIndex ->
+                            scrollEvent { centerValue, centerItemIndex ->
+                                ctx.provinceIndex = centerItemIndex
+                                ctx.provinceName = centerValue
+                            }
+                            scrollEndEvent { centerValue, centerItemIndex ->
                                 ctx.provinceIndex = centerItemIndex
                                 ctx.provinceName = centerValue
                             }
@@ -236,7 +250,10 @@ internal class ScrollPickerDemoPage: BasePager() {
                                 backgroundColor(Color.WHITE)
                             }
                             event {
-                                dragEndEvent { centerValue, centerItemIndex ->
+                                scrollEvent { centerValue, centerItemIndex ->
+                                    ctx.cityStr = centerValue
+                                }
+                                scrollEndEvent { centerValue, centerItemIndex ->
                                     ctx.cityStr = centerValue
                                 }
                             }


### PR DESCRIPTION
1. 滚动结束反馈：添加scrollEndEvent，使用scrollEndEvent替代dragEndEvent在滚动回调时候触发的回调
2. 滚动过程反馈：通过 scrollEvent 在拖拽过程中提供实时滚动位置反馈