### PR TITLE
fix: OHOS PAGView autoPlay not working and setProgress not synced

### DIFF
--- a/core-render-ohos/src/main/ets/adapter/IKRPAGViewAdapter.ets
+++ b/core-render-ohos/src/main/ets/adapter/IKRPAGViewAdapter.ets
@@ -27,6 +27,8 @@ export interface IKRPAGViewController {
   play(): void;
 
   stop(): void;
+
+  setProgress(value: number): void;
 }
 
 export interface IKRPAGViewListener {

--- a/core-render-ohos/src/main/ets/components/KRPAGView.ets
+++ b/core-render-ohos/src/main/ets/components/KRPAGView.ets
@@ -61,6 +61,8 @@ export class KRPAGView extends KuiklyRenderBaseView implements IKRPAGViewListene
   src: string = '';
   autoPlay: boolean = true;
   repeatCount = 0;
+  private hadSrcSet: boolean = false;
+  private hadStop: boolean = false;
   controller: IKRPAGViewController | undefined;
   static readonly VIEW_NAME = 'KRPAGView';
   private static readonly PROP_SRC = 'src';
@@ -73,6 +75,7 @@ export class KRPAGView extends KuiklyRenderBaseView implements IKRPAGViewListene
   private static readonly EVENT_ANIMATION_REPEAT = 'animationRepeat';
   private static readonly PROP_METHOD_PLAY = 'play';
   private static readonly PROP_METHOD_STOP = 'stop';
+  private static readonly PROP_METHOD_SET_PROGRESS = 'setProgress';
 
   private static readonly SCHEME_ASSETS = "assets://";
   private static readonly SCHEME_FILE = "files://";
@@ -89,10 +92,20 @@ export class KRPAGView extends KuiklyRenderBaseView implements IKRPAGViewListene
       this.animationCancelEvent = propValue as KuiklyRenderCallback;
     } else if (propKey == KRPAGView.EVENT_ANIMATION_REPEAT) {
       this.animationRepeatEvent = propValue as KuiklyRenderCallback;
-    } else {
-      if (propKey == KRPAGView.PROP_SRC) {
-        propValue = this.convertAssetsPathIfNeed(propValue as string)
+    } else if (propKey == KRPAGView.PROP_AUTO_PLAY) {
+      this.autoPlay = (propValue as number) == 1;
+      if (this.autoPlay) {
+        this.tryAutoPlay();
       }
+    } else if (propKey == KRPAGView.PROP_SRC) {
+      propValue = this.convertAssetsPathIfNeed(propValue as string);
+      this.src = propValue as string;
+      this.hadSrcSet = true;
+      if (this.controller) {
+        this.controller.setProp(propKey, propValue);
+      }
+      setTimeout(() => { this.tryAutoPlay(); });
+    } else {
       if (this.controller) {
         return this.controller?.setProp(propKey, propValue);
       } else {
@@ -106,9 +119,29 @@ export class KRPAGView extends KuiklyRenderBaseView implements IKRPAGViewListene
   call(method: string, params: KRAny, callback: KuiklyRenderCallback | null): void {
     console.log(`KRPAGView call method :${method}`);
     if (method == KRPAGView.PROP_METHOD_PLAY) {
+      this.autoPlay = true;
+      this.hadStop = false;
       this.controller?.play();
     } else if (method == KRPAGView.PROP_METHOD_STOP) {
-      this.controller?.stop();
+      this.autoPlay = false;
+      if (!this.hadStop) {
+        this.hadStop = true;
+        this.controller?.stop();
+      }
+    } else if (method == KRPAGView.PROP_METHOD_SET_PROGRESS) {
+      if (typeof params === 'string') {
+        const json: Record<string, Object> = JSON.parse(params as string) as Record<string, Object>;
+        const value = json['value'] as number;
+        if (value !== undefined) {
+          this.controller?.setProgress(value);
+        }
+      }
+    }
+  }
+
+  private tryAutoPlay(): void {
+    if (this.autoPlay && this.hadSrcSet && !this.hadStop) {
+      this.controller?.play();
     }
   }
 

--- a/ohosApp/entry/src/main/ets/kuikly/adapters/AppKRPAGAdapter.ets
+++ b/ohosApp/entry/src/main/ets/kuikly/adapters/AppKRPAGAdapter.ets
@@ -104,6 +104,10 @@ class AppKRPAGViewController implements IKRPAGViewController, PAGViewListener {
     this.viewController.pause();
   }
 
+  setProgress(value: number): void {
+    this.viewController.setProgress(value);
+  }
+
   setProp(propKey: string, propValue: KRValue | KuiklyRenderCallback): boolean {
     if (propKey == 'src') {
       const resdir = getContext().resourceDir;


### PR DESCRIPTION
## Summary
- Fix `autoPlay` prop not taking effect on OHOS: `KRPAGView.ets` now intercepts `autoPlay` in `setProp` and implements a `tryAutoPlay()` mechanism (aligned with Android behavior)
- Fix `setProgress` not synced to OHOS: add `setProgress` handling in `KRPAGView.ets` `call()` method, and add `setProgress(value: number)` to `IKRPAGViewController` interface

## Test plan
- [ ] Verify PAG animation auto-plays when `autoPlay(true)` is set
- [ ] Verify PAG animation does not auto-play when `autoPlay(false)` is set
- [ ] Verify `setProgress(value)` correctly updates playback progress on OHOS
- [ ] Verify `play()` / `stop()` method calls work as expected