### PR TITLE
fix: ohos compile error due to TextAreaView and TextFieldView

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextAreaView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextAreaView.h
@@ -42,7 +42,7 @@ class KRTextAreaView : public KRTextFieldView {
         return ArkUI_NodeEventType::NODE_TEXT_AREA_ON_PASTE;
     }
     ArkUI_NodeEventType GetOnWillChangeEventType() override {
-        return ArkUI_NodeEventType::NODE_TEXT_AREA_ON_WILL_CHANGE;
+        return ArkUI_NodeEventType::NODE_TEXT_AREA_ON_EDIT_CHANGE;;
     }
 
     void UpdateInputNodePlaceholder(const std::string &propValue) override;

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextFieldView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextFieldView.h
@@ -60,7 +60,7 @@ class KRTextFieldView : public IKRRenderViewExport {
         return ArkUI_NodeEventType::NODE_TEXT_INPUT_ON_PASTE;
     }
     virtual ArkUI_NodeEventType GetOnWillChangeEventType() {
-        return ArkUI_NodeEventType::NODE_TEXT_INPUT_ON_WILL_CHANGE;
+        return ArkUI_NodeEventType::NODE_TEXT_INPUT_ON_EDIT_CHANGE;
     }
     
     virtual void UpdateInputNodePlaceholder(const std::string &propValue);


### PR DESCRIPTION
fix: ohos compile error due to TextAreaView and TextFieldView