### PR TITLE
fix: compensate Modifier padding delta in realContentSize calculation

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ContentSizeExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ContentSizeExtensions.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.launch
 import kotlin.math.max
 
 /**
- * 计算内容大小
+ * Calculate content size
  */
 private fun ScrollableState.calculateContentSize(): Int {
     kuiklyInfo.realContentSize = null
@@ -49,16 +49,20 @@ private fun ScrollableState.calculateContentSize(): Int {
 
     val viewportSize = kuiklyInfo.viewportSize
 
-    // 如果可以算出来总的compose容器高度了，就返回精确的容器高度
+    // Return exact content height if total compose container height can be calculated
     val realContentSize = totalContentSize()
     if (realContentSize != null) {
-        kuiklyInfo.realContentSize =
-            realContentSize + (contentPadding.totalPadding(kuiklyInfo.orientation).value * density).toInt()
+        // Compensate for Modifier padding shrinking Compose internal viewport relative to native viewport
+        val composeViewport = composeViewportMainAxisSize() ?: viewportSize
+        val viewportDelta = viewportSize - composeViewport
+        // Compensate for contentPadding which does not affect viewportSize but is excluded from totalContentSize
+        val contentPaddingCompensation = (contentPadding.totalPadding(kuiklyInfo.orientation).value * density).toInt()
+        kuiklyInfo.realContentSize = realContentSize + viewportDelta + contentPaddingCompensation
         return kuiklyInfo.realContentSize!!
     }
 
     val bottomOffset = kuiklyInfo.composeOffset.toInt() + viewportSize
-    // 如果当前的底部距离容器高度较近了，就扩大缓冲区
+    // Expand buffer if bottom offset is close to content size
     if (contentSize - bottomOffset < ScrollableStateConstants.CONTENT_SIZE_BUFFER * density) {
         return (contentSize + ScrollableStateConstants.DEFAULT_EXPAND_SIZE* density).toInt()
     }
@@ -86,6 +90,7 @@ internal fun ScrollableState.calculateAndUpdateContentSize() {
     }
     kuiklyInfo.updateContentSizeToRender()
 }
+
 internal fun PaddingValues.totalPadding(orientation: Orientation): Dp {
     return if (orientation == Orientation.Vertical) {
         calculateTopPadding() + calculateBottomPadding()
@@ -96,7 +101,7 @@ internal fun PaddingValues.totalPadding(orientation: Orientation): Dp {
 }
 
 /**
- * 计算总内容大小
+ * Calculate total content size
  */
 internal fun ScrollableState.totalContentSize(): Int? {
     val curOffset = kuiklyInfo.composeOffset
@@ -106,6 +111,29 @@ internal fun ScrollableState.totalContentSize(): Int? {
         is LazyGridState -> calculateLazyGridContentSize(curOffset)
         is LazyStaggeredGridState -> calculateLazyStaggeredGridContentSize(curOffset)
         is ScrollState -> calculateScrollStateContentSize()
+        else -> null
+    }
+}
+
+/**
+ * Get the main axis size (in pixels) of the Compose internal viewport.
+ * Modifier padding shrinks the Compose internal viewport, causing a delta with the native ScrollView viewport.
+ */
+private fun ScrollableState.composeViewportMainAxisSize(): Int? {
+    return when(this) {
+        is LazyListState -> {
+            if (layoutInfo.orientation == Orientation.Vertical) layoutInfo.viewportSize.height
+            else layoutInfo.viewportSize.width
+        }
+        is LazyGridState -> {
+            if (layoutInfo.orientation == Orientation.Vertical) layoutInfo.viewportSize.height
+            else layoutInfo.viewportSize.width
+        }
+        is LazyStaggeredGridState -> {
+            if (layoutInfo.orientation == Orientation.Vertical) layoutInfo.viewportSize.height
+            else layoutInfo.viewportSize.width
+        }
+        is ScrollState -> viewportSize
         else -> null
     }
 }


### PR DESCRIPTION
When a LazyList has Modifier.padding(), the Compose internal viewport is smaller than the native ScrollView viewport. The realContentSize was calculated in Compose's internal coordinate system but applied to the native ScrollView, causing the last items to be clipped because native maxScrollOffset was too small.

Add composeViewportMainAxisSize() to retrieve the Compose internal viewport size from layoutInfo, and compensate both the Modifier padding delta and contentPadding in the realContentSize calculation.