### PR TITLE
fix: stabilize iOS pager and nested scroll

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
@@ -264,7 +264,17 @@ fun SubcomposeLayout(
                     val scaleParams = it.scaleWithDensity(kuiklyInfo.getDensity())
                     // 实现分页滑动
                     val offset = if (isVertical) scaleParams.offsetY.toInt() else scaleParams.offsetX.toInt()
-                    if ((offset <= 0 && scrollableState.isAtTop()) || (offset >= (kuiklyInfo.currentContentSize - viewportSize) && scrollableState.lastItemVisible())) {
+                    val targetOffset = if (isVertical) {
+                        scaleParams.targetContentOffsetY.toInt()
+                    } else {
+                        scaleParams.targetContentOffsetX.toInt()
+                    }
+                    val maxOffset = kuiklyInfo.currentContentSize - viewportSize
+                    val isAtTop = scrollableState.isAtTop()
+                    val lastItemVisible = scrollableState.lastItemVisible()
+                    val guardStart = offset <= 0 && isAtTop && targetOffset <= offset
+                    val guardEnd = offset >= maxOffset && lastItemVisible && targetOffset >= offset
+                    if (guardStart || guardEnd) {
                         return@willDragEndBySync
                     }
                     scrollableState.kuiklyWillDragEnd(scaleParams, orientation)

--- a/core-render-ios/Extension/Components/NestScroll/NestedScrollCoordinator.mm
+++ b/core-render-ios/Extension/Components/NestScroll/NestedScrollCoordinator.mm
@@ -463,13 +463,16 @@ static inline void lockScrollView(const UIScrollView<NestedScrollProtocol> *scro
 #pragma mark - Utils
 
 + (id<ScrollableProtocol>)findNestedOuterScrollView:(UIScrollView *)innerScrollView {
-    UIView<ScrollableProtocol> *innerScrollable = (UIView<ScrollableProtocol> *)innerScrollView;
-    UIView *outerScrollView = innerScrollable.superview;
+    // Use superview.superview since scrollview is a subview of view.
+    UIView *innerWrapperView = innerScrollView.superview;
+    UIView *outerScrollView = innerWrapperView.superview;
+    BOOL isInnerHorizontal =
+        [innerScrollView respondsToSelector:@selector(horizontal)] ?
+        [(id<ScrollableProtocol>)innerScrollView horizontal] : NO;
     while (outerScrollView) {
         if ([outerScrollView conformsToProtocol:@protocol(ScrollableProtocol)]) {
             UIView<ScrollableProtocol> *outerScrollable = (UIView<ScrollableProtocol> *)outerScrollView;
             // Make sure to find scrollable with same direction.
-            BOOL isInnerHorizontal = [innerScrollable respondsToSelector:@selector(horizontal)] ? [innerScrollable horizontal] : NO;
             BOOL isOuterHorizontal = [outerScrollable respondsToSelector:@selector(horizontal)] ? [outerScrollable horizontal] : NO;
             if (isInnerHorizontal == isOuterHorizontal) {
                 break;


### PR DESCRIPTION
## Summary
- Keep Compose pager drag-end handling active when swiping back inward from a content boundary, so iOS pager snapping can complete instead of stopping between pages.
- Start nested outer scroll lookup outside the inner scroll wrapper and derive direction from the inner scroll view itself.

## Test plan
- ./gradlew :compose:compileDebugKotlinAndroid

Made with [Cursor](https://cursor.com)