### PR TITLE
docs: update MakeKuiklyComposeNode guide with correct base classes and clearer descriptions

### DIFF
--- a/docs/Compose/extend-kuikly-dsl-ui.md
+++ b/docs/Compose/extend-kuikly-dsl-ui.md
@@ -4,9 +4,11 @@
 
 ## API 函数：MakeKuiklyComposeNode
 
-`MakeKuiklyComposeNode` 是 Kuikly Compose 用来把 **Kuikly 视图（`DeclarativeBaseView`）挂到 Compose 渲染树** 的统一入口。
+**`MakeKuiklyComposeNode` 是将 Kuikly 原生视图嵌入 Compose 渲染树的统一桥接入口。** 根据组件是否需要挂载 Compose 子节点，提供两个重载：
 
-### 叶子节点重载（无子内容）
+### 无子节点（原子组件）
+
+用于自身完整渲染、不接受外部子视图的组件：
 
 ```kotlin
 @Composable
@@ -20,7 +22,9 @@ fun <T : DeclarativeBaseView<*, *>> MakeKuiklyComposeNode(
 )
 ```
 
-### 容器重载（有子内容）
+### 有子节点（容器组件）
+
+用于需要将 Compose 子节点挂载到当前视图下的组件：
 
 ```kotlin
 @Composable
@@ -37,87 +41,144 @@ fun <T : DeclarativeBaseView<*, *>> MakeKuiklyComposeNode(
 
 ## 参数解析
 
-- **`factory: () -> T`**：创建具体 Kuikly 视图实例的工厂函数，例如 `VideoView()`、`VirtualNodeView()`。  
-- **`modifier: Modifier`**：Compose 侧传入的 `Modifier`，内部会同步到 Kuikly 节点，用于尺寸、布局、点击等。  
-- **`content: @Composable () -> Unit`（仅容器重载）**：子内容插槽，Compose 子节点会被挂载到当前 Kuikly 容器节点下。  
-- **`viewInit: T.() -> Unit`**：视图创建时调用一次，用于做一次性初始化，如注册监听、设置默认属性等。  
-- **`viewUpdate: (T) -> Unit`**：每次重组时调用，用于根据最新的 Compose 参数更新 Kuikly 视图属性。  
+- **`factory: () -> T`**：创建 Kuikly 视图实例的工厂函数。
+- **`modifier: Modifier`**：Compose 侧传入的 `Modifier`，内部会同步到 Kuikly 节点，用于尺寸、布局、点击等。
+- **`content: @Composable () -> Unit`（仅容器重载）**：子内容插槽，Compose 子节点会被挂载到当前 Kuikly 容器节点下。
+- **`viewInit: T.() -> Unit`**：视图创建时调用一次，用于一次性初始化，如设置背景、注册事件、构建内部子视图等。
+- **`viewUpdate: (T) -> Unit`**：每次重组时调用，用于根据最新的 Compose 参数更新 Kuikly 视图属性。
 - **`measurePolicy: MeasurePolicy`**：Compose 布局测量策略：
-  - 叶子节点默认为 `KuiklyDefaultMeasurePolicy`（占满父约束大小）  
-  - 容器重载默认为 `DefaultColumnMeasurePolicy`，可以按需要自定义布局测量。  
+  - 无子节点默认为 `KuiklyDefaultMeasurePolicy`（占满父约束大小）
+  - 有子节点默认为 `DefaultColumnMeasurePolicy`，可按需自定义。
 
-## 使用示例：叶子节点组件（Video）
+## 两种使用场景
 
-- 封装 Kuikly DSL 为 Composable：[`VideoView.kt`](https://github.com/Tencent-TDS/KuiklyUI/blob/main/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/VideoView.kt)  
-- Compose Demo 页面：[`ComposeVideoDemo.kt`](https://github.com/Tencent-TDS/KuiklyUI/blob/main/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/ComposeVideoDemo.kt)
+### 场景一：原子组件
 
-典型封装模式（简化示意）：
+**适用**：组件自身完整渲染（如视频、图片、地图等），**不接受外部子视图**，Kotlin 侧只负责桥接属性和事件到原生层。
+
+Kuikly DSL 侧继承 `DeclarativeBaseView`，实现 `viewName()` 返回原生 view 类型名，属性/事件通过 `getViewAttr()` / `getViewEvent()` 桥接：
 
 ```kotlin
+// Kuikly DSL 侧（VideoView 为例，原生层负责实际渲染）
+// core/src/commonMain/kotlin/com/tencent/kuikly/core/views/VideoView.kt
+
+// Compose 侧包装
 @Composable
-fun VideoView(
-    url: String,
+fun Video(
+    src: String,
+    playControl: VideoPlayControl,
+    playTimeDidChanged: (curTime: Int, totalTime: Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     MakeKuiklyComposeNode<VideoView>(
         factory = { VideoView() },
         modifier = modifier,
         viewInit = {
-            // 一次性初始化，例如绑定控制器
+            getViewAttr().run {
+                playControl(VideoPlayControl.PLAY)
+                src(src)
+            }
         },
-        viewUpdate = { view ->
-            // 根据最新的 url 等参数更新底层 Kuikly Video 视图
+        viewUpdate = {
+            it.getViewAttr().run {
+                src(src)
+                playControl(playControl)
+            }
+            it.getViewEvent().run {
+                playTimeDidChanged(handlerFn = playTimeDidChanged)
+            }
         }
     )
 }
-```
 
-调用方可以像使用普通 Compose 组件一样使用：
-
-```kotlin
-VideoView(
-    url = "https://example.com/video.mp4",
-    modifier = Modifier.fillMaxWidth()
+// 调用
+Video(
+    src = "https://example.com/video.mp4",
+    playControl = VideoPlayControl.PLAY,
+    playTimeDidChanged = { cur, total -> },
+    modifier = Modifier.size(320.dp, 180.dp)
 )
 ```
 
-## 使用示例：容器组件（如通用卡片/布局容器）
+### 场景二：容器组件
 
-容器组件需要同时处理「自身属性」和「子内容插槽」，典型封装模式：
+**适用**：组件作为布局容器，**可挂载任意 Compose 子节点**（通过 `content` 传入），自身负责容器样式（背景、圆角、点击等）。
+
+Kuikly DSL 侧继承 `ViewContainer`，实现 `createAttr()`、`createEvent()`、`viewName()`，在 `viewInit` 里只设置自身样式，子视图交给 `content`：
 
 ```kotlin
-@Composable
-fun DslCard(
-    modifier: Modifier = Modifier,
-    onClick: () -> Unit = {},
-    content: @Composable () -> Unit
-) {
-    MakeKuiklyComposeNode<VirtualNodeView>(
-        factory = { VirtualNodeView() },
-        modifier = modifier,
-        content = content,
-        viewInit = {
-            // 初始化容器属性，例如点击事件、背景、圆角等
-        },
-        viewUpdate = { view ->
-            // 根据最新参数更新容器
+// Kuikly DSL 侧
+class KuiklyCard : ViewContainer<ContainerAttr, Event>() {
+    override fun createAttr() = ContainerAttr()
+    override fun createEvent() = Event()
+    override fun viewName() = ViewConst.TYPE_VIEW
+
+    fun setup(onClick: (() -> Unit)? = null) {
+        attr {
+            backgroundColor(0xFFE3F2FDL)
+            borderRadius(12f)
         }
+        onClick?.let {
+            event { click { onClick() } }
+        }
+    }
+}
+
+// Compose 侧包装（使用容器重载，传入 content）
+@Composable
+fun KuiklyCard(
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+    content: @Composable () -> Unit,
+) {
+    MakeKuiklyComposeNode<KuiklyCard>(
+        factory = { KuiklyCard() },
+        modifier = modifier,
+        viewInit = { setup(onClick) },
+        viewUpdate = { it.setup(onClick) },
+        content = content,
     )
 }
-```
 
-业务侧使用示例：
-
-```kotlin
-DslCard {
-    Text("标题")
-    Text("描述文案")
-    VideoView(url = ...)
+// 调用
+KuiklyCard(
+    modifier = Modifier.fillMaxWidth().height(120.dp),
+    onClick = { /* handle click */ }
+) {
+    Text("卡片标题")
+    Text("卡片描述")
 }
 ```
 
-完整的容器封装与使用示例，可参考 Demo 中的 DSL 容器组件实践（后续会补充到本页，持续更新中）。
+## 注意事项
 
+`factory` 中传入的视图类型需根据场景选择正确基类：
 
+- **原子组件**：继承 `DeclarativeBaseView`，`viewName()` 返回原生 view 类型名，原生层负责渲染
+- **容器组件**：继承 `ViewContainer`，可挂载 Compose 子节点，`isRenderView()` 始终返回 `true`
 
+**不能**将 `ComposeView` 子类传入 `factory`——`ComposeView` 的扁平化优化会导致 Compose 计算出的布局 frame 无法传递给实际渲染层，视图将不可见。
 
+```kotlin
+// ❌ 错误：ComposeView 子类，编译通过但运行时不可见
+class MyView : ComposeView<ComposeAttr, ComposeEvent>() { ... }
+MakeKuiklyComposeNode<MyView>(factory = { MyView() }, ...)
+
+// ✅ 正确（原子组件）：DeclarativeBaseView 子类
+class MyView : DeclarativeBaseView<MyAttr, MyEvent>() {
+    override fun viewName() = "MyNativeView"
+}
+MakeKuiklyComposeNode<MyView>(factory = { MyView() }, ...)
+
+// ✅ 正确（容器组件）：ViewContainer 子类
+class MyView : ViewContainer<ContainerAttr, Event>() {
+    override fun createAttr() = ContainerAttr()
+    override fun createEvent() = Event()
+    override fun viewName() = ViewConst.TYPE_VIEW
+}
+MakeKuiklyComposeNode<MyView>(factory = { MyView() }, content = { ... }, ...)
+```
+
+## Demo 示例
+
+- 原子组件示例（VideoView）：[`VideoView.kt`](https://github.com/Tencent-TDS/KuiklyUI/blob/main/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/VideoView.kt)


### PR DESCRIPTION
## Summary

- Fix incorrect base class in Scene 1 (atomic component): replace `DivView` with `DeclarativeBaseView`, using `VideoView` as the reference example
- Fix incorrect base class in Scene 2 (container component): replace `DivView` with `ViewContainer`, which has `isRenderView()` always returning `true` and avoids the flat-layer optimization pitfall
- Rewrite API section headers and descriptions for clarity: rename "leaf node overload" / "container overload" to "no children (atomic)" / "with children (container)"
- Emphasize that container components exist to **mount Compose child nodes**, not just to carry styles
- Remove the broken `DialogTestPageCompose.kt` demo link from the Demo section

## Related Issue

Fixes #984