### PR TITLE
fix: pager snap offset calculation and deceleration handling

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/PagerStateExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/PagerStateExtensions.kt
@@ -77,10 +77,8 @@ private fun PagerState.handleTargetPageScroll(
 
         val maxOffset = kuiklyInfo.currentContentSize - kuiklyInfo.viewportSize
         var targetOffset = nextPage?.let { offset + it.offset }
-            ?: (pageSizeWithSpacing * (targetPage - 1))
+            ?: (pageSizeWithSpacing * targetPage)
         targetOffset = min(targetOffset, maxOffset)
-
-        if (targetOffset == offset) return
 
         val density = kuiklyInfo.getDensity()
         val springAnimation = SpringAnimation(


### PR DESCRIPTION
## Summary

Fix two bugs in `HorizontalPager` snap behavior that cause the page to stop at an intermediate position instead of snapping to the correct page.

### Bug 1: Off-by-one in fallback offset formula
When the target page is not found in visible/extra pages, the fallback formula used `pageSizeWithSpacing * (targetPage - 1)`, which produces a wrong offset (e.g. 0 instead of 1284 for page 1). Fixed to `pageSizeWithSpacing * targetPage`.

### Bug 2: Early return when `targetOffset == offset`
When the user's drag ends exactly at the target page boundary but with residual velocity, the `if (targetOffset == offset) return` skipped `setContentOffset`, allowing native scrollView deceleration to drift the page away from the correct snap position. Removed this early return so that `setContentOffset` with spring animation is always called to override any native deceleration.

### Reproduction
- Use a `HorizontalPager` with tab switching (e.g. 收藏/浏览历史/已赞/推送)
- Swipe between tabs repeatedly
- Occasionally the page stops at an intermediate offset and stays there

### Verification
Tested on iOS real device (iPhone 13 Pro Max, iOS 26.3.1). After the fix, the bug no longer reproduces.