### PR TITLE
fix(compose): fix pager guard allowing bounce-direction fling to trigger page change

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/PagerStateExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/PagerStateExtensions.kt
@@ -37,11 +37,11 @@ import kotlin.math.min
 internal fun PagerState.kuiklyWillDragEnd(params: WillEndDragParams, orientation: Orientation) {
     val effectivePageSizePx = pageSize + pageSpacing
     if (effectivePageSizePx == 0) return
-    
+
     val velocity = if (orientation == Orientation.Horizontal) -params.velocityX else -params.velocityY
     val startPage = if (velocity < 0) firstVisiblePage + 1 else firstVisiblePage
     val targetPage = startPage.coerceIn(0, pageCount)
-    
+
     val correctedTargetPage = calculateTargetPage(startPage, targetPage, velocity)
     handleTargetPageScroll(correctedTargetPage, params, orientation)
 }

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
@@ -74,6 +74,7 @@ import com.tencent.kuikly.compose.layout.restoreScrollerViewOnReuse
 import com.tencent.kuikly.compose.layout.transferScrollToTopCallback
 import com.tencent.kuikly.compose.scroller.handleScrollToTopCallback
 import com.tencent.kuikly.compose.scroller.isAtTop
+import com.tencent.kuikly.compose.scroller.lastItemVisible
 import com.tencent.kuikly.compose.scroller.kuiklyInfo
 import com.tencent.kuikly.compose.scroller.kuiklyOnScroll
 import com.tencent.kuikly.compose.scroller.kuiklyOnScrollEnd
@@ -263,7 +264,7 @@ fun SubcomposeLayout(
                     val scaleParams = it.scaleWithDensity(kuiklyInfo.getDensity())
                     // 实现分页滑动
                     val offset = if (isVertical) scaleParams.offsetY.toInt() else scaleParams.offsetX.toInt()
-                    if ((offset < 0 && scrollableState.isAtTop()) || offset > (kuiklyInfo.currentContentSize - viewportSize)) {
+                    if ((offset <= 0 && scrollableState.isAtTop()) || (offset >= (kuiklyInfo.currentContentSize - viewportSize) && scrollableState.lastItemVisible())) {
                         return@willDragEndBySync
                     }
                     scrollableState.kuiklyWillDragEnd(scaleParams, orientation)


### PR DESCRIPTION
## Summary

- **Bug**: In `HorizontalPager` with `bouncesEnable=false`, swiping in the bounce direction (right on page0 or left on the last page) had a low probability of incorrectly triggering a page-change animation.
- **Root cause**: The `willDragEndBySync` guard in `SubcomposeLayout.kt` used strict inequality (`offset < 0` / `offset > maxContent`) to detect boundary conditions. But with `bouncesEnable=false`, the native ScrollView locks the content offset exactly at `0` or `maxContent` — it never goes negative or over — so the guard was never triggered, and the fling velocity was allowed to advance the page.
- **Fix**: Changed to `offset <= 0` (start boundary) and `offset >= maxContent && lastItemVisible()` (end boundary) so the guard correctly fires when the content is locked at the edge.

## Files changed

- `compose/.../SubcomposeLayout.kt` — fix guard conditions (`<` → `<=`, `>` → `>=` + `lastItemVisible()`)
- `compose/.../PagerStateExtensions.kt` — remove debug logs added during investigation (no logic change)

## Test plan

- [ ] In `MyHorizontalPagerDemo`, swipe right repeatedly on page0 — page should stay at 0, no unwanted animation to page1
- [ ] Swipe left normally from page0 — page should advance to page1 as expected
- [ ] On the last page, swipe left in the bounce direction — page should not go backwards
- [ ] Normal right swipe on any non-boundary page — page change works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)