### PR TITLE
fix(Macos): skip redundant becomeFirstResponder for NSTextField

### DIFF
--- a/core-render-ios/Extension/Components/KRTextFieldView.m
+++ b/core-render-ios/Extension/Components/KRTextFieldView.m
@@ -225,6 +225,12 @@ NSString *const KRVFontWeightKey = @"fontWeight";
 
 - (void)css_focus:(NSDictionary *)args  {
     dispatch_async(dispatch_get_main_queue(), ^{
+        // macOS: NSTextField uses a field editor. Re-calling becomeFirstResponder
+        // while the field editor is active can re-select all text, causing the
+        // "first backspace selects all" bug on non-empty initial values.
+        if ([self respondsToSelector:@selector(currentEditor)] && [self currentEditor] != nil) {
+            return;
+        }
         [self becomeFirstResponder];
     });
 }

--- a/core-render-ios/Extension/Components/KRTextFieldView.m
+++ b/core-render-ios/Extension/Components/KRTextFieldView.m
@@ -225,12 +225,14 @@ NSString *const KRVFontWeightKey = @"fontWeight";
 
 - (void)css_focus:(NSDictionary *)args  {
     dispatch_async(dispatch_get_main_queue(), ^{
+#if TARGET_OS_OSX
         // macOS: NSTextField uses a field editor. Re-calling becomeFirstResponder
         // while the field editor is active can re-select all text, causing the
         // "first backspace selects all" bug on non-empty initial values.
-        if ([self respondsToSelector:@selector(currentEditor)] && [self currentEditor] != nil) {
+        if ([self currentEditor] != nil) {
             return;
         }
+#endif
         [self becomeFirstResponder];
     });
 }


### PR DESCRIPTION
fix: Macos skip redundant becomeFirstResponder for NSTextField