### PR TITLE
fix: fix pag demo can not play issue

### DIFF
--- a/h5App/src/jsMain/resources/index.html
+++ b/h5App/src/jsMain/resources/index.html
@@ -56,7 +56,7 @@
 <div id="root"></div>
 <script type="text/javascript" src="http://127.0.0.1:8083/nativevue2.js"></script>
 <script type="text/javascript"
-        src="https://cdn.jsdelivr.net/npm/libpag@latest/lib/libpag.min.js"></script>
+        src="https://cdn.jsdelivr.net/npm/libpag@4.3.51/lib/libpag.umd.min.js"></script>
 <script type="text/javascript" src="h5App.js"></script>
 </body>
 </html>


### PR DESCRIPTION
fix pag demo can not play issue. 

why:
because pagview's latest version use esm module instead common module. so we change libpag version to old one to compatible old browser