### PR TITLE
fix(compose): Initialize WeakReference.js.kt instance with referent

### DIFF
--- a/compose/src/jsMain/kotlin/com/tencent/kuikly/compose/ui/ui/node/WeakReference.js.kt
+++ b/compose/src/jsMain/kotlin/com/tencent/kuikly/compose/ui/ui/node/WeakReference.js.kt
@@ -2,7 +2,7 @@ package com.tencent.kuikly.compose.ui.node
 
 // TODO mark internal once https://youtrack.jetbrains.com/issue/KT-36695 is fixed
 actual class WeakReference<T : Any> actual constructor(referent: T) {
-    private var instance: T? = null
+    private var instance: T? = referent
 
     actual fun clear() {
         instance = null


### PR DESCRIPTION
## Problem

The `instance` field in `WeakReference.js.kt` was initialized to `null` instead of `referent`, causing `get()` to always return `null`.

This resulted in error:
```
LifecycleOwner was garbage collected before being removed from LifecycleRegistry
```

## Solution

Initialize `instance` with `referent` parameter.

```kotlin
// Before (bug)
private var instance: T? = null

// After (fix)
private var instance: T? = referent
```

## Test

- Run H5 app and confirm no LifecycleOwner errors

---

## 问题

`WeakReference.js.kt` 中的 `instance` 字段被初始化为 `null` 而不是 `referent`，导致 `get()` 总是返回 `null`。

这会导致错误：
```
LifecycleOwner was garbage collected before being removed from LifecycleRegistry
```

## 解决方案

用 `referent` 参数初始化 `instance`。

## 测试

- 运行 H5 应用，确认无 LifecycleOwner 错误