### PR TITLE
fix: solve ohos artifict build error

### DIFF
--- a/core/src/ohosArm64Main/kotlin/com/tencent/kuikly/core/datetime/DateTime.kt
+++ b/core/src/ohosArm64Main/kotlin/com/tencent/kuikly/core/datetime/DateTime.kt
@@ -37,6 +37,5 @@ actual object DateTime {
         return com_tencent_kuikly_GetThreadCPUTimeInNanoseconds() / 1_000_000
     }
 
-    internal actual fun logStack(): String = ""
 
 }


### PR DESCRIPTION
fix: delete logStack method in ohosArm64Main DateTime.kt to solve ohos artifict build error