### PR TITLE
fix: cold-start failure in OH_ArkUI_NodeContent_RegisterCallback

### DIFF
--- a/core-render-ohos/src/main/cpp/napi_init.cpp
+++ b/core-render-ohos/src/main/cpp/napi_init.cpp
@@ -161,6 +161,8 @@ static napi_value ArkTSOnSendEvent(napi_env env, napi_callback_info info) {
     return 0;
 }
 static napi_value CreateNativeRoot(napi_env env, napi_callback_info info) {
+    // The API OH_ArkUI_NodeContent_RegisterCallback depends on it
+    auto nodeApi = kuikly::util::GetNodeApi();
     KRRenderManager::GetInstance().CreateRenderViewIfNeeded(env, info);
     return nullptr;
 }


### PR DESCRIPTION
## 问题描述
当前KRRenderView.cpp中，OH_ArkUI_NodeContent_RegisterCallback(handle, cb)这个注册在冷启后首次调用会失败，冷启后第二次调用没问题。

## 问题原因
OH_ArkUI_NodeContent_RegisterCallback依赖OH_ArkUI_GetModuleInterface(ARKUI_NATIVE_NODE, ArkUI_NativeNodeAPI_1, impl_)这行代码的调用。
冷启后二次调用没问题是因为KRViewUtil.cpp有调用这行代码，但是冷启情况下这行代码的调用时机较晚，晚于OH_ArkUI_NodeContent_RegisterCallback。

## 复现场景
冷启首次打印出OH_ArkUI_NodeContent_RegisterCallback(handle, cb)的返回值，非0就是失败。

## 注册失败导致的问题
收不到NODE_CONTENT_EVENT_ON_DETACH_FROM_WINDOW的回调，导致RemoveRootViewFromContentHandle方法依赖析构函数的调用，走的延迟OH_ArkUI_NodeContent_RemoveNode逻辑。会偶现下述crash：
libace_compatible.z.so (OHOS::Ace::NG::NodeContent::RemoveNode(OHOS::Ace::NG::UINode*)+)
libace_compatible.z.so (OHOS::Ace::NG::(anonymous namespace)::RemoveChild(_ArkUINodeContent*, _ArkUINode*) (.llvm.3087760086327962596)+)，

## 解决方案
在napi_init.cpp的CreateNativeRoot方法中触发OH_ArkUI_GetModuleInterface的调用（初始化）。
