### PR TITLE
feat: add default KRCustomPropsHandler in h5 web render

### DIFF
--- a/core-render-web/base/src/jsMain/kotlin/com/tencent/kuikly/core/render/web/const/KRConst.kt
+++ b/core-render-web/base/src/jsMain/kotlin/com/tencent/kuikly/core/render/web/const/KRConst.kt
@@ -65,6 +65,7 @@ object KRCssConst {
 
     // Same as Attr.StyleConst.DEBUG_NAME
     const val DEBUG_NAME = "debugName"
+    const val CSS_CLASS = "cssClass"
     const val AUTO_DARK_ENABLE = "autoDarkEnable"
     const val TURBO_DISPLAY_AUTO_UPDATE_ENABLE = "turboDisplayAutoUpdateEnable"
     const val SCROLL_INDEX = "scrollIndex"

--- a/core-render-web/h5/src/jsMain/kotlin/com/tencent/kuikly/core/render/web/runtime/web/expand/KRCustomPropsHandler.kt
+++ b/core-render-web/h5/src/jsMain/kotlin/com/tencent/kuikly/core/render/web/runtime/web/expand/KRCustomPropsHandler.kt
@@ -1,0 +1,71 @@
+package com.tencent.kuikly.core.render.web.runtime.web.expand
+
+import com.tencent.kuikly.core.render.web.const.KRCssConst
+import com.tencent.kuikly.core.render.web.const.KRJsTypeConst
+import com.tencent.kuikly.core.render.web.export.IKuiklyRenderViewExport
+import com.tencent.kuikly.core.render.web.export.IKuiklyRenderViewPropExternalHandler
+import org.w3c.dom.HTMLElement
+
+/**
+ * Default Handler: external prop handler for custom props.
+ * Handles the "cssClass" attribute set via `fun Attr.cssClass(value: String)` in common code.
+ */
+internal class KRCustomPropsHandler : IKuiklyRenderViewPropExternalHandler {
+
+    override fun setViewExternalProp(
+        renderViewExport: IKuiklyRenderViewExport,
+        propKey: String,
+        propValue: Any
+    ): Boolean {
+        when (propKey) {
+            KRCssConst.CSS_CLASS -> {
+                val ele = renderViewExport.ele.unsafeCast<HTMLElement>()
+                if (jsTypeOf(ele.asDynamic().classList) == KRJsTypeConst.UNDEFINED) return false
+
+                removeTrackedCssClasses(ele)
+
+                val cssClassValue = propValue.unsafeCast<String>().trim()
+                cssClassValue
+                    .split("\\s+".toRegex())
+                    .filter { it.isNotEmpty() }
+                    .forEach { className ->
+                        ele.classList.add(className)
+                    }
+                ele.setAttribute(TRACKED_CSS_CLASS_ATTR, cssClassValue)
+                return true
+            }
+            else -> return false
+        }
+    }
+
+    override fun resetViewExternalProp(
+        renderViewExport: IKuiklyRenderViewExport,
+        propKey: String
+    ): Boolean {
+        return when (propKey) {
+            KRCssConst.CSS_CLASS -> {
+                val ele = renderViewExport.ele.unsafeCast<HTMLElement>()
+                if (jsTypeOf(ele.asDynamic().classList) == KRJsTypeConst.UNDEFINED) return false
+
+                removeTrackedCssClasses(ele)
+                ele.removeAttribute(TRACKED_CSS_CLASS_ATTR)
+                true
+            }
+            else -> false
+        }
+    }
+
+    private fun removeTrackedCssClasses(ele: HTMLElement) {
+        ele.getAttribute(TRACKED_CSS_CLASS_ATTR)
+            ?.trim()
+            ?.split("\\s+".toRegex())
+            ?.filter { it.isNotEmpty() }
+            ?.forEach { className ->
+                ele.classList.remove(className)
+            }
+    }
+
+    companion object {
+        private const val TRACKED_CSS_CLASS_ATTR = "data-kuikly-css-class"
+    }
+}

--- a/core-render-web/h5/src/jsMain/kotlin/com/tencent/kuikly/core/render/web/runtime/web/expand/KuiklyRenderViewDelegator.kt
+++ b/core-render-web/h5/src/jsMain/kotlin/com/tencent/kuikly/core/render/web/runtime/web/expand/KuiklyRenderViewDelegator.kt
@@ -399,6 +399,8 @@ class KuiklyRenderViewDelegator(private val delegate: KuiklyRenderViewDelegatorD
      * Register custom property handler
      */
     private fun registerViewExternalPropHandler(kuiklyRenderExport: IKuiklyRenderExport) {
+        // Register built-in external prop handlers
+        kuiklyRenderExport.viewPropExternalHandlerExport(KRCustomPropsHandler())
         // Delegate to external, allowing host project to expose its own custom property handler
         delegate.registerViewExternalPropHandler(kuiklyRenderExport)
     }

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/CssClassTestPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/CssClassTestPage.kt
@@ -1,0 +1,95 @@
+package com.tencent.kuikly.demo.pages
+
+import com.tencent.kuikly.core.annotations.Page
+import com.tencent.kuikly.core.base.*
+import com.tencent.kuikly.core.pager.Pager
+import com.tencent.kuikly.core.reactive.handler.observable
+import com.tencent.kuikly.core.timer.setTimeout
+import com.tencent.kuikly.core.views.*
+import com.tencent.kuikly.core.views.layout.Center
+import com.tencent.kuikly.demo.pages.demo.base.NavBar
+
+fun Attr.cssClass(value: String) {
+    "cssClass" with value
+}
+
+@Page("cssClassTestPage")
+internal class CssClassTestPage : Pager() {
+    var dynamicClassName by observable("test-single-class")
+    var dynamicClassNameForMultipleCase by observable("test-multi-class-1 test-multi-class-2")
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            View {
+                attr {
+                    size(pagerData.pageViewWidth, pagerData.pageViewHeight)
+                }
+                NavBar { attr { title = "CSS Class Test" } }
+
+                // Test Case 1: Single CSS Class
+                View {
+                    attr {
+                        size(pagerData.pageViewWidth, 100f)
+                        backgroundColor(Color.WHITE)
+                        cssClass(ctx.dynamicClassName)
+                    }
+                    Center {
+                        Text {
+                            attr {
+                                text(ctx.dynamicClassName)
+                                fontSize(16f)
+                                cssClass("test-text-class")
+                            }
+                        }
+                    }
+                }
+
+                // Test Case 2: Multiple CSS Classes
+                View {
+                    attr {
+                        size(pagerData.pageViewWidth, 100f)
+                        marginTop(20f)
+                        backgroundColor(Color.WHITE)
+                        cssClass(ctx.dynamicClassNameForMultipleCase)
+                    }
+                    Center {
+                        Text {
+                            attr {
+                                text(ctx.dynamicClassNameForMultipleCase)
+                                fontSize(16f)
+                            }
+                        }
+                    }
+                }
+
+                // Test Case 3: Empty/Whitespace Handling
+                View {
+                    attr {
+                        size(pagerData.pageViewWidth, 100f)
+                        marginTop(20f)
+                        backgroundColor(Color.WHITE)
+                        cssClass("  test-padded-class  ")
+                    }
+                    Center {
+                        Text {
+                            attr {
+                                text("Padded CSS Class: .test-padded-class")
+                                fontSize(16f)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun created() {
+        super.created()
+        val ctx = this
+        setTimeout(2000) {
+            ctx.dynamicClassName = "test-single-class-updated"
+            ctx.dynamicClassNameForMultipleCase = "test-multi-class-1-updated test-multi-class-2-updated"
+        }
+    }
+}

--- a/docs/DevGuide/h5-css-class.md
+++ b/docs/DevGuide/h5-css-class.md
@@ -1,0 +1,92 @@
+# 使用 `cssClass` 为 DOM 节点附加 CSS 类名
+
+`cssClass` 是 Kuikly 在 H5 平台提供的一个内置能力，用于给渲染后的 DOM 节点附加 CSS class，方便复用宿主侧样式体系，或补充 H5 特有样式。
+
+这个能力适用于 H5 渲染场景，不属于“如何扩展自定义属性”的通用教程范畴，因此单独放在 Web 教程中说明更合适。
+
+## 定义属性
+
+可以先在 Kuikly 侧定义一个扩展属性：
+
+```kotlin
+fun Attr.cssClass(value: String) {
+    "cssClass" with value
+}
+```
+
+## 基本用法
+
+可以在 `View`、`Text` 等组件上使用 `cssClass`：
+
+```kotlin
+View {
+    attr {
+        size(pagerData.pageViewWidth, 100f)
+        backgroundColor(Color.WHITE)
+        cssClass("test-single-class")
+    }
+}
+
+Text {
+    attr {
+        text("Single CSS Class: .test-single-class")
+        fontSize(16f)
+        cssClass("test-text-class")
+    }
+}
+```
+
+## 支持多个 class
+
+多个 class 可以通过空格分隔：
+
+```kotlin
+cssClass("test-multi-class-1 test-multi-class-2")
+```
+
+H5 宿主侧会按空白字符拆分后逐个添加到 DOM 元素的 `classList` 中。
+
+## 空白处理
+
+前后空白会被自动忽略：
+
+```kotlin
+cssClass("  test-padded-class  ")
+```
+
+最终生效的 class 名仍然是 `test-padded-class`。
+
+## 动态更新
+
+`cssClass` 支持响应式更新。属性值发生变化后，H5 渲染层会先移除该属性之前写入到 DOM 的 class，再应用新的 class 值。
+
+例如：
+
+```kotlin
+var dynamicClassName by observable("test-single-class")
+
+View {
+    attr {
+        cssClass(dynamicClassName)
+    }
+}
+
+setTimeout(2000) {
+    dynamicClassName = "test-single-class-updated"
+}
+```
+
+上面的示例在更新后，DOM 上最终保留的是 `test-single-class-updated`，而不是旧值和新值的叠加结果。
+
+## 说明
+
+* `cssClass` 仅在 H5 渲染生效。
+* 多个 class 使用空格分隔，前后空白会自动忽略。
+* `cssClass` 最终会映射到 DOM 元素的 `classList`。
+* 该能力适合补充 H5 特有样式，或接入宿主已有的 CSS 样式体系。
+
+## 示例参考
+
+完整示例可参考：
+
+* `demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/CssClassTestPage.kt`

--- a/docs/sidebar/zh.ts
+++ b/docs/sidebar/zh.ts
@@ -161,7 +161,7 @@ export const zhSidebar = sidebar({
                     text: "Web教程",
                     collapsible: false,
                     children: [
-                        "web-import-jssdk.md", "h5-image-path.md", "h5-spa-demo.md", "h5-custom-font.md"
+                        "web-import-jssdk.md", "h5-image-path.md", "h5-spa-demo.md", "h5-custom-font.md", "h5-css-class.md"
                     ]
                 }
             ],


### PR DESCRIPTION
add default KRCustomPropsHandler in h5 web render
Test cases:
- Single CSS class
- Dynamic update of single CSS class
- Multiple CSS classes in one string
- Leading/trailing whitespace trimming