### PR TITLE
fix: avoid "Cannot round NaN value" exception when scale is 0 in appl…

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/KNode.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/KNode.kt
@@ -557,7 +557,17 @@ internal class KNode<T : DeclarativeBaseView<*, *>>(
             }
         }
 
-        private fun Float.toDegrees(): Float = (this * 180_000 / PI).roundToInt() / 1000f
+        private fun Float.toDegrees(): Float {
+            return if (this.isNaN()) {
+                /**
+                 * 1. When the scale is 0 in applyTransform, it generates NaN, which causes roundToInt to throw an exception
+                 * 2. When the scale is 0, the value of degree does not affect rendering, so 0 is returned here
+                 */
+                0f
+            } else {
+                (this * 180_000 / PI).roundToInt() / 1000f
+            }
+        }
 
         private fun Attr.applyTransform(size: IntSize, matrix: Matrix) {
             val translateX = matrix[3, 0]


### PR DESCRIPTION
```
AnimatedVisibility(
    visible = true,
    enter = scaleIn(initialScale = 0f, transformOrigin = TransformOrigin.Center)
) {
...
}
```

The source code above will cause exception below:

```
java.ang.IllegalArgumentException: Cannot round NaN value.
at kotlin.math.MathKt__MathJVMKt.roundTolnt（MathJVM.kt:619）
at com.tencent.kuikly.compose.ui.node.KNodes$Companion.toDegrees（KNode.kt:560）
at com.tencent.kuikly.compose.ui.node.KNodes$Companion.applyTransform-dqFHml8（KNode.kt:562）
at com.tencent.kuikly.compose.ui.node.KNodes$Companion.flush（KNode.kt:517）
```