### PR TITLE
test: add padding to empty page view for hooks testing

### DIFF
--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/app/AppEmptyPageView.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/app/AppEmptyPageView.kt
@@ -60,6 +60,8 @@ internal class AppEmptyPageView(): ComposeView<AppEmptyPageViewAttr, AppEmptyPag
                 allCenter()
                 flex(1f)
                 backgroundColor(ctx.theme.colors.background)
+                // Test hooks: padding around the text
+                padding(16f)
             }
             Text {
                 attr {
@@ -72,7 +74,7 @@ internal class AppEmptyPageView(): ComposeView<AppEmptyPageViewAttr, AppEmptyPag
 }
 
 internal class AppEmptyPageViewAttr : ComposeAttr() {
-    var title by observable("No Content")
+    var title by observable("")
 }
 
 internal class AppEmptyPageViewEvent : ComposeEvent()

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/app/AppEmptyPageView.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/app/AppEmptyPageView.kt
@@ -72,7 +72,7 @@ internal class AppEmptyPageView(): ComposeView<AppEmptyPageViewAttr, AppEmptyPag
 }
 
 internal class AppEmptyPageViewAttr : ComposeAttr() {
-    var title by observable("")
+    var title by observable("No Content")
 }
 
 internal class AppEmptyPageViewEvent : ComposeEvent()


### PR DESCRIPTION
这是一个用于测试 hooks 的简单改动。

## 改动内容

- 在 AppEmptyPageView 的 body 函数中添加了 padding(16f) 属性
- 添加了注释说明这是用于测试 hooks 的改动

## 测试范围

可用于验证 hooks 在 PR 提交流程中的正确触发。