### PR TITLE
fix: ohos compile error caused by KRRenderValue in KROhSharedPreferencesModule

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/preferences/KROhSharedPreferencesModule.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/preferences/KROhSharedPreferencesModule.cpp
@@ -50,11 +50,11 @@ void KROhSharedPreferencesModule::InitIfNeeded() {
 KRAnyValue KROhSharedPreferencesModule::CallMethod(bool sync, const std::string &method, KRAnyValue params,
                                                  const KRRenderCallback &callback) {
     if (method == this->GET_ITEM) {
-        return std::make_shared<KRRenderValue>(this->GetItem(params));
+        return KRRenderValue::Make(this->GetItem(params));
     } else if (method == this->SET_ITEM) {
-        return std::make_shared<KRRenderValue>(this->SetItem(params));
+        return KRRenderValue::Make(this->SetItem(params));
     }
-    return std::make_shared<KRRenderValue>("");
+    return KRRenderValue::Make("");
 }
 
 std::string KROhSharedPreferencesModule::GetItem(const KRAnyValue &params) {


### PR DESCRIPTION
fix: ohos compile error caused by KRRenderValue in KROhSharedPreferencesModule