### PR TITLE
fix: remove playTimeDidChanged from ComposeVideoDemo to avoid confusion

### DIFF
--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/ComposeVideoDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/ComposeVideoDemo.kt
@@ -36,9 +36,7 @@ import com.tencent.kuikly.compose.setContent
 import com.tencent.kuikly.compose.ui.Alignment
 import com.tencent.kuikly.compose.ui.Modifier
 import com.tencent.kuikly.compose.ui.graphics.Color
-import com.tencent.kuikly.compose.ui.text.style.TextAlign
 import com.tencent.kuikly.compose.ui.unit.dp
-import com.tencent.kuikly.compose.ui.unit.sp
 import com.tencent.kuikly.core.annotations.Page
 import com.tencent.kuikly.core.views.VideoPlayControl
 
@@ -57,10 +55,6 @@ internal class ComposeVideoDemo : ComposeContainer() {
 
 @Composable
 fun ComposeVideoDemoImpl(){
-    // 定义当前播放时间和总时间
-    var currentTime by remember { mutableStateOf(0) }
-    var totalTime by remember { mutableStateOf(1) } // 避免除以0错误
-
     // 定义播放控制状态
     var playControl by remember { mutableStateOf(VideoPlayControl.PLAY) }
 
@@ -77,13 +71,6 @@ fun ComposeVideoDemoImpl(){
         Video(
             src = videoUrl,
             playControl = playControl,
-            playTimeDidChanged = { curTime, total ->
-                println("xxxx playTimeDidChanged $curTime, $total")
-                currentTime = curTime
-                if (total > 0) {
-                    totalTime = total
-                }
-            },
             modifier = Modifier.align(Alignment.Center).size(width = 400.dp, height = 300.dp).background(Color.Red),
         )
 
@@ -97,15 +84,6 @@ fun ComposeVideoDemoImpl(){
                     .padding(8.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            // 时间显示
-            Text(
-                text = "播放进度: ${formatTime(currentTime)} / ${formatTime(totalTime)}",
-                color = Color.White,
-                fontSize = 14.sp,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(bottom = 8.dp),
-            )
-
             // 控制按钮
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -122,34 +100,13 @@ fun ComposeVideoDemoImpl(){
                                 VideoPlayControl.PAUSE
                             }
                     },
-                    modifier = Modifier.padding(end = 8.dp),
                 ) {
                     Text(
                         text = if (playControl != VideoPlayControl.PLAY) "播放" else "暂停",
                         color = Color.White,
                     )
                 }
-
-                // 停止按钮
-                Button(
-                    onClick = {
-                        playControl = VideoPlayControl.STOP
-                    },
-                ) {
-                    Text(
-                        text = "停止",
-                        color = Color.White,
-                    )
-                }
             }
         }
     }
-}
-
-// 格式化时间（毫秒转为分:秒格式）
-private fun formatTime(timeMs: Int): String {
-    val totalSeconds = timeMs / 1000
-    val minutes = totalSeconds / 60
-    val seconds = totalSeconds % 60
-    return "${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}"
 }

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/VideoView.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/VideoView.kt
@@ -25,7 +25,6 @@ import com.tencent.kuikly.core.views.VideoView
 fun Video(
     src: String,
     playControl: VideoPlayControl,
-    playTimeDidChanged: (curTime: Int, totalTime: Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     MakeKuiklyComposeNode<VideoView>(
@@ -43,11 +42,6 @@ fun Video(
             it.getViewAttr().run {
                 src(src)
                 playControl(playControl)
-            }
-            it.getViewEvent().run {
-                playTimeDidChanged(handlerFn = playTimeDidChanged)
-                playStateDidChanged(handlerFn = { state, b ->
-                })
             }
         }
     )


### PR DESCRIPTION
## Summary

该 PR 修复了 issue #858 中提到的 `ComposeVideoDemo` 中播放进度不更新的问题。

## Problem

Demo 中的 `playTimeDidChanged` 回调无效，因为 `VideoViewAdapter`（基于 ExoPlayer）没有实现播放时间更新的监听机制。这导致用户误以为功能有问题。

## Solution

由于该 demo 仅用于展示如何将 Kuikly DSL 组件扩展到 Compose DSL，我们移除了时间相关的功能：

- 移除 `playTimeDidChanged` 回调和播放进度显示
- 移除停止按钮（ExoPlayer 的 `stop()` 会释放资源，无法重新播放）
- 仅保留播放/暂停控制按钮，保持 demo 简洁

## Changes

- `demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/ComposeVideoDemo.kt`
- `demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/VideoView.kt`

Fixes #858