### PR TITLE
feat(ksp): Add JS/H5 target support and fix WeakReference/platform detection bugs

### DIFF
--- a/compose/src/jsMain/kotlin/com/tencent/kuikly/compose/ui/ui/node/WeakReference.js.kt
+++ b/compose/src/jsMain/kotlin/com/tencent/kuikly/compose/ui/ui/node/WeakReference.js.kt
@@ -2,7 +2,7 @@ package com.tencent.kuikly.compose.ui.node
 
 // TODO mark internal once https://youtrack.jetbrains.com/issue/KT-36695 is fixed
 actual class WeakReference<T : Any> actual constructor(referent: T) {
-    private var instance: T? = null
+    private var instance: T? = referent  // Fixed: initialize with referent
 
     actual fun clear() {
         instance = null

--- a/core-ksp/src/main/kotlin/com/tencent/kuikly/core/ksp/Extensions.kt
+++ b/core-ksp/src/main/kotlin/com/tencent/kuikly/core/ksp/Extensions.kt
@@ -34,6 +34,10 @@ fun String.ohosFamily(): Boolean {
     return contains("ohos")
 }
 
+fun String.jsFamily(): Boolean {
+    return contains("js")
+}
+
 private fun KSClassDeclaration.pageAnnotateValue(): String {
     var name = ""
     annotations.toList()[0].arguments.forEach {

--- a/core-ksp/src/main/kotlin/impl/JSTargetEntryBuilder.kt
+++ b/core-ksp/src/main/kotlin/impl/JSTargetEntryBuilder.kt
@@ -1,0 +1,130 @@
+package impl
+
+import com.squareup.kotlinpoet.*
+
+/**
+ * JS Target Entry Builder for H5/Web platform (Single Module Mode)
+ *
+ * Processing flow:
+ * 1. KSP detects JS target via outputSourceSet.jsFamily() in KuiklyCoreProcessorProvider
+ * 2. Scans all classes annotated with @Page
+ * 3. Generates KuiklyCoreEntry.kt with:
+ *    - registerAllPages(): Registers all page routes to BridgeManager
+ *    - callKotlinMethodImpl(): Bridge for JS to call Kotlin methods
+ *    - registerCallNativeImpl(): Registers native callbacks for each pager
+ *    - main(): Entry point that sets up window.callKotlinMethod and
+ *      window.com.tencent.kuikly.core.nvi.registerCallNative for H5 render layer
+ *
+ * Runtime call chain:
+ * index.html -> h5App.js -> main() -> registerAllPages()
+ *                                  -> window.callKotlinMethod = ...
+ *                                  -> window.com.tencent.kuikly.core.nvi.registerCallNative = ...
+ *                       -> nativevue2.js calls these registered functions
+ *
+ * Created by xuwakao on 2025/12
+ */
+open class JSTargetEntryBuilder : KuiklyCoreAbsEntryBuilder() {
+
+    override fun build(builder: FileSpec.Builder, pagesAnnotations: List<PageInfo>) {
+        // Add JS-specific imports
+        builder.addImport("com.tencent.kuikly.core.nvi", "CallNativeCallback")
+        builder.addImport("kotlinx.browser", "window")
+
+        // Add private properties
+        builder.addProperty(
+            PropertySpec.builder("didInit", Boolean::class)
+                .addModifiers(KModifier.PRIVATE)
+                .mutable()
+                .initializer("false")
+                .build()
+        )
+
+        // Add registerAllPages function
+        builder.addFunction(createRegisterAllPagesFunc(pagesAnnotations))
+
+        // Add callKotlinMethodImpl function
+        builder.addFunction(createCallKotlinMethodImplFunc())
+
+        // Add registerCallNativeImpl function
+        builder.addFunction(createRegisterCallNativeImplFunc())
+
+        // Add main function
+        builder.addFunction(createMainFunc())
+    }
+
+    private fun createRegisterAllPagesFunc(pagesAnnotations: List<PageInfo>): FunSpec {
+        return FunSpec.builder("registerAllPages")
+            .addModifiers(KModifier.PRIVATE)
+            .addStatement("if (didInit) return")
+            .addStatement("didInit = true")
+            .addStatement("BridgeManager.init()")
+            .addRegisterPageRouteStatement(pagesAnnotations)
+            .build()
+    }
+
+    private fun createCallKotlinMethodImplFunc(): FunSpec {
+        // Use Any? instead of dynamic for the function signature
+        // The actual dynamic behavior is handled in the lambda in main()
+        val anyNullable = Any::class.asTypeName().copy(nullable = true)
+        return FunSpec.builder("callKotlinMethodImpl")
+            .addModifiers(KModifier.PRIVATE)
+            .addParameter("methodId", Int::class)
+            .addParameter("arg0", anyNullable)
+            .addParameter("arg1", anyNullable)
+            .addParameter("arg2", anyNullable)
+            .addParameter("arg3", anyNullable)
+            .addParameter("arg4", anyNullable)
+            .addParameter("arg5", anyNullable)
+            .returns(anyNullable)
+            .addStatement("BridgeManager.callKotlinMethod(methodId, arg0, arg1, arg2, arg3, arg4, arg5)")
+            .addStatement("return Unit")
+            .build()
+    }
+
+    private fun createRegisterCallNativeImplFunc(): FunSpec {
+        return FunSpec.builder("registerCallNativeImpl")
+            .addModifiers(KModifier.PRIVATE)
+            .addParameter("pagerId", String::class)
+            .addParameter("callback", ClassName("com.tencent.kuikly.core.nvi", "CallNativeCallback"))
+            .addStatement("NativeBridge.registerCallNativeCallback(pagerId, callback)")
+            .addStatement("if (!BridgeManager.containNativeBridge(pagerId)) {")
+            .addStatement("    BridgeManager.registerNativeBridge(pagerId, NativeBridge())")
+            .addStatement("}")
+            .build()
+    }
+
+    private fun createMainFunc(): FunSpec {
+        return FunSpec.builder("main")
+            .addCode("""
+                |registerAllPages()
+                |
+                |// Register callKotlinMethod on window
+                |window.asDynamic().callKotlinMethod = { methodId: Int, arg0: dynamic, arg1: dynamic, arg2: dynamic, arg3: dynamic, arg4: dynamic, arg5: dynamic ->
+                |    callKotlinMethodImpl(methodId, arg0, arg1, arg2, arg3, arg4, arg5)
+                |}
+                |
+                |// Create namespace path: window.com.tencent.kuikly.core.nvi
+                |js(${'"'}${'"'}${'"'}
+                |    if (typeof window.com === 'undefined') window.com = {};
+                |    if (typeof window.com.tencent === 'undefined') window.com.tencent = {};
+                |    if (typeof window.com.tencent.kuikly === 'undefined') window.com.tencent.kuikly = {};
+                |    if (typeof window.com.tencent.kuikly.core === 'undefined') window.com.tencent.kuikly.core = {};
+                |    if (typeof window.com.tencent.kuikly.core.nvi === 'undefined') window.com.tencent.kuikly.core.nvi = {};
+                |${'"'}${'"'}${'"'})
+                |
+                |// Register registerCallNative function
+                |window.asDynamic().com.tencent.kuikly.core.nvi.registerCallNative = { pagerId: String, callback: CallNativeCallback ->
+                |    registerCallNativeImpl(pagerId, callback)
+                |}
+                |""".trimMargin())
+            .build()
+    }
+
+    override fun entryFileName(): String {
+        return "KuiklyCoreEntry"
+    }
+
+    override fun packageName(): String {
+        return ""
+    }
+}

--- a/core-ksp/src/main/kotlin/impl/submodule/JSMultiTargetEntryBuilder.kt
+++ b/core-ksp/src/main/kotlin/impl/submodule/JSMultiTargetEntryBuilder.kt
@@ -1,0 +1,154 @@
+package impl.submodule
+
+import com.squareup.kotlinpoet.*
+import impl.JSTargetEntryBuilder
+import impl.PageInfo
+
+/**
+ * JS Multi-Module Target Entry Builder for H5/Web platform
+ *
+ * Extends JSTargetEntryBuilder to support multi-module architecture where pages
+ * are distributed across multiple Gradle modules.
+ *
+ * KSP options:
+ * - enableMultiModule: true to enable multi-module mode
+ * - isMainModule: true if this is the main module
+ * - subModules: "&" separated list of sub-module IDs (e.g., "home&settings&profile")
+ * - moduleId: ID of current module (for sub-modules)
+ *
+ * Generated code:
+ *
+ * Sub-module (isMainModule=false):
+ *   object KuiklyCoreEntry_<moduleId> {
+ *       fun triggerRegisterPages() {
+ *           BridgeManager.registerPageRouter("page1") { Page1() }
+ *       }
+ *   }
+ *
+ * Main module (isMainModule=true):
+ *   private fun registerAllPages() {
+ *       BridgeManager.registerPageRouter(...)  // local pages
+ *       KuiklyCoreEntry_home.triggerRegisterPages()      // sub-modules
+ *       KuiklyCoreEntry_settings.triggerRegisterPages()
+ *   }
+ *   fun main() { ... }
+ *
+ * Created by xuwakao on 2025/12
+ */
+class JSMultiTargetEntryBuilder(
+    private val isMainModule: Boolean,
+    private val subModules: String,
+    private val moduleId: String
+) : JSTargetEntryBuilder() {
+
+    override fun build(builder: FileSpec.Builder, pagesAnnotations: List<PageInfo>) {
+        if (!isMainModule) {
+            // Sub-module: generate an object with triggerRegisterPages()
+            builder.addType(
+                TypeSpec.objectBuilder(entryFileName() + "_" + moduleId)
+                    .addFunction(createSubModuleRegisterPagesFuncSpec(pagesAnnotations))
+                    .build()
+            )
+        } else {
+            // Main module: generate full entry with main()
+            builder.addImport("com.tencent.kuikly.core.nvi", "CallNativeCallback")
+            builder.addImport("kotlinx.browser", "window")
+
+            builder.addProperty(
+                PropertySpec.builder("didInit", Boolean::class)
+                    .addModifiers(KModifier.PRIVATE)
+                    .mutable()
+                    .initializer("false")
+                    .build()
+            )
+
+            builder.addFunction(createRegisterAllPagesFunc(pagesAnnotations))
+            builder.addFunction(createCallKotlinMethodImplFunc())
+            builder.addFunction(createRegisterCallNativeImplFunc())
+            builder.addFunction(createMainFunc())
+        }
+    }
+
+    private fun createSubModuleRegisterPagesFuncSpec(pagesAnnotations: List<PageInfo>): FunSpec {
+        return FunSpec.builder("triggerRegisterPages")
+            .addRegisterPageRouteStatement(pagesAnnotations)
+            .build()
+    }
+
+    private fun createRegisterAllPagesFunc(pagesAnnotations: List<PageInfo>): FunSpec {
+        return FunSpec.builder("registerAllPages")
+            .addModifiers(KModifier.PRIVATE)
+            .addStatement("if (didInit) return")
+            .addStatement("didInit = true")
+            .addStatement("BridgeManager.init()")
+            .addRegisterPageRouteStatement(pagesAnnotations)
+            .addSubModuleStatement()
+            .build()
+    }
+
+    private fun FunSpec.Builder.addSubModuleStatement(): FunSpec.Builder {
+        subModules.split("&").forEach {
+            val name = it.trim()
+            if (name.isNotEmpty()) {
+                addStatement(entryFileName() + "_" + name + ".triggerRegisterPages()")
+            }
+        }
+        return this
+    }
+
+    private fun createCallKotlinMethodImplFunc(): FunSpec {
+        val anyNullable = Any::class.asTypeName().copy(nullable = true)
+        return FunSpec.builder("callKotlinMethodImpl")
+            .addModifiers(KModifier.PRIVATE)
+            .addParameter("methodId", Int::class)
+            .addParameter("arg0", anyNullable)
+            .addParameter("arg1", anyNullable)
+            .addParameter("arg2", anyNullable)
+            .addParameter("arg3", anyNullable)
+            .addParameter("arg4", anyNullable)
+            .addParameter("arg5", anyNullable)
+            .returns(anyNullable)
+            .addStatement("BridgeManager.callKotlinMethod(methodId, arg0, arg1, arg2, arg3, arg4, arg5)")
+            .addStatement("return Unit")
+            .build()
+    }
+
+    private fun createRegisterCallNativeImplFunc(): FunSpec {
+        return FunSpec.builder("registerCallNativeImpl")
+            .addModifiers(KModifier.PRIVATE)
+            .addParameter("pagerId", String::class)
+            .addParameter("callback", ClassName("com.tencent.kuikly.core.nvi", "CallNativeCallback"))
+            .addStatement("NativeBridge.registerCallNativeCallback(pagerId, callback)")
+            .addStatement("if (!BridgeManager.containNativeBridge(pagerId)) {")
+            .addStatement("    BridgeManager.registerNativeBridge(pagerId, NativeBridge())")
+            .addStatement("}")
+            .build()
+    }
+
+    private fun createMainFunc(): FunSpec {
+        return FunSpec.builder("main")
+            .addCode("""
+                |registerAllPages()
+                |
+                |// Register callKotlinMethod on window
+                |window.asDynamic().callKotlinMethod = { methodId: Int, arg0: dynamic, arg1: dynamic, arg2: dynamic, arg3: dynamic, arg4: dynamic, arg5: dynamic ->
+                |    callKotlinMethodImpl(methodId, arg0, arg1, arg2, arg3, arg4, arg5)
+                |}
+                |
+                |// Create namespace path: window.com.tencent.kuikly.core.nvi
+                |js(${'\"'}${'\"'}${'\"'}
+                |    if (typeof window.com === 'undefined') window.com = {};
+                |    if (typeof window.com.tencent === 'undefined') window.com.tencent = {};
+                |    if (typeof window.com.tencent.kuikly === 'undefined') window.com.tencent.kuikly = {};
+                |    if (typeof window.com.tencent.kuikly.core === 'undefined') window.com.tencent.kuikly.core = {};
+                |    if (typeof window.com.tencent.kuikly.core.nvi === 'undefined') window.com.tencent.kuikly.core.nvi = {};
+                |${'\"'}${'\"'}${'\"'})
+                |
+                |// Register registerCallNative function
+                |window.asDynamic().com.tencent.kuikly.core.nvi.registerCallNative = { pagerId: String, callback: CallNativeCallback ->
+                |    registerCallNativeImpl(pagerId, callback)
+                |}
+                |""".trimMargin())
+            .build()
+    }
+}


### PR DESCRIPTION
  Add KSP processor support for Kotlin/JS target to automatically generate KuiklyCoreEntry.kt for H5/Web platform, consistent with Android/iOS/OHOS.

  ## Changes

  ### 1. Fix KSP processor for unknown platforms
  - Make `getEntryBuilder()` return null for unsupported platforms
  - Previously it incorrectly defaulted to `AndroidTargetEntryBuilder`, causing errors when assembling shared module
  - Now outputs warning like "Skipping KSP code generation for commonMain" and skips code generation for non-platform source sets

  ### 2. Fix WeakReference.js.kt initialization bug
  - The `instance` field was initialized to `null` instead of `referent`
  - This caused `get()` to always return `null`, resulting in error: "LifecycleOwner was garbage collected before being removed from LifecycleRegistry"

  ### 3. Add JS target code generation
  - Add `jsFamily()` detection function in Extensions.kt
  - Add `JSTargetEntryBuilder` for single module mode
  - Add `JSMultiTargetEntryBuilder` for multi-module mode
  - Generated code includes `registerAllPages()`, `callKotlinMethodImpl()`, `registerCallNativeImpl()`, and `main()` entry point

  ## Test Plan
  - Build shared module with `./gradlew :shared:assemble`
  - Verify JS target generates KuiklyCoreEntry.kt correctly
  - Run H5 app and confirm no LifecycleOwner errors

  ---

  为 Kotlin/JS 目标添加 KSP 处理器支持，自动生成 H5/Web 平台的 KuiklyCoreEntry.kt，与 Android/iOS/OHOS 保持一致。

  ## 更改

  ### 1. 修复未知平台的 KSP 处理器
  - 对不支持的平台，`getEntryBuilder()` 返回 null
  - 之前错误地默认使用 `AndroidTargetEntryBuilder`，导致 assemble shared 模块时报错
  - 现在会输出类似 "Skipping KSP code generation for commonMain" 的警告，并跳过非平台 source set 的代码生成

  ### 2. 修复 WeakReference.js.kt 初始化 bug
  - `instance` 字段被初始化为 `null` 而不是 `referent`
  - 导致 `get()` 总是返回 `null`，产生错误："LifecycleOwner was garbage collected before being removed from LifecycleRegistry"

  ### 3. 添加 JS 目标代码生成
  - 在 Extensions.kt 中添加 `jsFamily()` 检测函数
  - 添加 `JSTargetEntryBuilder` 支持单模块模式
  - 添加 `JSMultiTargetEntryBuilder` 支持多模块模式
  - 生成的代码包括 `registerAllPages()`、`callKotlinMethodImpl()`、`registerCallNativeImpl()` 和 `main()` 入口函数

  ## 测试计划
  - 执行 `./gradlew :shared:assemble` 构建 shared 模块
  - 验证 JS 目标正确生成 KuiklyCoreEntry.kt
  - 运行 H5 应用，确认无 LifecycleOwner 错误