### PR TITLE
fix(ohos): make SliderPage child items respond to dynamic pageItem size (foldable screen fix)

### DIFF
--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/compose/SliderPageView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/compose/SliderPageView.kt
@@ -20,6 +20,7 @@ import com.tencent.kuikly.core.base.event.EventHandlerFn
 import com.tencent.kuikly.core.global.GlobalFunctionRef
 import com.tencent.kuikly.core.global.GlobalFunctions
 import com.tencent.kuikly.core.nvi.serialization.json.JSONObject
+import com.tencent.kuikly.core.reactive.handler.observable
 import com.tencent.kuikly.core.timer.setTimeout
 import com.tencent.kuikly.core.views.PageList
 import com.tencent.kuikly.core.views.PageListEvent
@@ -203,8 +204,8 @@ class SliderPageView : ComposeView<SliderPageAttr, SliderPageEvent>() {
 class SliderPageAttr: ComposeAttr() {
     var defaultPageIndex: Int = 0
     var isHorizontal: Boolean = true
-    var pageItemWidth = 0f
-    var pageItemHeight = 0f
+    var pageItemWidth: Float by observable(0f)
+    var pageItemHeight: Float by observable(0f)
     var scrollEnable: Boolean = true
     // 轮播时间间隔（ms单位），若 == 0 则不轮播
     var loopPlayIntervalTimeMs :Int = 3000

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/SliderPageViewDemoPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/SliderPageViewDemoPage.kt
@@ -65,7 +65,7 @@ internal class SliderPageViewDemoPage: BasePager() {
                    SliderPage {
                        attr {
                            isHorizontal = true
-                           pageItemWidth = 375f
+                           pageItemWidth = ctx.pageData.pageViewWidth
                            pageItemHeight = 375f
 
                            initSliderItems(ctx.pageItemList) { item ->


### PR DESCRIPTION


Problem:
- On HarmonyOS foldable devices, when the screen folds/unfolds, the SliderPageView container width follows the screen (container reads observable pageViewWidth), but each slider child item keeps its old width/height, so the cards no longer fill the new container size.

Root cause:
- SliderPageAttr.pageItemWidth / pageItemHeight were plain `var`s, not observable.
- Therefore the reactive `attr {}` block inside SliderPageView.body() -> `PageList.pageItemWidth(ctx.attr.pageItemWidth)` never established a reactive dependency on pageItemWidth, so when the outer value changed, the inner block did not re-execute, PageListAttr.pageItemWidth() was not called again, and existing child items' size was never updated.

Fix:
- Make SliderPageAttr.pageItemWidth / pageItemHeight observable via `by observable(0f)`.
- When the business passes an observable value (e.g. pageData.pageViewWidth), the outer attr block re-runs -> the inner PageList attr block re-runs -> PageListAttr.pageItemWidth() detects the change and triggers pageItemSizeChangeCallback -> PageListContentView resizes all children and resets the scroll offset.
- Update SliderPageViewDemoPage to use ctx.pageData.pageViewWidth instead of hard-coded 375f to validate the foldable scenario.

Compatibility:
- Fully backward compatible: assigning a constant still works as before; reactive updates only happen when an observable value is assigned, so there is no extra runtime cost for the common case.