### PR TITLE
fix(demo): set default empty page title to 'No Content'

### DIFF
--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/app/AppEmptyPageView.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/app/AppEmptyPageView.kt
@@ -72,7 +72,7 @@ internal class AppEmptyPageView(): ComposeView<AppEmptyPageViewAttr, AppEmptyPag
 }
 
 internal class AppEmptyPageViewAttr : ComposeAttr() {
-    var title by observable("")
+    var title by observable("No Content")
 }
 
 internal class AppEmptyPageViewEvent : ComposeEvent()


### PR DESCRIPTION
## Summary
- Set `AppEmptyPageViewAttr.title` default value from `""` to `"No Content"` so the empty state is visually indicated instead of showing a blank area

## Test plan
- [ ] Verify empty page in demo app shows "No Content" text by default
- [ ] Verify custom title still overrides the default when set