### PR TITLE
feat: compose TextField support custom emoji

### DIFF
--- a/COMPOSE_TEXTFIELD_OFFICIAL_ALIGNMENT_PLAN.md
+++ b/COMPOSE_TEXTFIELD_OFFICIAL_ALIGNMENT_PLAN.md
@@ -1,0 +1,1356 @@
+# Compose DSL TextField 官方对齐改造方案
+
+创建日期：2026-05-07
+
+## 1. 目标
+
+将 KuiklyUI Compose DSL 的 TextField 从当前“字符串驱动输入框”升级为与 Jetpack Compose 官方 TextField 架构一致的“状态驱动文本编辑系统”。
+
+核心目标：
+
+1. 支持 `TextFieldValue(text, selection, composition)` 完整双向同步。
+2. 支持官方推荐的 `TextFieldState` 状态驱动 API。
+3. 支持 `edit { insert / replace / delete / append }` 事务式编辑。
+4. 支持 `InputTransformation` 输入过滤。
+5. 支持 `OutputTransformation` 显示格式化。
+6. 支持 selection / cursor / composition 跨端一致语义。
+7. 支持业务在光标处插入文本，不再依赖 `insertTextFnRef`。
+8. 支持自定义表情输入：`state.edit { insert(selection.start, "[微笑]") }`，渲染层通过输出转换或平台富文本能力显示图片。
+9. 保持现有 `value + onValueChange` API 兼容。
+
+## 2. 官方 Compose 对齐基准
+
+官方 TextField 现有两套 API：
+
+### 2.1 旧 API：`TextFieldValue`
+
+```kotlin
+var value by remember { mutableStateOf(TextFieldValue("hello")) }
+
+BasicTextField(
+    value = value,
+    onValueChange = { value = it }
+)
+
+val pos = value.selection.start
+value = TextFieldValue(
+    text = value.text.substring(0, pos) + "[微笑]" + value.text.substring(pos),
+    selection = TextRange(pos + "[微笑]".length)
+)
+```
+
+对齐要求：
+
+1. `value.text` 下发到原生。
+2. `value.selection` 下发到原生。
+3. 原生输入变化回传 `text + selection + composition`。
+4. 用户点击移动光标时也回传 selection。
+5. `onValueChange` 返回完整 `TextFieldValue`，不是只返回 text。
+
+### 2.2 新 API：`TextFieldState`
+
+```kotlin
+val state = rememberTextFieldState()
+
+BasicTextField(
+    state = state,
+    inputTransformation = InputTransformation.maxLength(100),
+    outputTransformation = OutputTransformation { /* display only */ }
+)
+
+state.edit {
+    insert(selection.start, "[微笑]")
+}
+```
+
+对齐要求：
+
+1. `TextFieldState` 保存真实文本、selection、composition。
+2. 所有程序化编辑统一走 `edit {}`。
+3. 用户输入先进入 `TextFieldBuffer`。
+4. `InputTransformation` 在提交 state 前执行。
+5. `OutputTransformation` 只影响展示，不污染真实文本。
+6. selection 与 output transformation 后的显示位置自动映射。
+
+## 3. 当前 KuiklyUI 差距
+
+### 3.1 Compose 层
+
+当前 `CoreTextField` 只下发 `value.text`：
+
+```kotlin
+getViewAttr().text(value.text)
+```
+
+当前 `textDidChange` 只回传 text：
+
+```kotlin
+onValueChange(TextFieldValue(it.text))
+```
+
+缺失：
+
+1. selection 下发。
+2. selection 变化回调。
+3. composition 回调。
+4. `TextFieldState`。
+5. `TextFieldBuffer`。
+6. `InputTransformation`。
+7. `OutputTransformation`。
+8. 官方 `edit {}` 入口。
+
+### 3.2 Core 层
+
+已有能力：
+
+1. `cursorIndex(callback)`。
+2. `setCursorIndex(index)`。
+3. `textDidChange { text, length }`。
+
+缺失：
+
+1. selection range，不只是 cursor index。
+2. composition range。
+3. selection change event。
+4. 统一 `setTextInputState`。
+5. 统一 `getTextInputState`。
+6. 事务式 native edit method。
+
+### 3.3 Render 层
+
+iOS `UITextView` / Android `EditText` / OHOS `TextArea` 都具备原生 selection 能力，但 Kuikly Render 当前没有统一抽象。
+
+缺失：
+
+1. `selectionStart` / `selectionEnd` prop 或 method。
+2. `onSelectionChange` event。
+3. `markedTextRange` / composition range event。
+4. 批量设置 text + selection 的原子方法。
+5. 输出转换后的 offset mapping。
+
+### 3.4 最新自定义表情 commit 基线
+
+最新 commit `4d84f915 feat: compose TextField support custom emoji` 已经落地一条“短码保留 + 平台富文本显示”的过渡链路，本方案必须复用，不应推倒重做。
+
+已落地能力：
+
+| 层级 | 文件 | 能力 |
+|---|---|---|
+| Compose DSL | `compose/src/commonMain/kotlin/com/tencent/kuikly/compose/extension/ModifierSetProp.kt` | 新增 `Modifier.textPostProcessor(processor)`，可向 Text / TextField 下发处理器名称 |
+| Kuikly DSL | `core/src/commonMain/kotlin/com/tencent/kuikly/core/views/InputView.kt` | `InputAttr.textPostProcessor(processor)`，自研 DSL `Input` 可声明处理器 |
+| Android Render | `core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRTextFieldView.kt` | `EditText` 支持 `textPostProcessor`，`afterTextChanged` 中实时刷新 `ImageSpan` |
+| Android Adapter | `androidApp/src/main/java/com/tencent/kuikly/android/demo/adapter/KRTextPostProcessorAdapter.kt` | `[smile]` / `[heart]` / `[thumbup]` / `[star]` / `[fire]` → drawable `ImageSpan` |
+| Compose Demo | `demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/TextFieldEmojiDemo.kt` | `TextField + Modifier.textPostProcessor("input")` 表情预览 |
+| Kuikly DSL Demo | `demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/EmojiTextInputDemo.kt` | `Input.attr.textPostProcessor("input")` 表情预览 |
+| Docs | `docs/DevGuide/text-post-processor-guide.md` | 文本后置处理器实践指南 |
+
+现有实现特征：
+
+1. 真实文本仍保留 shortcode，例如 `[smile]`。
+2. Android 输入框通过 `ImageSpan` 覆盖显示，不替换底层字符。
+3. `textDidChange` 回调仍返回真实文本。
+4. 表情按钮当前是 `text += shortCode`，只能追加到末尾，不能插入当前光标。
+5. 当前没有 selection 双向同步，Compose 层仍无法知道用户点击后的真实光标位置。
+6. 当前没有 `TextFieldState` / `TextFieldBuffer` / `InputTransformation` / `OutputTransformation`。
+7. 当前 Android 输入框已具备显示链路；iOS / OHOS / Web 仍需补齐同等输入框链路。
+
+对本方案的影响：
+
+1. `textPostProcessor` 不废弃为“立即删除”，改为 `OutputTransformation` 的平台渲染桥接能力。
+2. 自定义表情近期目标不是“重新发明表情协议”，而是让现有 shortcode + span/attachment 链路获得 selection 与状态驱动能力。
+3. `OutputTransformation` 第一阶段可包装现有 `textPostProcessor`：业务写 `EmojiOutputTransformation("input")`，内部继续下发 `textPostProcessor`。
+4. `TextFieldValue.selection` / `TextFieldState.edit` 落地后，表情按钮从“追加到末尾”升级为“替换当前选区或插入当前光标”。
+5. Android Render 的 `applyEmojiSpans` 可作为 `OutputTransformation` Android 平台实现的短期复用点。
+6. iOS 可复用已有 `KRTextAttachmentStringProtocol` / `p_outputText` / cursor mapping 思路，实现与 Android 等价的 shortcode 保留模型。
+
+## 4. 总体架构
+
+目标架构：
+
+```text
+业务代码
+  │
+  ├─ BasicTextField(value = TextFieldValue, onValueChange = ...)
+  │
+  └─ BasicTextField(state = TextFieldState, inputTransformation, outputTransformation)
+        │
+        ▼
+Compose Text Input Core
+  ├─ TextFieldState
+  ├─ TextFieldBuffer
+  ├─ EditProcessor
+  ├─ InputTransformation pipeline
+  ├─ OutputTransformation pipeline
+  ├─ OffsetMappingCalculator
+  └─ CoreTextField
+        │
+        ▼
+Core Text Editing View
+  ├─ TextInputState(text, selection, composition)
+  ├─ setTextInputState(state)
+  ├─ getTextInputState(callback)
+  ├─ editText(command)
+  ├─ onTextInputStateChange
+  └─ onSelectionChange
+        │
+        ▼
+Render Native Input
+  ├─ iOS: UITextView / UITextField
+  ├─ Android: EditText
+  ├─ OHOS: TextInput / TextArea
+  ├─ Web: input / textarea
+  └─ MiniApp: input / textarea
+```
+
+## 5. API 设计
+
+### 5.1 保留旧 API
+
+```kotlin
+@Composable
+fun BasicTextField(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = TextStyle.Default,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    cursorBrush: Brush = SolidColor(Color.Black),
+    decorationBox: @Composable (innerTextField: @Composable () -> Unit) -> Unit = { it() }
+)
+```
+
+兼容要求：
+
+1. `onValueChange` 返回完整 `TextFieldValue`。
+2. selection 改变必须触发 `onValueChange` 或等价内部同步。
+3. 程序设置 `value.selection` 必须更新原生光标。
+4. composition 字段优先透传；平台不支持时置空。
+
+### 5.2 新增官方推荐 API
+
+```kotlin
+@Composable
+fun BasicTextField(
+    state: TextFieldState,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = TextStyle.Default,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    lineLimits: TextFieldLineLimits = TextFieldLineLimits.Default,
+    inputTransformation: InputTransformation? = null,
+    outputTransformation: OutputTransformation? = null,
+    cursorBrush: Brush = SolidColor(Color.Black),
+    decorator: TextFieldDecorator? = null
+)
+```
+
+### 5.3 `TextFieldState`
+
+```kotlin
+@Stable
+class TextFieldState internal constructor(
+    initialText: String,
+    initialSelection: TextRange,
+) {
+    val text: CharSequence
+    var selection: TextRange
+        internal set
+    var composition: TextRange?
+        internal set
+
+    fun edit(block: TextFieldBuffer.() -> Unit)
+    fun setTextAndPlaceCursorAtEnd(text: String)
+    fun clearText()
+}
+
+@Composable
+fun rememberTextFieldState(
+    initialText: String = "",
+    initialSelection: TextRange = TextRange(initialText.length)
+): TextFieldState
+```
+
+语义：
+
+1. `text` 是真实值。
+2. `selection` 是真实文本坐标系。
+3. `composition` 是输入法组合区间。
+4. `initialText` 只在首次初始化时生效。
+5. 初始化后修改文本必须走 `edit {}` 或工具方法。
+
+### 5.4 `TextFieldBuffer`
+
+```kotlin
+class TextFieldBuffer internal constructor(
+    initialText: String,
+    initialSelection: TextRange,
+    initialComposition: TextRange?
+) : CharSequence {
+    var selection: TextRange
+    var composition: TextRange?
+
+    fun append(text: String)
+    fun insert(index: Int, text: String)
+    fun replace(start: Int, end: Int, text: String)
+    fun delete(start: Int, end: Int)
+    fun selectAll()
+    fun placeCursorAtEnd()
+    fun revertAllChanges()
+    fun asCharSequence(): CharSequence
+}
+```
+
+### 5.5 `InputTransformation`
+
+```kotlin
+fun interface InputTransformation {
+    fun TextFieldBuffer.transformInput()
+
+    fun then(next: InputTransformation): InputTransformation
+
+    companion object {
+        fun maxLength(maxLength: Int): InputTransformation
+    }
+}
+```
+
+执行时机：
+
+```text
+原生输入事件 → TextFieldBuffer → InputTransformation → TextFieldState → Render
+```
+
+约束：
+
+1. 只能修改 `TextFieldBuffer`。
+2. 不允许直接修改外部 state。
+3. 可调用 `revertAllChanges()` 拒绝本次输入。
+4. 多个 transformation 按声明顺序执行。
+
+### 5.6 `OutputTransformation`
+
+```kotlin
+fun interface OutputTransformation {
+    fun TextFieldBuffer.transformOutput()
+}
+```
+
+执行时机：
+
+```text
+TextFieldState.text → OutputTransformation → displayText / displaySpans → Render
+```
+
+约束：
+
+1. 不修改 `TextFieldState.text`。
+2. 只生成显示内容。
+3. 框架负责真实坐标与显示坐标映射。
+4. 替代一部分旧 `VisualTransformation` 场景。
+
+### 5.7 自定义表情输入 API
+
+业务用法对齐官方：
+
+```kotlin
+val state = rememberTextFieldState()
+
+BasicTextField(
+    state = state,
+    outputTransformation = EmojiOutputTransformation("emoji")
+)
+
+EmojiPanel { code ->
+    state.edit {
+        insert(selection.start, code)
+    }
+}
+```
+
+不再需要：
+
+```kotlin
+Modifier.insertTextFnRef { ... }
+```
+
+## 6. 内部数据结构
+
+### 6.1 `TextInputState`
+
+`TextInputState` 不是官方 Compose API，仅作为 Kuikly Core / Render 通信与自研 DSL 绑定用的内部/框架层 payload。官方对外对齐对象仍是 `TextFieldValue`、`TextFieldState`、`TextFieldBuffer`、`TextRange`。
+
+Core / Render 通信统一使用：
+
+```kotlin
+data class TextInputState(
+    val text: String,
+    val selectionStart: Int,
+    val selectionEnd: Int,
+    val compositionStart: Int = -1,
+    val compositionEnd: Int = -1
+)
+```
+
+JSON payload：
+
+```json
+{
+  "text": "hello",
+  "selectionStart": 5,
+  "selectionEnd": 5,
+  "compositionStart": -1,
+  "compositionEnd": -1,
+  "length": 5
+}
+```
+
+### 6.2 坐标系约定
+
+所有 Kotlin 层 API 使用真实文本坐标系：
+
+```text
+真实文本：你好[微笑]
+selection: 6
+显示文本：你好🖼
+displaySelection: 3
+```
+
+Render 层需要维护：
+
+1. raw index → display index。
+2. display index → raw index。
+3. attachment / span 删除回退到 raw text。
+4. selection 回调必须转换成 raw index。
+
+## 7. Compose 层改造
+
+### 7.1 新增文件
+
+```text
+compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/TextFieldState.kt
+compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/TextFieldBuffer.kt
+compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/InputTransformation.kt
+compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/OutputTransformation.kt
+compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/TextInputState.kt
+compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/TextEditProcessor.kt
+compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/TextFieldLineLimits.kt
+```
+
+### 7.2 修改 `CoreTextField.kt`
+
+改造点：
+
+1. `value` API 内部适配成临时 `TextFieldStateAdapter`。
+2. `state` API 直接绑定 `TextFieldState`。
+3. 下发 native state 时使用 `setTextInputState`。
+4. 接收 native event 时构造 `TextInputState`。
+5. 经过 `InputTransformation` 后提交到 `TextFieldState`。
+6. `TextFieldState` 变化后执行 `OutputTransformation`。
+7. 通过 raw/display offset mapping 恢复 selection。
+8. 只在 state 与 native 不一致时下发，避免输入回环。
+
+### 7.3 旧 API 适配策略
+
+`BasicTextField(value, onValueChange)` 内部创建 adapter：
+
+```text
+外部 TextFieldValue
+  → CoreTextFieldAdapter
+  → TextInputState
+  → Native
+```
+
+Native 回调：
+
+```text
+Native TextInputState
+  → TextFieldValue(text, selection, composition)
+  → onValueChange
+```
+
+必须处理两种变更：
+
+1. 用户输入导致 text 变。
+2. 用户点击或拖拽导致 selection 变但 text 不变。
+
+## 8. Core 层改造
+
+### 8.1 新增统一方法
+
+`AutoHeightTextAreaView` / `TextAreaView` / `InputView` 增加：
+
+```kotlin
+fun setTextInputState(state: TextInputState)
+fun getTextInputState(callback: (TextInputState) -> Unit)
+fun editText(command: TextEditCommand)
+```
+
+### 8.2 新增事件
+
+`TextAreaEvent` / `InputEvent` 增加：
+
+```kotlin
+fun textInputStateChange(
+    isSyncEdit: Boolean = true,
+    handler: (TextInputState) -> Unit
+)
+
+fun selectionChange(
+    handler: (TextRange) -> Unit
+)
+```
+
+### 8.3 兼容旧事件
+
+旧 `textDidChange { InputParams(text, length) }` 保留。
+
+内部实现：
+
+```text
+textInputStateChange → 派生 textDidChange
+```
+
+## 9. Render 层改造
+
+### 9.1 iOS
+
+目标组件：
+
+```text
+core-render-ios/Extension/Components/KRTextAreaView.m
+core-render-ios/Extension/Components/KRTextFieldView.m
+```
+
+新增 prop / method / event：
+
+```objc
+css_setTextInputState:
+css_getTextInputState:
+css_editText:
+css_textInputStateChange
+css_selectionChange
+```
+
+实现要点：
+
+1. `UITextView.selectedRange` 映射到 raw selection。
+2. `markedTextRange` 映射到 raw composition。
+3. `textViewDidChange:` 回传完整 state。
+4. `textViewDidChangeSelection:` 回传 selection。
+5. 设置 text + selection 必须原子化，避免先改 text 后光标跳动。
+6. attachment 场景使用已有 `p_outputText` / cursor mapping 能力。
+7. `OutputTransformation` 后的 attachment 不污染 raw text。
+8. `_ignoreTextDidChanged` 只屏蔽内部重入，不屏蔽最终 state 同步。
+
+### 9.2 Android
+
+目标组件：
+
+```text
+core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRTextFieldView.kt
+```
+
+实现要点：
+
+1. `selectionStart` / `selectionEnd` 回传到 Kotlin。
+2. `onSelectionChanged` 触发 `selectionChange`。
+3. `afterTextChanged` 回传完整 `TextInputState`。
+4. composition 可通过 `BaseInputConnection` / composing span 尽量获取；取不到时置 `-1`。
+5. `setTextInputState` 使用 `Editable` 原子替换文本并设置 selection。
+6. 避免 `setText` 导致 selection 强制到末尾。
+7. 现有 `textPostProcessor` span 能力迁移为 `OutputTransformation` 的平台实现之一。
+
+### 9.3 OHOS
+
+目标组件：
+
+```text
+core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextFieldView.*
+core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextAreaView.*
+```
+
+实现要点：
+
+1. 复用 ArkUI text selection 属性。
+2. 扩展 selection range，而不是只支持 start position。
+3. 文本变化事件携带 selection。
+4. composition 能力不足时先置空。
+
+### 9.4 Web / MiniApp
+
+目标组件：
+
+```text
+core-render-web/base/src/jsMain/kotlin/com/tencent/kuikly/core/render/web/expand/components/KRTextFieldView.kt
+core-render-web/base/src/jsMain/kotlin/com/tencent/kuikly/core/render/web/expand/components/KRTextAreaView.kt
+```
+
+实现要点：
+
+1. `HTMLInputElement.selectionStart/selectionEnd`。
+2. `compositionstart/compositionupdate/compositionend`。
+3. `input` 事件回传 text + selection + composition。
+4. 程序化设置 value 后恢复 selection。
+
+## 10. OutputTransformation 与自定义表情
+
+### 10.1 官方语义
+
+`OutputTransformation` 只影响显示，不改变真实文本。
+
+```text
+state.text = "你好[微笑]"
+display = "你好🖼"
+```
+
+### 10.2 Kuikly 实现策略
+
+短期：
+
+1. Compose 层定义 `OutputTransformation`。
+2. 对纯文本格式化场景在 Kotlin 层生成 display text。
+3. 对图片 attachment / span 场景，复用最新 commit 已落地的 `textPostProcessor` 链路。
+4. `EmojiOutputTransformation("input")` 第一阶段只作为声明式包装，内部继续下发 `textPostProcessor = "input"`。
+5. Android 继续复用 `KRTextFieldView.applyEmojiSpans`：短码字符保留在 `Editable` 中，显示层叠加 `ImageSpan`。
+6. iOS 使用 `NSTextAttachment + KRTextAttachmentStringProtocol` 达成同等语义：显示图片，回调还原 shortcode。
+7. Render 回调必须返回 raw text，不允许把图片占位符污染到 Kotlin state。
+8. selection 回调必须把 display index 映射回 raw shortcode index。
+
+中期：
+
+1. `OutputTransformation` 统一 raw/display mapping。
+2. `textPostProcessor` 成为 `OutputTransformation` 的平台显示后端之一。
+3. `TextFieldValue.selection` 与 `TextFieldState.selection` 使用 raw text 坐标。
+4. 删除 Android `ImageSpan` 或 iOS `NSTextAttachment` 时，必须删除完整 shortcode 区间。
+
+长期：
+
+1. 定义跨端 `InlineContent` / `Placeholder` 数据结构。
+2. `OutputTransformation` 输出 display buffer + inline content spans。
+3. 各端 render 统一消费 inline spans。
+4. 业务侧不再直接依赖平台私有 `textPostProcessor`，但保留兼容入口。
+
+### 10.3 表情插入方式
+
+业务代码：
+
+```kotlin
+state.edit {
+    insert(selection.start, "[微笑]")
+}
+```
+
+框架流程：
+
+```text
+edit insert raw shortcode
+  → state.text 更新
+  → outputTransformation 生成 attachment display
+  → render 显示图片
+  → selection raw index 映射到图片后 display index
+```
+
+## 11. 输入流程
+
+用户输入：
+
+```text
+Native input
+  → native raw TextInputState
+  → Core textInputStateChange
+  → Compose TextEditProcessor
+  → TextFieldBuffer
+  → InputTransformation
+  → TextFieldState commit
+  → OutputTransformation
+  → Native set display state
+```
+
+程序编辑：
+
+```text
+state.edit { insert(...) }
+  → TextFieldBuffer
+  → TextFieldState commit
+  → OutputTransformation
+  → Core setTextInputState
+  → Native set text + selection
+```
+
+selection 变化：
+
+```text
+User tap / drag selection handle
+  → Native selectionChange
+  → raw selection mapping
+  → TextFieldState.selection update
+  → value API onValueChange(TextFieldValue(...))
+```
+
+composition 变化：
+
+```text
+IME composing
+  → Native composition range
+  → TextFieldState.composition update
+  → 不执行 OutputTransformation 破坏 composing 区间
+  → composition end 后再完整格式化
+```
+
+## 12. 兼容与迁移
+
+### 12.1 保持兼容
+
+保留：
+
+1. `BasicTextField(value: String, onValueChange: (String) -> Unit)`。
+2. `BasicTextField(value: TextFieldValue, onValueChange: (TextFieldValue) -> Unit)`。
+3. `Modifier.textPostProcessor(processor)`。
+4. `cursorIndex` / `setCursorIndex`。
+5. `textDidChange`。
+
+### 12.2 推荐迁移
+
+旧写法：
+
+```kotlin
+var value by remember { mutableStateOf(TextFieldValue("")) }
+BasicTextField(value = value, onValueChange = { value = it })
+```
+
+新写法：
+
+```kotlin
+val state = rememberTextFieldState()
+BasicTextField(state = state)
+```
+
+表情旧写法：
+
+```kotlin
+insertTextFn?.invoke("[微笑]")
+```
+
+表情新写法：
+
+```kotlin
+state.edit {
+    insert(selection.start, "[微笑]")
+}
+```
+
+### 12.3 预期使用案例
+
+以下代码分为两类：
+
+1. “已落地写法”：最新自定义表情 commit 当前已经支持。
+2. “目标写法”：改造完成后的官方对齐 API。
+
+#### 12.3.0 已落地写法：`textPostProcessor` 追加式表情输入
+
+Compose DSL 当前写法：
+
+```kotlin
+@Composable
+private fun CurrentComposeEmojiDemo() {
+    var text by remember { mutableStateOf("") }
+
+    Column {
+        TextField(
+            value = text,
+            onValueChange = { text = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .textPostProcessor("input"),
+            placeholder = { Text("输入内容或点击表情按钮") },
+        )
+
+        Row {
+            listOf("[smile]", "[heart]", "[thumbup]").forEach { code ->
+                Button(onClick = { text += code }) {
+                    Text(code)
+                }
+            }
+        }
+
+        Text(
+            text = text,
+            modifier = Modifier.textPostProcessor("input"),
+        )
+    }
+}
+```
+
+Kuikly DSL 当前写法：
+
+```kotlin
+Input {
+    attr {
+        text(ctx.inputText)
+        placeholder("输入文字或点击下方表情按钮")
+        textPostProcessor("input")
+    }
+    event {
+        textDidChange { params ->
+            ctx.inputText = params.text
+        }
+    }
+}
+```
+
+当前限制：
+
+1. 表情按钮只能 `text += code` 追加到末尾。
+2. Compose 层拿不到用户点击后的光标位置。
+3. 不能替换选区。
+4. Android 已支持输入框实时 `ImageSpan`；iOS / OHOS / Web 输入框链路仍需补齐。
+5. 这是后续 `OutputTransformation` 与 selection 双向同步的基线，不应回退。
+
+#### 12.3.1 Compose DSL：官方新 API，表情输入
+
+```kotlin
+@Page("ComposeEmojiInputDemo")
+class ComposeEmojiInputDemo : ComposeContainer() {
+    override fun willInit() {
+        super.willInit()
+        setContent { Content() }
+    }
+
+    @Composable
+    private fun Content() {
+        val state = rememberTextFieldState()
+
+        Column(modifier = Modifier.padding(16.dp)) {
+            BasicTextField(
+                state = state,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(120.dp)
+                    .border(1.dp, Color.Gray)
+                    .padding(8.dp),
+                inputTransformation = InputTransformation.maxLength(500),
+                outputTransformation = EmojiOutputTransformation("emoji"),
+                textStyle = TextStyle(fontSize = 16.sp),
+            )
+
+            Row(modifier = Modifier.padding(top = 12.dp)) {
+                listOf("[微笑]", "[爱心]", "[点赞]").forEach { code ->
+                    Button(onClick = {
+                        state.edit {
+                            replace(selection.start, selection.end, code)
+                        }
+                    }) {
+                        Text(code)
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+预期行为：
+
+1. `state.text` 保存真实文本，例如 `你好[微笑]`。
+2. `OutputTransformation` 只影响显示，例如展示为 `你好🖼`。
+3. `state.edit { replace(selection.start, selection.end, code) }` 在当前光标或选区插入表情占位符。
+4. 用户点击移动光标后，`state.selection` 自动更新。
+5. 删除图片时，真实文本删除完整 shortcode。
+
+#### 12.3.2 Compose DSL：官方旧 API，`TextFieldValue` 双向 selection
+
+```kotlin
+@Composable
+private fun TextFieldValueDemo() {
+    var value by remember {
+        mutableStateOf(TextFieldValue("hello", selection = TextRange(5)))
+    }
+
+    Column {
+        BasicTextField(
+            value = value,
+            onValueChange = { value = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+                .border(1.dp, Color.Gray)
+                .padding(8.dp),
+        )
+
+        Button(onClick = {
+            val start = value.selection.start
+            val end = value.selection.end
+            val insertText = "[微笑]"
+            val newText = value.text.replaceRange(start, end, insertText)
+            val newCursor = start + insertText.length
+            value = TextFieldValue(
+                text = newText,
+                selection = TextRange(newCursor),
+            )
+        }) {
+            Text("插入表情")
+        }
+    }
+}
+```
+
+预期行为：
+
+1. `value.selection` 下发到原生光标。
+2. 用户点击移动光标后，`onValueChange` 返回新的 `TextFieldValue.selection`。
+3. 业务可用官方旧 API 的方式在光标处拼接文本。
+
+#### 12.3.3 Compose DSL：输入过滤 + 展示格式化
+
+```kotlin
+@Composable
+private fun PhoneInputDemo() {
+    val state = rememberTextFieldState()
+
+    BasicTextField(
+        state = state,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+        inputTransformation = InputTransformation.maxLength(11).then {
+            if (!asCharSequence().all { it.isDigit() }) {
+                revertAllChanges()
+            }
+        },
+        outputTransformation = OutputTransformation {
+            if (length > 3) insert(3, " ")
+            if (length > 8) insert(8, " ")
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .border(1.dp, Color.Gray)
+            .padding(8.dp),
+    )
+}
+```
+
+预期行为：
+
+1. `state.text` 只保存数字，例如 `13800138000`。
+2. UI 显示格式化结果，例如 `138 0013 8000`。
+3. 过滤逻辑不写在 `onValueChange`，避免异步状态回写导致跳变。
+
+#### 12.3.4 Kuikly DSL：状态驱动 TextArea，表情输入
+
+自研 Kuikly DSL 不直接暴露官方 Compose `TextFieldState`，但应提供同语义的 `TextInputState` 绑定能力。
+
+```kotlin
+@Page("KuiklyDslEmojiInputDemo")
+internal class KuiklyDslEmojiInputDemo : BasePager() {
+    private var inputState by observable(TextInputState(text = ""))
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            attr {
+                flexDirectionColumn()
+                padding(16f)
+                backgroundColor(Color.WHITE)
+            }
+
+            TextArea {
+                attr {
+                    height(120f)
+                    border(1f, BorderStyle.SOLID, Color.GRAY)
+                    borderRadius(8f)
+                    padding(8f)
+                    textInputState(ctx.inputState)
+                    textPostProcessor("emoji")
+                }
+                event {
+                    textInputStateChange(true) { state ->
+                        ctx.inputState = state
+                    }
+                }
+            }
+
+            View {
+                attr {
+                    flexDirectionRow()
+                    marginTop(12f)
+                }
+
+                listOf("[微笑]", "[爱心]", "[点赞]").forEach { code ->
+                    Text {
+                        attr {
+                            text(code)
+                            marginRight(12f)
+                            padding(8f)
+                            border(1f, BorderStyle.SOLID, Color.GRAY)
+                            borderRadius(6f)
+                        }
+                        event {
+                            click {
+                                ctx.inputState = ctx.inputState.edit {
+                                    replace(selection.start, selection.end, code)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+预期行为：
+
+1. Kuikly DSL 业务状态保存 `TextInputState`。
+2. `TextArea.attr.textInputState(state)` 原子下发 text + selection + composition。
+3. `textInputStateChange` 回传完整 text + selection + composition。
+4. 表情按钮不调用原生 `insertText`，而是修改 state 后由框架同步到原生。
+5. 自研 DSL 与 Compose DSL 使用同一套 Core / Render 能力。
+
+#### 12.3.5 Kuikly DSL：兼容旧 `textDidChange` 写法
+
+```kotlin
+@Page("KuiklyDslLegacyInputDemo")
+internal class KuiklyDslLegacyInputDemo : BasePager() {
+    private var text by observable("")
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            TextArea {
+                attr {
+                    height(80f)
+                    text(ctx.text)
+                }
+                event {
+                    textDidChange {
+                        ctx.text = it.text
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+兼容策略：
+
+1. 旧 API 继续可用。
+2. 旧 `textDidChange` 只关心 text，不暴露 selection。
+3. 新需求优先使用 `TextInputState` / `textInputStateChange`。
+
+#### 12.3.6 Kuikly DSL：程序设置光标与选区
+
+```kotlin
+private fun moveCursorToEnd() {
+    inputState = inputState.copy(
+        selectionStart = inputState.text.length,
+        selectionEnd = inputState.text.length,
+        compositionStart = -1,
+        compositionEnd = -1,
+    )
+}
+
+private fun selectAll() {
+    inputState = inputState.copy(
+        selectionStart = 0,
+        selectionEnd = inputState.text.length,
+        compositionStart = -1,
+        compositionEnd = -1,
+    )
+}
+```
+
+预期行为：
+
+1. 修改 `inputState.selectionStart/selectionEnd` 后，原生 selection 同步变化。
+2. `selectionStart == selectionEnd` 表示光标。
+3. `selectionStart != selectionEnd` 表示选区。
+4. selection 坐标始终使用真实文本坐标，不使用富文本显示坐标。
+
+## 13. 分阶段实施计划
+
+### Phase 0：基于现有表情 commit 建立行为基线
+
+交付：
+
+1. 记录当前 `CoreTextField` 行为。
+2. 以 `TextFieldEmojiDemo` 和 `EmojiTextInputDemo` 作为现有自定义表情基线 demo。
+3. 补充 selection 观测 demo：点击文本中间、拖选、删除、粘贴、拼音输入。
+4. 固化 Android 当前 `textPostProcessor + ImageSpan` 行为：raw text 保留 shortcode，显示层渲染图片。
+5. 定义跨端 `TextInputState` payload。
+
+验收：
+
+1. 现有 `textPostProcessor("input")` 表情显示不回归。
+2. `textDidChange` 继续返回 raw shortcode 文本。
+3. 当前“表情按钮追加到末尾”的限制被记录为待解决问题。
+4. 点击移动光标、删除、粘贴、拼音输入均有基线记录。
+
+### Phase 1：旧 API 完整支持 `TextFieldValue`
+
+交付：
+
+1. `textDidChange` 回传 selection。
+2. `selectionChange` event。
+3. `CoreTextField` 下发 `value.selection`。
+4. `onValueChange(TextFieldValue(text, selection, composition))`。
+
+验收：
+
+1. 业务修改 `TextFieldValue.selection` 可移动光标。
+2. 用户点击移动光标后 Kotlin 可感知。
+3. 在光标处拼接字符串方案可正常插入。
+
+### Phase 2：Core `TextInputState`
+
+交付：
+
+1. 新增 `TextInputState`。
+2. 新增 `setTextInputState`。
+3. 新增 `getTextInputState`。
+4. 新增 `textInputStateChange`。
+5. 旧 `textDidChange` 由新事件派生。
+
+验收：
+
+1. text + selection 原子同步。
+2. 不出现 set text 后光标跳末尾。
+3. 旧 API 不破坏。
+
+### Phase 3：`TextFieldState` / `TextFieldBuffer`
+
+交付：
+
+1. `rememberTextFieldState`。
+2. `TextFieldState.edit {}`。
+3. `TextFieldBuffer` 基础编辑操作。
+4. `BasicTextField(state = ...)`。
+
+验收：
+
+1. `state.edit { insert(...) }` 在当前光标插入。
+2. `setTextAndPlaceCursorAtEnd` 正常。
+3. `clearText` 正常。
+4. state API 与 value API 行为一致。
+
+### Phase 4：`InputTransformation`
+
+交付：
+
+1. `InputTransformation` 接口。
+2. `then` 链式组合。
+3. `maxLength`。
+4. `revertAllChanges`。
+5. 数字过滤 demo。
+
+验收：
+
+1. 限长不依赖 render 层 maxLength。
+2. 拼音输入期间不误删 composing text。
+3. 粘贴大段文本可正确过滤。
+
+### Phase 5：`OutputTransformation` 与现有 `textPostProcessor` 桥接
+
+交付：
+
+1. `OutputTransformation` 接口。
+2. display buffer。
+3. raw/display offset mapping。
+4. 电话号码格式化 demo。
+5. `EmojiOutputTransformation(processor)`，内部复用 `textPostProcessor`。
+6. Android 复用现有 `applyEmojiSpans`，iOS 补齐 `NSTextAttachment` 输入框显示链路。
+7. 将 `TextFieldEmojiDemo` 从 `Modifier.textPostProcessor("input")` 迁移为推荐写法，同时保留旧写法兼容示例。
+
+验收：
+
+1. state 保存 raw text，例如 `[smile]`。
+2. UI 显示图片或 formatted text。
+3. 光标位置映射正确。
+4. 删除 display token 后 raw text 删除完整 shortcode。
+5. 最新 commit 中的 Android 表情显示能力不回归。
+
+### Phase 6：跨端补齐
+
+优先级：
+
+1. iOS TextArea。
+2. Android EditText。
+3. iOS TextField。
+4. OHOS TextArea / TextField。
+5. Web / MiniApp。
+
+验收：
+
+1. 同一 demo 五端行为一致。
+2. selection / composition payload 一致。
+3. 表情输入至少 iOS / Android 可用。
+
+### Phase 7：文档与废弃策略
+
+交付：
+
+1. Compose TextField 官方对齐文档。
+2. 迁移指南。
+3. 表情输入最佳实践。
+4. 标记不推荐 `insertTextFnRef`。
+5. 标记 `textPostProcessor` 为过渡 API，推荐 `OutputTransformation`。
+
+## 14. 测试矩阵
+
+### 14.1 基础输入
+
+| Case | 预期 |
+|---|---|
+| 输入英文 | text 与 selection 同步 |
+| 输入中文拼音 | composition 不被破坏 |
+| 输入 emoji unicode | 不切割 surrogate pair |
+| 删除单字符 | selection 正确回退 |
+| 选区替换 | start/end 范围被替换 |
+| 粘贴文本 | transformation 生效 |
+
+### 14.2 selection
+
+| Case | 预期 |
+|---|---|
+| 点击文本中间 | Kotlin selection 更新 |
+| 拖拽选区 | start/end 更新 |
+| 程序设置 selection | 原生光标移动 |
+| state.edit 后 selection | 按编辑操作更新 |
+| output format 后 selection | raw/display 映射正确 |
+
+### 14.3 transformation
+
+| Case | 预期 |
+|---|---|
+| maxLength | 超长输入拒绝或截断 |
+| digit only | 非数字输入 revert |
+| phone output | raw text 无格式符 |
+| emoji output | raw text 保留 `[微笑]` |
+| 删除 emoji 图片 | raw text 删除完整 shortcode |
+
+### 14.4 平台
+
+| 平台 | 必测 |
+|---|---|
+| iOS TextArea | selection、composition、attachment |
+| iOS TextField | selection、单行插入 |
+| Android EditText | Spannable、selection、IME |
+| OHOS | selection range |
+| Web | composition event、selectionStart/End |
+| MiniApp | input/textarea 能力降级 |
+
+## 15. 风险与处理
+
+### 15.1 composition 跨端能力不一致
+
+处理：
+
+1. iOS / Web 优先支持 composition range。
+2. Android 尽量通过 composing span 获取。
+3. OHOS / MiniApp 不支持时回传 `composition = null`。
+4. transformation 在 composition 期间默认延迟执行破坏性格式化。
+
+### 15.2 OutputTransformation offset mapping 复杂
+
+处理：
+
+1. Phase 5 先支持 insert-only output transformation。
+2. 再支持 replace/delete。
+3. 每次 buffer edit 记录 change list。
+4. 根据 change list 自动生成 raw/display mapping。
+
+### 15.3 原生 setText 导致循环回调
+
+处理：
+
+1. Native 设置期间使用 `_ignoreTextDidChanged` / `ignoreTextWatcher`。
+2. 设置完成后主动发一次最终 state，或由 Compose state 驱动确认。
+3. Compose 层比较 `lastNativeState` 与 `targetState`，避免重复下发。
+
+### 15.4 旧 API 行为变化
+
+处理：
+
+1. 旧 `String` API 保持只关心 text。
+2. 旧 `TextFieldValue` API 增强 selection，不破坏 text。
+3. 新 state API 独立推出。
+4. Demo 和文档引导新 API。
+
+## 16. 不建议的方案
+
+### 16.1 不建议继续推进 `insertTextFnRef`
+
+原因：
+
+1. 与官方 `TextFieldState.edit { insert(...) }` 不一致。
+2. 只能解决插入文本，不能解决 selection 双向同步。
+3. 后续还要追加 delete / replace / cursor / selection 等命令。
+4. 容易形成平台命令式 API，而不是 Compose 状态驱动模型。
+
+### 16.2 不建议只在 iOS Render 做表情替换
+
+原因：
+
+1. 不能解决 Compose 层 selection 缺失。
+2. 不能跨端一致。
+3. 不能覆盖官方 `OutputTransformation` 场景。
+4. 业务仍需平台定制代码。
+
+### 16.3 不建议只扩展 `TextFieldValue.selection`
+
+原因：
+
+1. 只能对齐旧 API。
+2. 无法支持官方推荐的 `InputTransformation` / `OutputTransformation`。
+3. 复杂输入仍会堆在 `onValueChange`。
+
+## 17. 推荐优先级
+
+最小闭环：
+
+```text
+Phase 1 TextFieldValue selection 双向同步
+  → Phase 2 TextInputState
+  → Phase 3 TextFieldState.edit
+```
+
+表情输入闭环：
+
+```text
+TextFieldState.edit insert shortcode
+  → OutputTransformation / textPostProcessor display
+  → raw/display selection mapping
+```
+
+最终官方对齐闭环：
+
+```text
+TextFieldState
+  + TextFieldBuffer
+  + InputTransformation
+  + OutputTransformation
+  + selection/composition 双向同步
+  + BasicTextField / Material TextField 分层
+```
+
+## 18. 验收标准
+
+1. `BasicTextField(value = TextFieldValue(...))` 与官方旧 API 行为一致。
+2. `BasicTextField(state = rememberTextFieldState())` 与官方新 API 核心行为一致。
+3. `state.edit { insert(selection.start, text) }` 可在当前光标插入。
+4. 用户点击、拖选、输入、删除、粘贴都能同步 `selection`。
+5. 拼音输入期间 `composition` 不被错误提交或格式化破坏。
+6. `InputTransformation.maxLength()` 可跨端一致限长。
+7. `OutputTransformation` 不污染 `state.text`。
+8. 自定义表情输入不需要 `insertTextFnRef`。
+9. iOS / Android 至少完成全链路验证。
+10. 旧 API demo 不回归。

--- a/androidApp/src/main/java/com/tencent/kuikly/android/demo/KuiklyRenderActivity.kt
+++ b/androidApp/src/main/java/com/tencent/kuikly/android/demo/KuiklyRenderActivity.kt
@@ -168,7 +168,7 @@ class KuiklyRenderActivity : AppCompatActivity() {
             KuiklyRenderAdapterManager.krVideoViewAdapter = VideoViewAdapter()
         }
         if (KuiklyRenderAdapterManager.krTextPostProcessorAdapter == null) {
-            KuiklyRenderAdapterManager.krTextPostProcessorAdapter = KRTextPostProcessorAdapter()
+            KuiklyRenderAdapterManager.krTextPostProcessorAdapter = KRTextPostProcessorAdapter(this)
         }
     }
 

--- a/androidApp/src/main/java/com/tencent/kuikly/android/demo/adapter/KRTextPostProcessorAdapter.kt
+++ b/androidApp/src/main/java/com/tencent/kuikly/android/demo/adapter/KRTextPostProcessorAdapter.kt
@@ -15,19 +15,95 @@
 
 package com.tencent.kuikly.android.demo.adapter
 
-import android.util.Log
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.DynamicDrawableSpan
+import android.text.style.ImageSpan
+import androidx.core.content.ContextCompat
 import com.tencent.kuikly.core.render.android.adapter.IKRTextPostProcessorAdapter
 import com.tencent.kuikly.core.render.android.adapter.TextPostProcessorInput
 import com.tencent.kuikly.core.render.android.adapter.TextPostProcessorOutput
 import com.tencent.kuikly.core.render.android.css.ktx.toPxF
 
 /**
- * Created by kam on 2023/10/25.
+ * 自定义表情后置处理器
+ * 将文本中的 emoji 短码（如 [smile]）替换为对应的图片 span
+ *
+ * 实现方式：在短码字符位置上设置 ImageSpan，保留原始字符
+ * 返回 SpannableStringBuilder（实现了 Editable 接口），这样 EditText 可以正确显示
  */
-class KRTextPostProcessorAdapter : IKRTextPostProcessorAdapter {
-    override fun onTextPostProcess(inputParams: TextPostProcessorInput): TextPostProcessorOutput {
+class KRTextPostProcessorAdapter(context: Context) : IKRTextPostProcessorAdapter {
+
+    private val appContext: Context = context.applicationContext
+
+    companion object {
+        // 短码 -> drawable 资源映射
+        private val EMOJI_MAP = mapOf(
+            "[smile]" to com.tencent.kuikly.android.demo.R.drawable.emoji_smile,
+            "[heart]" to com.tencent.kuikly.android.demo.R.drawable.emoji_heart,
+            "[thumbup]" to com.tencent.kuikly.android.demo.R.drawable.emoji_thumbup,
+            "[star]" to com.tencent.kuikly.android.demo.R.drawable.emoji_star,
+            "[fire]" to com.tencent.kuikly.android.demo.R.drawable.emoji_fire,
+        )
+
+        // 匹配 [xxx] 格式的短码（含中文）
+        private val EMOJI_PATTERN = "\\[([^\\]]+)\\]".toRegex()
+    }
+
+    override fun onTextPostProcess(
+        kuiklyRenderContext: com.tencent.kuikly.core.render.android.IKuiklyRenderContext?,
+        inputParams: TextPostProcessorInput
+    ): TextPostProcessorOutput {
+        return when (inputParams.processor) {
+            "emoji", "input" -> processEmoji(inputParams)
+            else -> TextPostProcessorOutput(inputParams.sourceText)
+        }
+    }
+
+    /**
+     * Emoji processor: replace shortcode like [smile] with ImageSpan
+     */
+    private fun processEmoji(inputParams: TextPostProcessorInput): TextPostProcessorOutput {
+        val sourceText = inputParams.sourceText?.toString() ?: return TextPostProcessorOutput("")
+
+        // 查找所有短码匹配
+        val matches = EMOJI_PATTERN.findAll(sourceText).toList()
+        if (matches.isEmpty()) {
+            return TextPostProcessorOutput(SpannableStringBuilder(sourceText))
+        }
+
+        // 计算 emoji 大小（基于字体大小）
         val fontSize = inputParams.textProps.fontSize.toPxF()
-        Log.d("CR7", "fontSize: $fontSize")
-        return TextPostProcessorOutput(inputParams.sourceText)
+        val emojiSize = fontSize.toInt().coerceAtLeast(48)
+
+        // 使用 SpannableStringBuilder 以保留原始字符（短码）并附加 ImageSpan
+        val spannable = SpannableStringBuilder(sourceText)
+
+        for (match in matches) {
+            val shortcode = match.value
+            val drawableRes = EMOJI_MAP[shortcode]
+            if (drawableRes != null) {
+                val drawable: Drawable? = ContextCompat.getDrawable(appContext, drawableRes)
+                drawable?.setBounds(0, 0, emojiSize, emojiSize)
+                if (drawable != null) {
+                    spannable.setSpan(
+                        ImageSpan(drawable, DynamicDrawableSpan.ALIGN_CENTER),
+                        match.range.first,
+                        match.range.last + 1,
+                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                }
+            }
+        }
+
+        return TextPostProcessorOutput(spannable)
+    }
+
+    // 保留旧方法以兼容接口
+    @Deprecated("Use onTextPostProcess(kuiklyRenderContext, inputParams) instead")
+    override fun onTextPostProcess(inputParams: TextPostProcessorInput): TextPostProcessorOutput {
+        return onTextPostProcess(null, inputParams)
     }
 }

--- a/androidApp/src/main/res/drawable/emoji_fire.xml
+++ b/androidApp/src/main/res/drawable/emoji_fire.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#FF6B35" android:pathData="M12,2c0,0 4,4 4,9c0,2.21 -1.79,4 -4,4s-4,-1.79 -4,-4C8,6 12,2 12,2z"/>
+    <path android:fillColor="#FF4500" android:pathData="M12,8c0,0 2.5,2 2.5,5c0,1.38 -1.12,2.5 -2.5,2.5s-2.5,-1.12 -2.5,-2.5C9.5,10 12,8 12,8z"/>
+    <path android:fillColor="#FFD700" android:pathData="M10,16c0,0 1,2 2,2s2,-2 2,-2H10z"/>
+</vector>

--- a/androidApp/src/main/res/drawable/emoji_heart.xml
+++ b/androidApp/src/main/res/drawable/emoji_heart.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#FF4444"
+          android:pathData="M12,21c-1.15,-1.15 -8.53,-5.83 -8.53,-11.06C3.47,7.14 6.53,4 10,4c1.75,0 3.07,0.68 4,1.77C14.93,4.68 16.25,4 18,4c3.47,0 6.53,3.14 6.53,5.94C20.53,15.17 13.15,19.85 12,21z"/>
+</vector>

--- a/androidApp/src/main/res/drawable/emoji_smile.xml
+++ b/androidApp/src/main/res/drawable/emoji_smile.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- circle face -->
+    <path android:fillColor="#FFD700" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2z"/>
+    <!-- left eye -->
+    <path android:fillColor="#333333" android:pathData="M9,9m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    <!-- right eye -->
+    <path android:fillColor="#333333" android:pathData="M15,9m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    <!-- smile -->
+    <path android:strokeColor="#333333" android:strokeWidth="1.5" android:fillColor="#00000000"
+          android:pathData="M8,14c0,0 2,3 4,3s4,-3 4,-3"/>
+</vector>

--- a/androidApp/src/main/res/drawable/emoji_star.xml
+++ b/androidApp/src/main/res/drawable/emoji_star.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#FFD700"
+          android:pathData="M12,2l3.09,6.26L22,9.27l-5,4.87L18.18,22L12,18.27L5.82,22L7,14.14l-5,-4.87l6.91,-1.01L12,2z"/>
+</vector>

--- a/androidApp/src/main/res/drawable/emoji_thumbup.xml
+++ b/androidApp/src/main/res/drawable/emoji_thumbup.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- thumb -->
+    <path android:fillColor="#FFD700" android:pathData="M4,7c0,-1.1 0.9,-2 2,-2h1v10H6c-1.1,0 -2,-0.9 -2,-2V7z"/>
+    <!-- hand -->
+    <path android:fillColor="#FFD700" android:pathData="M20,7c0,-1.1 -0.9,-2 -2,-2h-5.5c-0.83,0 -1.5,0.67 -1.5,1.5v4c0,0.83 0.67,1.5 1.5,1.5H14l-1.5,1.5V14c0,1.1 0.9,2 2,2h3.5c0.83,0 1.5,-0.67 1.5,-1.5V9C20,7.9 19.1,7 18,7z"/>
+</vector>

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/extension/ModifierSetProp.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/extension/ModifierSetProp.kt
@@ -104,3 +104,10 @@ fun Modifier.lineBreakMargin(dp: Dp): Modifier = setProp("lineBreakMargin", dp.v
  * 业务侧请使用 [com.tencent.kuikly.compose.ui.input.pointer.pointerHoverIcon]。
  */
 internal fun Modifier.cursor(type: String): Modifier = setProp("cursor", type)
+
+/**
+ * Set text post-processor name for text/input components.
+ * Works with KRTextPostProcessorAdapter to enable features like emoji shortcode replacement.
+ * @param processor processor name, e.g. "input"
+ */
+fun Modifier.textPostProcessor(processor: String): Modifier = setProp("textPostProcessor", processor)

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/BasicTextField.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/BasicTextField.kt
@@ -23,7 +23,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.tencent.kuikly.compose.extension.scaleToDensity
+import com.tencent.kuikly.compose.extension.textPostProcessor
 import com.tencent.kuikly.compose.foundation.interaction.MutableInteractionSource
+import com.tencent.kuikly.compose.foundation.text.input.InputTransformation
+import com.tencent.kuikly.compose.foundation.text.input.OutputTransformation
+import com.tencent.kuikly.compose.foundation.text.input.TextFieldBuffer
+import com.tencent.kuikly.compose.foundation.text.input.TextFieldState
+import com.tencent.kuikly.compose.foundation.text.input.TextPostProcessorOutputTransformation
 import com.tencent.kuikly.compose.ui.Modifier
 import com.tencent.kuikly.compose.ui.graphics.Brush
 import com.tencent.kuikly.compose.ui.graphics.Color
@@ -73,6 +79,61 @@ internal fun TextAreaAttr.setTextStyle(style: TextStyle, density: Density) {
     if (style.lineHeight.isSpecified) {
         lineHeight(this.scaleToDensity(density, style.lineHeight.value))
     }
+}
+
+@Composable
+fun BasicTextField(
+    state: TextFieldState,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = TextStyle.Default,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    inputTransformation: InputTransformation? = null,
+    outputTransformation: OutputTransformation? = null,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    interactionSource: MutableInteractionSource? = null,
+    cursorBrush: Brush = SolidColor(Color.Black),
+    decorationBox: @Composable (innerTextField: @Composable () -> Unit) -> Unit =
+        @Composable { innerTextField -> innerTextField() }
+) {
+    val transformedModifier = when (outputTransformation) {
+        is TextPostProcessorOutputTransformation -> modifier.textPostProcessor(outputTransformation.processor)
+        else -> modifier
+    }
+    CoreTextField(
+        value = TextFieldValue(
+            text = state.text,
+            selection = state.selection,
+            composition = state.composition
+        ),
+        onValueChange = { newValue ->
+            val buffer = TextFieldBuffer(newValue.text, newValue.selection, newValue.composition)
+            inputTransformation?.let {
+                with(it) { buffer.transformInput() }
+            }
+            if (!buffer.hasReverted) {
+                state.updateFromTextField(buffer.toString(), buffer.selection, buffer.composition)
+            }
+        },
+        modifier = transformedModifier,
+        textStyle = textStyle,
+        onTextLayout = onTextLayout,
+        interactionSource = interactionSource,
+        cursorBrush = cursorBrush,
+        singleLine = singleLine,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        softWrap = !singleLine,
+        maxLines = if (singleLine) 1 else maxLines,
+        decorationBox = decorationBox,
+        enabled = enabled,
+        readOnly = readOnly,
+    )
 }
 
 /**

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/CoreTextField.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/CoreTextField.kt
@@ -58,6 +58,7 @@ import com.tencent.kuikly.compose.ui.text.AnnotatedString
 import com.tencent.kuikly.compose.ui.text.MultiParagraph
 import com.tencent.kuikly.compose.ui.text.TextLayoutInput
 import com.tencent.kuikly.compose.ui.text.TextLayoutResult
+import com.tencent.kuikly.compose.ui.text.TextRange
 import com.tencent.kuikly.compose.ui.text.TextStyle
 import com.tencent.kuikly.compose.ui.text.input.ImeAction
 import com.tencent.kuikly.compose.ui.text.input.ImeOptions
@@ -73,6 +74,7 @@ import com.tencent.kuikly.compose.ui.unit.dp
 import com.tencent.kuikly.compose.ui.unit.isSpecified
 import com.tencent.kuikly.compose.ui.util.fastRoundToInt
 import com.tencent.kuikly.core.views.AutoHeightTextAreaView
+import com.tencent.kuikly.core.views.TextInputState
 import com.tencent.kuikly.core.views.LengthLimitType
 import com.tencent.kuikly.core.views.TextAreaAttr
 import com.tencent.kuikly.core.views.TextAreaEvent
@@ -193,6 +195,11 @@ internal fun CoreTextField(
     // 共享的文本长度和是否超限状态，供 textDidChange 和 textLengthBeyondLimit 回调共享
     var currentTextLength by remember { mutableStateOf(-1) }
     var currentLimitExceeded by remember { mutableStateOf(false) }
+    var receivedTextInputStateEvent by remember { mutableStateOf(false) }
+    // 记录上一次同步到原生层的文本，用于判断是否需要重新同步
+    var lastSyncedText by remember { mutableStateOf("") }
+    // 标记是否正在处理原生事件，避免 set(value) 反向同步导致选择状态被重置
+    var isProcessingNativeEvent by remember { mutableStateOf(false) }
 
     val measurePolicy = remember(value) { object : MeasurePolicy {
         private val placementBlock: Placeable.PlacementScope.() -> Unit = {}
@@ -369,10 +376,36 @@ internal fun CoreTextField(
                             }
                         }
                     }
+
                     set(value) {
                         if (it == null) return@set
                         withTextAreaView {
-                            getViewAttr().text(value.text)
+                            val newText = value.text
+                            val oldText = lastSyncedText
+                            getViewAttr().updatePropCache(TextConst.VALUE, newText)
+                            val composition = value.composition
+
+                            // 判断是否需要同步到原生层
+                            // 只有当文本发生变化，或者不是来自原生事件时，才同步
+                            // 这样可以避免用户拖动选择游标时，Kotlin层用旧selection覆盖原生层的当前selection
+                            val textChanged = newText != oldText
+                            val shouldSyncToNative = textChanged || !isProcessingNativeEvent
+
+                            if (shouldSyncToNative) {
+                                setTextInputState(
+                                    TextInputState(
+                                        text = newText,
+                                        selectionStart = value.selection.start,
+                                        selectionEnd = value.selection.end,
+                                        compositionStart = composition?.start ?: TextInputState.NO_COMPOSITION,
+                                        compositionEnd = composition?.end ?: TextInputState.NO_COMPOSITION
+                                    )
+                                )
+                                lastSyncedText = newText
+                            }
+
+                            // 重置标志，等待下一次原生事件
+                            isProcessingNativeEvent = false
                         }
                     }
                     set(editable) {
@@ -425,7 +458,58 @@ internal fun CoreTextField(
                     }
                     set(onValueChange to onLimitChange) {
                         withTextAreaView {
+                            getViewEvent().textInputStateChange {
+                                // 标记正在处理原生事件，避免 set(value) 反向同步导致选择状态被重置
+                                isProcessingNativeEvent = true
+                                receivedTextInputStateEvent = true
+                                autoHeightTextAreaView.getViewAttr()
+                                    .updatePropCache(TextConst.VALUE, it.text)
+                                val composition = if (
+                                    it.compositionStart != TextInputState.NO_COMPOSITION &&
+                                    it.compositionEnd != TextInputState.NO_COMPOSITION
+                                ) {
+                                    TextRange(it.compositionStart, it.compositionEnd)
+                                } else {
+                                    null
+                                }
+                                onValueChange(
+                                    TextFieldValue(
+                                        it.text,
+                                        selection = TextRange(it.selectionStart, it.selectionEnd),
+                                        composition = composition
+                                    )
+                                )
+                                val newLength = it.length ?: -1
+                                if (newLength != currentTextLength || currentLimitExceeded) {
+                                    currentTextLength = newLength
+                                    currentLimitExceeded = false
+                                    onLimitChange?.invoke(currentTextLength, currentLimitExceeded)
+                                }
+                            }
+                            getViewEvent().selectionChange {
+                                // 标记正在处理原生事件，避免 set(value) 反向同步导致选择状态被重置
+                                isProcessingNativeEvent = true
+                                receivedTextInputStateEvent = true
+                                val composition = if (
+                                    it.compositionStart != TextInputState.NO_COMPOSITION &&
+                                    it.compositionEnd != TextInputState.NO_COMPOSITION
+                                ) {
+                                    TextRange(it.compositionStart, it.compositionEnd)
+                                } else {
+                                    null
+                                }
+                                onValueChange(
+                                    TextFieldValue(
+                                        it.text,
+                                        selection = TextRange(it.selectionStart, it.selectionEnd),
+                                        composition = composition
+                                    )
+                                )
+                            }
                             getViewEvent().textDidChange {
+                                if (receivedTextInputStateEvent) {
+                                    return@textDidChange
+                                }
                                 autoHeightTextAreaView.getViewAttr()
                                     .updatePropCache(TextConst.VALUE, it.text)
                                 onValueChange(TextFieldValue(it.text))

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/InputTransformation.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/InputTransformation.kt
@@ -1,0 +1,40 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.compose.foundation.text.input
+
+fun interface InputTransformation {
+    fun TextFieldBuffer.transformInput()
+
+    fun then(next: InputTransformation): InputTransformation {
+        val current = this
+        return InputTransformation {
+            with(current) { transformInput() }
+            if (!hasReverted) {
+                with(next) { transformInput() }
+            }
+        }
+    }
+
+    companion object {
+        fun maxLength(maxLength: Int): InputTransformation {
+            return InputTransformation {
+                if (length > maxLength) {
+                    delete(maxLength, length)
+                }
+            }
+        }
+    }
+}

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/OutputTransformation.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/OutputTransformation.kt
@@ -1,0 +1,31 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.compose.foundation.text.input
+
+fun interface OutputTransformation {
+    fun TextFieldBuffer.transformOutput()
+}
+
+/**
+ * Kuikly bridge for the existing textPostProcessor render path.
+ */
+class TextPostProcessorOutputTransformation(
+    val processor: String
+) : OutputTransformation {
+    override fun TextFieldBuffer.transformOutput() {
+        // Rendering is delegated to platform textPostProcessor implementations.
+    }
+}

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/TextFieldBuffer.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/TextFieldBuffer.kt
@@ -1,0 +1,91 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.compose.foundation.text.input
+
+import com.tencent.kuikly.compose.ui.text.TextRange
+import com.tencent.kuikly.compose.ui.text.coerceIn
+
+class TextFieldBuffer internal constructor(
+    initialText: String,
+    initialSelection: TextRange,
+    initialComposition: TextRange?
+) : CharSequence {
+    private val initialText = initialText
+    private val initialSelection = initialSelection
+    private val initialComposition = initialComposition
+    private val content = StringBuilder(initialText)
+    private var reverted = false
+
+    var selection: TextRange = initialSelection.coerceIn(0, content.length)
+    var composition: TextRange? = initialComposition?.coerceIn(0, content.length)
+
+    internal val hasReverted: Boolean get() = reverted
+
+    override val length: Int get() = content.length
+
+    override fun get(index: Int): Char = content[index]
+
+    override fun subSequence(startIndex: Int, endIndex: Int): CharSequence {
+        return content.subSequence(startIndex, endIndex)
+    }
+
+    fun append(text: String) {
+        replace(content.length, content.length, text)
+    }
+
+    fun insert(index: Int, text: String) {
+        replace(index, index, text)
+    }
+
+    fun replace(start: Int, end: Int, text: String) {
+        val coercedStart = start.coerceIn(0, content.length)
+        val coercedEnd = end.coerceIn(0, content.length)
+        val rangeStart = minOf(coercedStart, coercedEnd)
+        val rangeEnd = maxOf(coercedStart, coercedEnd)
+        // 在 Kotlin 公共代码中，StringBuilder 的 API 受限，使用子序列拼接方式
+        val prefix = content.substring(0, rangeStart)
+        val suffix = if (rangeEnd < content.length) content.substring(rangeEnd) else ""
+        content.clear()
+        content.append(prefix).append(text).append(suffix)
+        val newCursor = rangeStart + text.length
+        selection = TextRange(newCursor)
+        composition = null
+    }
+
+    fun delete(start: Int, end: Int) {
+        replace(start, end, "")
+    }
+
+    fun selectAll() {
+        selection = TextRange(0, content.length)
+    }
+
+    fun placeCursorAtEnd() {
+        selection = TextRange(content.length)
+    }
+
+    fun revertAllChanges() {
+        content.clear()
+        content.append(initialText)
+        selection = initialSelection.coerceIn(0, content.length)
+        composition = initialComposition?.coerceIn(0, content.length)
+        reverted = true
+    }
+
+    fun asCharSequence(): CharSequence = content
+
+    override fun toString(): String = content.toString()
+}

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/TextFieldState.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/TextFieldState.kt
@@ -1,0 +1,81 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.compose.foundation.text.input
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.tencent.kuikly.compose.ui.text.TextRange
+import com.tencent.kuikly.compose.ui.text.coerceIn
+
+@Stable
+class TextFieldState internal constructor(
+    initialText: String,
+    initialSelection: TextRange
+) {
+    var text: String by mutableStateOf(initialText)
+        private set
+
+    var selection: TextRange by mutableStateOf(initialSelection.coerceIn(0, initialText.length))
+        internal set
+
+    var composition: TextRange? by mutableStateOf(null)
+        internal set
+
+    fun edit(block: TextFieldBuffer.() -> Unit) {
+        val buffer = TextFieldBuffer(text, selection, composition)
+        buffer.block()
+        if (buffer.hasReverted) {
+            return
+        }
+        text = buffer.toString()
+        selection = buffer.selection.coerceIn(0, text.length)
+        composition = buffer.composition?.coerceIn(0, text.length)
+    }
+
+    fun setTextAndPlaceCursorAtEnd(text: String) {
+        this.text = text
+        selection = TextRange(text.length)
+        composition = null
+    }
+
+    fun clearText() {
+        text = ""
+        selection = TextRange.Zero
+        composition = null
+    }
+
+    internal fun updateFromTextField(
+        text: String,
+        selection: TextRange,
+        composition: TextRange?
+    ) {
+        this.text = text
+        this.selection = selection.coerceIn(0, text.length)
+        this.composition = composition?.coerceIn(0, text.length)
+    }
+}
+
+@Composable
+fun rememberTextFieldState(
+    initialText: String = "",
+    initialSelection: TextRange = TextRange(initialText.length)
+): TextFieldState {
+    return remember { TextFieldState(initialText, initialSelection) }
+}

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRRichTextView.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRRichTextView.kt
@@ -654,8 +654,9 @@ class KRRichTextShadow : IKuiklyRenderShadowExport, IKuiklyRenderContextWrapper 
         constraintSize: SizeF,
         measureMode: TextMeasureMode
     ): Layout {
+        val adapter = KuiklyRenderAdapterManager.krTextPostProcessorAdapter
         val textSource = if (textProps.textPostProcessor.isNotEmpty()) {
-            KuiklyRenderAdapterManager.krTextPostProcessorAdapter?.onTextPostProcess(
+            adapter?.onTextPostProcess(
                 kuiklyRenderContext, TextPostProcessorInput(textProps.textPostProcessor, text, textProps)
             )?.text ?: text
         } else {

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRTextFieldView.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRTextFieldView.kt
@@ -31,6 +31,7 @@ import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.TextWatcher
+import android.text.style.ImageSpan
 import android.util.SizeF
 import android.util.TypedValue
 import android.view.Gravity
@@ -63,6 +64,7 @@ import com.tencent.kuikly.core.render.android.expand.module.KRKeyboardModule
 import com.tencent.kuikly.core.render.android.expand.module.KeyboardStatusListener
 import com.tencent.kuikly.core.render.android.export.IKuiklyRenderViewExport
 import com.tencent.kuikly.core.render.android.export.KuiklyRenderCallback
+import org.json.JSONObject
 
 /**
  * KTV单行输入组件
@@ -74,6 +76,18 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
      * text变化回调
      */
     private var textDidChangeCallback: KuiklyRenderCallback? = null
+
+    /**
+     * Raw text input state callback.
+     */
+    private var textInputStateChangeCallback: KuiklyRenderCallback? = null
+
+    /**
+     * Selection-only change callback.
+     */
+    private var selectionChangeCallback: KuiklyRenderCallback? = null
+
+    private var isSettingTextInputState = false
 
     /**
      * 聚焦回调
@@ -121,6 +135,7 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
 
     private var hadSetEditorFactory = false
     private var textProps: KRTextProps? = null
+    private var textPostProcessor: String = ""
 
     /**
      * 键盘显示需要 window 和 view 两者同时处于 focus才能显示
@@ -169,6 +184,13 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
     override fun setProp(propKey: String, propValue: Any): Boolean {
         return when (propKey) {
             TEXT -> setText(propValue)
+            PROP_KEY_TEXT_POST_PROCESSOR -> {
+                textPostProcessor = propValue as String
+                setInputEditorAdapterIfNeed()
+                // Apply emoji processing to existing text (handles case where text was set before textPostProcessor)
+                applyEmojiSpans(editableText)
+                true
+            }
             KRTextProps.PROP_KEY_VALUES -> setValues(propValue)
             FONT_SIZE -> setFontSize(propValue)
             FONT_WEIGHT -> setFontWeight(propValue)
@@ -183,6 +205,12 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
             MAX_TEXT_LENGTH -> setMaxTextLength(propValue)
             EDITABLE -> setEditable(propValue)
             TEXT_DID_CHANGE -> observeTextChanged(propValue)
+            TEXT_INPUT_STATE -> {
+                setTextInputState(propValue.toString())
+                true
+            }
+            TEXT_INPUT_STATE_CHANGE -> observeTextInputStateChanged(propValue)
+            SELECTION_CHANGE -> observeSelectionChanged(propValue)
             INPUT_RETURN -> observeInputReturn(propValue)
             IME_ACTION -> observeInputReturn(propValue)
             INPUT_FOCUS -> {
@@ -242,6 +270,8 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
             METHOD_BLUR -> setBlur()
             METHOD_GET_CURSOR_INDEX -> getCursorIndex(callback)
             METHOD_SET_CURSOR_INDEX -> setCursorIndex(params)
+            METHOD_SET_TEXT_INPUT_STATE -> setTextInputState(params)
+            METHOD_GET_TEXT_INPUT_STATE -> getTextInputState(callback)
             else -> super.call(method, params, callback)
         }
     }
@@ -519,6 +549,7 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
     }
 
     private fun setText(propValue: Any): Boolean {
+        setInputEditorAdapterIfNeed()
         setInputText((propValue as? String)?: "")
         return true
     }
@@ -544,6 +575,9 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
     override fun onSelectionChanged(selStart: Int, selEnd: Int) {
         super.onSelectionChanged(selStart, selEnd)
         cursorIndex = selStart
+        if (!isSettingTextInputState) {
+            selectionChangeCallback?.invoke(createTextInputStateParamMap())
+        }
     }
 
     private fun setFontSize(propValue: Any): Boolean {
@@ -613,13 +647,52 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
 
     private fun setCursorIndex(params: String?) {
         val index = params?.toIntOrNull() ?: return
-        setSelection(index)
+        setSelection(index.coerceIn(0, text?.length ?: 0))
+    }
+
+    private fun setTextInputState(params: String?) {
+        val json = runCatching { JSONObject(params ?: "{}") }.getOrElse { JSONObject() }
+        val rawText = json.optString(KEY_TEXT, "")
+        val selectionStart = json.optInt(KEY_SELECTION_START, rawText.length).coerceIn(0, rawText.length)
+        val selectionEnd = json.optInt(KEY_SELECTION_END, selectionStart).coerceIn(0, rawText.length)
+        isSettingTextInputState = true
+        try {
+            setInputEditorAdapterIfNeed()
+            lineHeightSpan?.let { span ->
+                val spannable = SpannableString(rawText)
+                if (rawText.isNotEmpty()) {
+                    spannable.setSpan(span, 0, rawText.length, Spanned.SPAN_EXCLUSIVE_INCLUSIVE)
+                }
+                super.setText(spannable, BufferType.EDITABLE)
+            } ?: super.setText(rawText, BufferType.EDITABLE)
+            applyEmojiSpans(editableText)
+            setSelection(selectionStart, selectionEnd)
+        } finally {
+            isSettingTextInputState = false
+        }
+    }
+
+    private fun getTextInputState(callback: KuiklyRenderCallback?) {
+        callback?.invoke(createTextInputStateParamMap())
     }
 
     @Suppress("UNCHECKED_CAST")
     private fun observeTextChanged(propValue: Any): Boolean {
         textDidChangeCallback = propValue as KuiklyRenderCallback
         observeTextWatcher()
+        return true
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun observeTextInputStateChanged(propValue: Any): Boolean {
+        textInputStateChangeCallback = propValue as KuiklyRenderCallback
+        observeTextWatcher()
+        return true
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun observeSelectionChanged(propValue: Any): Boolean {
+        selectionChangeCallback = propValue as KuiklyRenderCallback
         return true
     }
 
@@ -715,14 +788,34 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
         }
         return if (length == null) {
             mapOf(
-                "text" to text.toString()
+                KEY_TEXT to text.toString()
             )
         } else {
             mapOf(
-                "text" to text.toString(),
-                "length" to length!!
+                KEY_TEXT to text.toString(),
+                KEY_LENGTH to length!!
             )
         }
+    }
+
+    private fun createTextInputStateParamMap(): Map<String, Any> {
+        val text = text?.toString() ?: KRCssConst.EMPTY_STRING
+        val selectionStart = selectionStart.coerceIn(0, text.length)
+        val selectionEnd = selectionEnd.coerceIn(0, text.length)
+        val result = mutableMapOf<String, Any>(
+            KEY_TEXT to text,
+            KEY_SELECTION_START to selectionStart,
+            KEY_SELECTION_END to selectionEnd,
+            KEY_COMPOSITION_START to NO_COMPOSITION,
+            KEY_COMPOSITION_END to NO_COMPOSITION
+        )
+        val length = if (lengthLimitType != LENGTH_LIMIT_TYPE_UNSET) {
+            getLengthLimitInputFilter()?.calculateLength(text)
+        } else {
+            null
+        }
+        length?.let { result[KEY_LENGTH] = it }
+        return result
     }
 
     private fun resetDefaultStyle() {
@@ -751,7 +844,41 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
         return true
     }
 
+    /**
+     * Apply emoji ImageSpans to the given Editable by delegating to the text post-processor adapter.
+     * Called from afterTextChanged to ensure emoji spans are refreshed on every text change.
+     */
+    private fun applyEmojiSpans(editable: Editable?) {
+        if (editable == null) return
+        val adapter = KuiklyRenderAdapterManager.krTextPostProcessorAdapter ?: return
+        val tp = textProps ?: KRTextProps(kuiklyRenderContext).also {
+            it.fontSize = if (fontSize > 0) fontSize else 16f
+        }
+        if (textPostProcessor.isEmpty()) return
+        val output = adapter.onTextPostProcess(
+            kuiklyRenderContext,
+            TextPostProcessorInput(textPostProcessor, editable, tp)
+        )
+        val outputText = output.text
+        if (outputText is Spannable) {
+            // Remove existing ImageSpans and apply new ones from the processed output
+            val oldSpans = editable.getSpans(0, editable.length, ImageSpan::class.java)
+            for (span in oldSpans) {
+                editable.removeSpan(span)
+            }
+            val newSpans = outputText.getSpans(0, outputText.length, ImageSpan::class.java)
+            for (span in newSpans) {
+                val start = outputText.getSpanStart(span)
+                val end = outputText.getSpanEnd(span)
+                if (start >= 0 && end <= editable.length) {
+                    editable.setSpan(span, start, end, outputText.getSpanFlags(span))
+                }
+            }
+        }
+    }
+
     private fun setInputEditorAdapterIfNeed() {
+        if (textPostProcessor.isEmpty()) return
         val textPostProcessorAdapter = KuiklyRenderAdapterManager.krTextPostProcessorAdapter ?: return
         if (hadSetEditorFactory) {
             return
@@ -762,13 +889,15 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
                 if (source == null) {
                     return SpannableStringBuilder()
                 }
-                val tp = textProps ?: return SpannableStringBuilder()
-                val outputText = textPostProcessorAdapter.onTextPostProcess(kuiklyRenderContext, TextPostProcessorInput("input",
+                val tp = textProps ?: KRTextProps(kuiklyRenderContext).also {
+                    it.fontSize = if (fontSize > 0) fontSize else 16f
+                }
+                val outputText = textPostProcessorAdapter.onTextPostProcess(kuiklyRenderContext, TextPostProcessorInput(textPostProcessor,
                     source, tp)).text
                 return if (outputText is Editable) {
                     outputText
                 } else {
-                    SpannableStringBuilder()
+                    SpannableStringBuilder(source)
                 }
             }
         })
@@ -815,7 +944,12 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
         if (textWatcher == null) {
             textWatcher = object : TextWatcher {
                 override fun afterTextChanged(s: Editable?) {
+                    if (isSettingTextInputState) {
+                        return
+                    }
                     s?.also(::ensureLineHeightSpan)
+                    applyEmojiSpans(s)
+                    textInputStateChangeCallback?.invoke(createTextInputStateParamMap())
                     textDidChangeCallback?.invoke(createCallbackParamMap())
                 }
 
@@ -832,6 +966,7 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
 
     companion object {
         const val VIEW_NAME = "KRTextFieldView"
+        private const val PROP_KEY_TEXT_POST_PROCESSOR = "textPostProcessor"
         private const val TEXT = "text"
         private const val FONT_SIZE = "fontSize"
         private const val FONT_WEIGHT = "fontWeight"
@@ -846,6 +981,9 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
         private const val MAX_TEXT_LENGTH = "maxTextLength"
         private const val EDITABLE = "editable"
         private const val TEXT_DID_CHANGE = "textDidChange"
+        private const val TEXT_INPUT_STATE = "textInputState"
+        private const val TEXT_INPUT_STATE_CHANGE = "textInputStateChange"
+        private const val SELECTION_CHANGE = "selectionChange"
         private const val INPUT_RETURN = "inputReturn"
         private const val INPUT_FOCUS = "inputFocus"
         private const val INPUT_BLUR = "inputBlur"
@@ -860,12 +998,22 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
         private const val METHOD_BLUR = "blur"
         private const val METHOD_GET_CURSOR_INDEX = "getCursorIndex"
         private const val METHOD_SET_CURSOR_INDEX = "setCursorIndex"
+        private const val METHOD_SET_TEXT_INPUT_STATE = "setTextInputState"
+        private const val METHOD_GET_TEXT_INPUT_STATE = "getTextInputState"
 
         private const val TYPE_ENABLE_EDIT = 1
         private const val TYPE_ENABLE_HIDE_KEYBOARD = 1
 
         private const val KEY_KEYBOARD_CHANGED_DURATION = "duration"
         private const val DEFAULT_KEYBOARD_CHANGED_ANIMATION_DURATION = 0.2
+
+        private const val KEY_TEXT = "text"
+        private const val KEY_SELECTION_START = "selectionStart"
+        private const val KEY_SELECTION_END = "selectionEnd"
+        private const val KEY_COMPOSITION_START = "compositionStart"
+        private const val KEY_COMPOSITION_END = "compositionEnd"
+        private const val KEY_LENGTH = "length"
+        private const val NO_COMPOSITION = -1
 
         private const val LENGTH_LIMIT_TYPE_UNSET = -1
         private const val LENGTH_LIMIT_TYPE_BYTE = 0

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/AutoHeightTextAreaView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/AutoHeightTextAreaView.kt
@@ -127,6 +127,26 @@ class AutoHeightTextAreaView(val singleLine: Boolean = false) :
         }
     }
 
+    /**
+     * Atomically set raw text, selection, and composition state.
+     */
+    fun setTextInputState(state: TextInputState) {
+        performTaskWhenRenderViewDidLoad {
+            renderView?.callMethod("setTextInputState", state.encode())
+        }
+    }
+
+    /**
+     * Get raw text, selection, and composition state from native input view.
+     */
+    fun getTextInputState(callback: (TextInputState) -> Unit) {
+        performTaskWhenRenderViewDidLoad {
+            renderView?.callMethod("getTextInputState", "") {
+                callback(TextInputState.decode(it))
+            }
+        }
+    }
+
     override fun measure(
         node: FlexNode,
         width: Float,

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/InputView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/InputView.kt
@@ -23,12 +23,22 @@ import com.tencent.kuikly.core.nvi.serialization.json.JSONObject
 
 class InputView : DeclarativeBaseView<InputAttr, InputEvent>() {
 
+    // 标记是否正在处理原生事件，避免反向同步导致选择状态被重置
+    internal var isProcessingNativeEvent: Boolean = false
+    // 记录上一次同步到原生层的文本，用于判断是否需要重新同步
+    internal var lastSyncedText: String = ""
+
     override fun createAttr(): InputAttr {
         return InputAttr()
     }
 
     override fun createEvent(): InputEvent {
-        return InputEvent()
+        val event = InputEvent()
+        // 设置原生事件触发前的回调，用于标记正在处理原生事件
+        event.beforeNativeEventCallback = {
+            this.isProcessingNativeEvent = true
+        }
+        return event
     }
 
     override fun viewName(): String {
@@ -39,6 +49,24 @@ class InputView : DeclarativeBaseView<InputAttr, InputEvent>() {
         super.createRenderView()
         if (attr.autofocus) {
             focus()
+        }
+    }
+
+    override fun didSetProp(propKey: String, propValue: Any) {
+        // 处理 TEXT_INPUT_STATE prop，添加防循环同步逻辑
+        if (propKey == InputAttr.TEXT_INPUT_STATE) {
+            val state = TextInputState.decode(propValue as? JSONObject)
+            val textChanged = state.text != lastSyncedText
+            // 只有当文本发生变化，或者不是来自原生事件时，才同步到原生层
+            val shouldSyncToNative = textChanged || !isProcessingNativeEvent
+            if (shouldSyncToNative) {
+                super.didSetProp(propKey, propValue)
+                lastSyncedText = state.text
+            }
+            // 重置标志，等待下一次原生事件
+            isProcessingNativeEvent = false
+        } else {
+            super.didSetProp(propKey, propValue)
         }
     }
 
@@ -89,6 +117,26 @@ class InputView : DeclarativeBaseView<InputAttr, InputEvent>() {
         }
     }
 
+    /**
+     * Atomically set raw text, selection, and composition state.
+     */
+    fun setTextInputState(state: TextInputState) {
+        performTaskWhenRenderViewDidLoad {
+            renderView?.callMethod("setTextInputState", state.encode())
+        }
+    }
+
+    /**
+     * Get raw text, selection, and composition state from native input view.
+     */
+    fun getTextInputState(callback: (TextInputState) -> Unit) {
+        performTaskWhenRenderViewDidLoad {
+            renderView?.callMethod("getTextInputState", "") {
+                callback(TextInputState.decode(it))
+            }
+        }
+    }
+
 }
 
 class InputAttr : Attr() {
@@ -101,6 +149,24 @@ class InputAttr : Attr() {
      */
     fun text(text: String): InputAttr {
         TextConst.VALUE with text
+        return this
+    }
+
+    /**
+     * Atomically set raw text, selection, and composition state.
+     */
+    fun textInputState(state: TextInputState): InputAttr {
+        TEXT_INPUT_STATE with state.encode()
+        return this
+    }
+
+    /**
+     * Set text post-processor name.
+     * Works with KRTextPostProcessorAdapter to enable features like emoji shortcode replacement.
+     * @param processor processor name, e.g. "input"
+     */
+    fun textPostProcessor(processor: String): InputAttr {
+        "textPostProcessor" with processor
         return this
     }
 
@@ -302,6 +368,7 @@ class InputAttr : Attr() {
     companion object {
         const val RETURN_KEY_TYPE = "returnKeyType"
         const val KEYBOARD_TYPE = "keyboardType"
+        const val TEXT_INPUT_STATE = "textInputState"
         const val IME_NO_FULLSCREEN = "imeNoFullscreen"
         const val ENABLES_RETURN_KEY_AUTOMATICALLY =  "enablesReturnKeyAutomatically"
     }
@@ -320,6 +387,9 @@ data class KeyboardParams(
 )
 
 class InputEvent : Event() {
+    // 原生事件触发前的回调，用于设置 View 的标志位
+    internal var beforeNativeEventCallback: (() -> Unit)? = null
+
     /**
      * 当文本发生变化时调用的方法
      * @param isSyncEdit 是否同步编辑，该值为true则可以实现同步修改输入文本不会异步更新带来的跳变
@@ -332,6 +402,28 @@ class InputEvent : Event() {
             val length = if (it.has("length")) it.optInt("length") else null
             handler(InputParams(text, length = length))
         }, isSync = isSyncEdit)
+    }
+
+    /**
+     * Called when raw text, selection, or composition changes.
+     */
+    fun textInputStateChange(isSyncEdit: Boolean = true, handler: TextInputStateHandlerFn) {
+        register(TEXT_INPUT_STATE_CHANGE, {
+            // 标记正在处理原生事件，避免 didSetProp 反向同步导致选择状态被重置
+            beforeNativeEventCallback?.invoke()
+            handler(TextInputState.decode(it as? JSONObject))
+        }, isSync = isSyncEdit)
+    }
+
+    /**
+     * Called when selection changes without requiring text changes.
+     */
+    fun selectionChange(handler: TextInputStateHandlerFn) {
+        register(SELECTION_CHANGE, {
+            // 标记正在处理原生事件，避免 didSetProp 反向同步导致选择状态被重置
+            beforeNativeEventCallback?.invoke()
+            handler(TextInputState.decode(it as? JSONObject))
+        }, isSync = true)
     }
 
     /**
@@ -410,6 +502,8 @@ class InputEvent : Event() {
 
     companion object {
         const val TEXT_DID_CHANGE = "textDidChange"
+        const val TEXT_INPUT_STATE_CHANGE = "textInputStateChange"
+        const val SELECTION_CHANGE = "selectionChange"
         const val INPUT_FOCUS = "inputFocus"
         const val INPUT_BLUR = "inputBlur"
         const val KEYBOARD_HEIGHT_CHANGE = "keyboardHeightChange"

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextAreaView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextAreaView.kt
@@ -60,6 +60,10 @@ open class TextAreaView : DeclarativeBaseView<TextAreaAttr, TextAreaEvent>(), Me
             flexNode.markDirty()
         }
     }
+    // 标记是否正在处理原生事件，避免反向同步导致选择状态被重置
+    internal var isProcessingNativeEvent: Boolean = false
+    // 记录上一次同步到原生层的文本，用于判断是否需要重新同步
+    internal var lastSyncedText: String = ""
 
     override fun willInit() {
         super.willInit()
@@ -75,7 +79,12 @@ open class TextAreaView : DeclarativeBaseView<TextAreaAttr, TextAreaEvent>(), Me
     }
 
     override fun createEvent(): TextAreaEvent {
-        return TextAreaEvent()
+        val event = TextAreaEvent()
+        // 设置原生事件触发前的回调，用于标记正在处理原生事件
+        event.beforeNativeEventCallback = {
+            this.isProcessingNativeEvent = true
+        }
+        return event
     }
 
     override fun viewName(): String {
@@ -102,10 +111,24 @@ open class TextAreaView : DeclarativeBaseView<TextAreaAttr, TextAreaEvent>(), Me
     }
 
     override fun didSetProp(propKey: String, propValue: Any) {
-        super.didSetProp(propKey, propValue)
-        if (propKey !in NON_SHADOW_PROPS) {
-            shadow?.setProp(propKey, propValue)
-            flexNode.markDirty()
+        // 处理 TEXT_INPUT_STATE prop，添加防循环同步逻辑
+        if (propKey == TextAreaAttr.TEXT_INPUT_STATE) {
+            val state = TextInputState.decode(propValue as? JSONObject)
+            val textChanged = state.text != lastSyncedText
+            // 只有当文本发生变化，或者不是来自原生事件时，才同步到原生层
+            val shouldSyncToNative = textChanged || !isProcessingNativeEvent
+            if (shouldSyncToNative) {
+                super.didSetProp(propKey, propValue)
+                lastSyncedText = state.text
+            }
+            // 重置标志，等待下一次原生事件
+            isProcessingNativeEvent = false
+        } else {
+            super.didSetProp(propKey, propValue)
+            if (propKey !in NON_SHADOW_PROPS) {
+                shadow?.setProp(propKey, propValue)
+                flexNode.markDirty()
+            }
         }
     }
 
@@ -150,6 +173,26 @@ open class TextAreaView : DeclarativeBaseView<TextAreaAttr, TextAreaEvent>(), Me
     fun setCursorIndex(index: Int) {
         performTaskWhenRenderViewDidLoad {
             renderView?.callMethod("setCursorIndex", index.toString())
+        }
+    }
+
+    /**
+     * Atomically set raw text, selection, and composition state.
+     */
+    fun setTextInputState(state: TextInputState) {
+        performTaskWhenRenderViewDidLoad {
+            renderView?.callMethod("setTextInputState", state.encode())
+        }
+    }
+
+    /**
+     * Get raw text, selection, and composition state from native input view.
+     */
+    fun getTextInputState(callback: (TextInputState) -> Unit) {
+        performTaskWhenRenderViewDidLoad {
+            renderView?.callMethod("getTextInputState", "") {
+                callback(TextInputState.decode(it))
+            }
         }
     }
 
@@ -252,6 +295,14 @@ open class TextAreaAttr : Attr() {
     }
 
     /**
+     * Atomically set raw text, selection, and composition state.
+     */
+    fun textInputState(state: TextInputState): TextAreaAttr {
+        TEXT_INPUT_STATE with state.encode()
+        return this
+    }
+
+    /**
      * 设置输入文本的文本样式
      * 配合TextArea的textDidChange来更改spans实现输入框富文本化
      * 注：设置新inputSpans后，光标会保持原index
@@ -324,6 +375,16 @@ open class TextAreaAttr : Attr() {
 
     fun placeholder(placeholder: String): TextAreaAttr {
         TextConst.PLACEHOLDER with placeholder
+        return this
+    }
+
+    /**
+     * Set text post-processor name.
+     * Works with KRTextPostProcessorAdapter to enable features like emoji shortcode replacement.
+     * @param processor processor name, e.g. "input"
+     */
+    fun textPostProcessor(processor: String): TextAreaAttr {
+        "textPostProcessor" with processor
         return this
     }
 
@@ -447,6 +508,7 @@ open class TextAreaAttr : Attr() {
     companion object {
         const val RETURN_KEY_TYPE = "returnKeyType"
         const val KEYBOARD_TYPE = "keyboardType"
+        const val TEXT_INPUT_STATE = "textInputState"
     }
 }
 
@@ -535,6 +597,8 @@ open class TextAreaEvent : Event() {
     private val syncTextDidChangeObservers = fastMutableListOf<InputEventHandlerFn>()
     private var textDidChangeHandler: InputEventHandlerFn? = null
     private var isSyncEdit = false
+    // 原生事件触发前的回调，用于设置 View 的标志位
+    internal var beforeNativeEventCallback: (() -> Unit)? = null
 
     internal fun addTextDidChangeObserver(observer: InputEventHandlerFn) {
         if (observer in syncTextDidChangeObservers) {
@@ -597,6 +661,28 @@ open class TextAreaEvent : Event() {
         this.isSyncEdit = isSyncEdit
         this.textDidChangeHandler = handler
         updateTextDidChangeInternal()
+    }
+
+    /**
+     * Called when raw text, selection, or composition changes.
+     */
+    fun textInputStateChange(isSyncEdit: Boolean = true, handler: TextInputStateHandlerFn) {
+        this.register(TEXT_INPUT_STATE_CHANGE, {
+            // 标记正在处理原生事件，避免 didSetProp 反向同步导致选择状态被重置
+            beforeNativeEventCallback?.invoke()
+            handler(TextInputState.decode(it as? JSONObject))
+        }, isSync = isSyncEdit)
+    }
+
+    /**
+     * Called when selection changes without requiring text changes.
+     */
+    fun selectionChange(handler: TextInputStateHandlerFn) {
+        this.register(SELECTION_CHANGE, {
+            // 标记正在处理原生事件，避免 didSetProp 反向同步导致选择状态被重置
+            beforeNativeEventCallback?.invoke()
+            handler(TextInputState.decode(it as? JSONObject))
+        }, isSync = true)
     }
 
     /**
@@ -681,6 +767,8 @@ open class TextAreaEvent : Event() {
 
     companion object {
         const val TEXT_DID_CHANGE = "textDidChange"
+        const val TEXT_INPUT_STATE_CHANGE = "textInputStateChange"
+        const val SELECTION_CHANGE = "selectionChange"
         const val INPUT_FOCUS = "inputFocus"
         const val INPUT_BLUR = "inputBlur"
         const val KEYBOARD_HEIGHT_CHANGE = "keyboardHeightChange"

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextInputState.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextInputState.kt
@@ -1,0 +1,93 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.core.views
+
+import com.tencent.kuikly.core.nvi.serialization.json.JSONObject
+
+/**
+ * Internal cross-layer text input state payload for Core / Render communication.
+ *
+ * All indices are raw text offsets. [selectionStart] == [selectionEnd] means cursor position.
+ * [compositionStart] and [compositionEnd] are -1 when the platform does not provide composing range.
+ */
+data class TextInputState(
+    val text: String,
+    val selectionStart: Int = text.length,
+    val selectionEnd: Int = selectionStart,
+    val compositionStart: Int = NO_COMPOSITION,
+    val compositionEnd: Int = NO_COMPOSITION,
+    val length: Int? = null
+) {
+    fun toJSONObject(): JSONObject {
+        return JSONObject().apply {
+            put(KEY_TEXT, text)
+            put(KEY_SELECTION_START, selectionStart)
+            put(KEY_SELECTION_END, selectionEnd)
+            put(KEY_COMPOSITION_START, compositionStart)
+            put(KEY_COMPOSITION_END, compositionEnd)
+            length?.let { put(KEY_LENGTH, it) }
+        }
+    }
+
+    fun encode(): String = toJSONObject().toString()
+
+    companion object {
+        const val NO_COMPOSITION = -1
+
+        const val KEY_TEXT = "text"
+        const val KEY_SELECTION_START = "selectionStart"
+        const val KEY_SELECTION_END = "selectionEnd"
+        const val KEY_COMPOSITION_START = "compositionStart"
+        const val KEY_COMPOSITION_END = "compositionEnd"
+        const val KEY_LENGTH = "length"
+
+        fun decode(params: JSONObject?): TextInputState {
+            val json = params ?: JSONObject()
+            val text = json.optString(KEY_TEXT)
+            val selectionStart = if (json.has(KEY_SELECTION_START)) {
+                json.optInt(KEY_SELECTION_START)
+            } else {
+                text.length
+            }
+            val selectionEnd = if (json.has(KEY_SELECTION_END)) {
+                json.optInt(KEY_SELECTION_END)
+            } else {
+                selectionStart
+            }
+            val compositionStart = if (json.has(KEY_COMPOSITION_START)) {
+                json.optInt(KEY_COMPOSITION_START)
+            } else {
+                NO_COMPOSITION
+            }
+            val compositionEnd = if (json.has(KEY_COMPOSITION_END)) {
+                json.optInt(KEY_COMPOSITION_END)
+            } else {
+                NO_COMPOSITION
+            }
+            val length = if (json.has(KEY_LENGTH)) json.optInt(KEY_LENGTH) else null
+            return TextInputState(
+                text = text,
+                selectionStart = selectionStart,
+                selectionEnd = selectionEnd,
+                compositionStart = compositionStart,
+                compositionEnd = compositionEnd,
+                length = length
+            )
+        }
+    }
+}
+
+typealias TextInputStateHandlerFn = (TextInputState) -> Unit

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/ComposeAllSample.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/ComposeAllSample.kt
@@ -107,6 +107,7 @@ internal class ComposeAllSample : ComposeContainer() {
             DemoItem("LazyHorizontalGrid", "LazyHorizontalGrid基本用法示例", "LazyHorizontalGridDemo1"),
             DemoItem("焦点处理", "Focus焦点处理示例", "focusDemo"),
             DemoItem("TextField", "TextField 组件示例", "TextFieldDemo"),
+            DemoItem("TextFieldEmoji", "TextField 自定义表情示例", "TextFieldEmojiDemo"),
             DemoItem("PullToRefresh", "PullToRefresh 组件示例", "PullToRefreshDemo"),
             // 其他
             DemoItem("封装KuiklyView", "封装Kuikly的VideoView为一个Composeable组件示例", "ComposeVideoDemo"),

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/TextFieldEmojiDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/TextFieldEmojiDemo.kt
@@ -1,0 +1,233 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.demo.pages.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.tencent.kuikly.compose.ComposeContainer
+import com.tencent.kuikly.compose.extension.textPostProcessor
+import com.tencent.kuikly.compose.foundation.background
+import com.tencent.kuikly.compose.foundation.clickable
+import com.tencent.kuikly.compose.foundation.layout.Arrangement
+import com.tencent.kuikly.compose.foundation.layout.Box
+import com.tencent.kuikly.compose.foundation.layout.Column
+import com.tencent.kuikly.compose.foundation.layout.Row
+import com.tencent.kuikly.compose.foundation.layout.Spacer
+import com.tencent.kuikly.compose.foundation.layout.fillMaxSize
+import com.tencent.kuikly.compose.foundation.layout.fillMaxWidth
+import com.tencent.kuikly.compose.foundation.layout.height
+import com.tencent.kuikly.compose.foundation.layout.padding
+import com.tencent.kuikly.compose.foundation.layout.size
+import com.tencent.kuikly.compose.foundation.shape.CircleShape
+import com.tencent.kuikly.compose.foundation.text.BasicTextField
+import com.tencent.kuikly.compose.foundation.text.input.TextPostProcessorOutputTransformation
+import com.tencent.kuikly.compose.foundation.text.input.rememberTextFieldState
+import com.tencent.kuikly.compose.material3.Button
+import com.tencent.kuikly.compose.material3.Text
+import com.tencent.kuikly.compose.setContent
+import com.tencent.kuikly.compose.ui.Alignment
+import com.tencent.kuikly.compose.ui.Modifier
+import com.tencent.kuikly.compose.ui.graphics.Color
+import com.tencent.kuikly.compose.ui.text.TextStyle
+import com.tencent.kuikly.compose.ui.unit.dp
+import com.tencent.kuikly.compose.ui.unit.sp
+import com.tencent.kuikly.core.annotations.Page
+
+/**
+ * Compose DSL 自定义表情输入 Demo。
+ *
+ * 使用 TextFieldState + edit 方法，在当前光标/选区插入短码。
+ */
+@Page("TextFieldEmojiDemo")
+class TextFieldEmojiDemo : ComposeContainer() {
+
+    private val emojiList = listOf(
+        "[smile]" to "微笑",
+        "[heart]" to "爱心",
+        "[thumbup]" to "点赞",
+        "[star]" to "星星",
+        "[fire]" to "火焰",
+    )
+
+    override fun willInit() {
+        super.willInit()
+        setContent {
+            ComposeNavigationBar {
+                TextFieldEmojiDemoImpl()
+            }
+        }
+    }
+
+    @Composable
+    fun TextFieldEmojiDemoImpl() {
+        val state = rememberTextFieldState()
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color(0xFFF5F5F5))
+                .padding(16.dp)
+        ) {
+            Text(
+                text = "自定义表情输入 Demo",
+                fontSize = 20.sp,
+                color = Color.Black,
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+            Text(
+                text = "演示 BasicTextField + TextPostProcessor 实现表情输入",
+                fontSize = 12.sp,
+                color = Color.Gray,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+
+            // 组件1: BasicTextField - 输入框（支持表情预览）
+            Text(
+                text = "① BasicTextField（输入框 + 表情预览）",
+                fontSize = 14.sp,
+                color = Color(0xFF666666),
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            BasicTextField(
+                state = state,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(72.dp)
+                    .background(Color.White)
+                    .padding(12.dp)
+                    .textPostProcessor("input"),
+                outputTransformation = TextPostProcessorOutputTransformation("input"),
+                textStyle = TextStyle(fontSize = 16.sp, color = Color(0xFF333333)),
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // 组件2: EmojiGrid - 自定义表情面板
+            Text(
+                text = "② EmojiGrid（自定义表情面板）",
+                fontSize = 14.sp,
+                color = Color(0xFF666666),
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color.White)
+                    .padding(12.dp)
+            ) {
+                EmojiGrid(emojiList) { shortCode ->
+                    state.edit {
+                        replace(selection.start, selection.end, shortCode)
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // 组件3: 原始文本显示
+            Text(
+                text = "③ 原始文本 State.text（短码格式）",
+                fontSize = 14.sp,
+                color = Color(0xFF666666),
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+            Text(
+                text = state.text.ifEmpty { "（暂无内容）" },
+                fontSize = 14.sp,
+                color = Color(0xFF333333),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color.White)
+                    .padding(8.dp)
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // 组件4: 表情预览（使用 textPostProcessor 修饰符）
+            Text(
+                text = "④ 表情预览 Text.composable（textPostProcessor 修饰符）",
+                fontSize = 14.sp,
+                color = Color(0xFF666666),
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color.White)
+                    .padding(12.dp)
+            ) {
+                Text(
+                    text = state.text.ifEmpty { "（请在上方输入框或表情面板输入）" },
+                    fontSize = 16.sp,
+                    color = if (state.text.isEmpty()) Color(0xFFCCCCCC) else Color(0xFF333333),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .textPostProcessor("input")
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = { state.clearText() },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("清空内容")
+            }
+
+            Spacer(modifier = Modifier.height(300.dp))
+        }
+    }
+}
+
+@Composable
+fun EmojiGrid(
+    emojis: List<Pair<String, String>>,
+    onEmojiClick: (String) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        emojis.forEach { (shortCode, label) ->
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .clickable { onEmojiClick(shortCode) }
+                    .padding(8.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .background(Color(0xFFF0F0F0), shape = CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = label.first().toString(),
+                        fontSize = 20.sp,
+                        color = Color(0xFF666666)
+                    )
+                }
+                Text(
+                    text = label,
+                    fontSize = 10.sp,
+                    color = Color.Gray,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+        }
+    }
+}

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/EmojiTextInputDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/EmojiTextInputDemo.kt
@@ -1,0 +1,231 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.demo.pages.demo
+
+import com.tencent.kuikly.core.annotations.Page
+import com.tencent.kuikly.core.base.Border
+import com.tencent.kuikly.core.base.BorderStyle
+import com.tencent.kuikly.core.base.Color
+import com.tencent.kuikly.core.base.ViewBuilder
+import com.tencent.kuikly.core.base.ViewContainer
+import com.tencent.kuikly.core.base.ViewRef
+import com.tencent.kuikly.core.pager.Pager
+import com.tencent.kuikly.core.reactive.handler.observable
+import com.tencent.kuikly.core.views.TextArea
+import com.tencent.kuikly.core.views.TextAreaView
+import com.tencent.kuikly.core.views.TextInputState
+import com.tencent.kuikly.core.views.Text
+import com.tencent.kuikly.core.views.View
+import com.tencent.kuikly.core.views.compose.Button
+import com.tencent.kuikly.demo.pages.demo.base.NavBar
+
+@Page("EmojiTextInputDemo")
+internal class EmojiTextInputDemo : Pager() {
+
+    private var inputState: TextInputState by observable(TextInputState(text = ""))
+    private var previewText: String by observable("")
+    private var inputRef: ViewRef<TextAreaView>? = null
+
+    private val emojiShortcodes = listOf("[smile]", "[heart]", "[thumbup]", "[star]", "[fire]")
+    private val emojiLabels  = listOf("😊", "❤️", "👍", "⭐", "🔥")
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            View {
+                attr {
+                    size(pagerData.pageViewWidth, pagerData.pageViewHeight)
+                    backgroundColor(Color(0xFFF5F5F5))
+                    flexDirectionColumn()
+                }
+
+                NavBar { attr { title = "自定义表情 Demo (自研DSL)" } }
+
+                View {
+                    attr {
+                        marginTop(12f)
+                        marginLeft(16f)
+                        marginRight(16f)
+                    }
+                    Text {
+                        attr {
+                            text("点击表情按钮会替换当前选区或插入当前光标，raw text 保留短码。")
+                            color(Color(0xFF666666))
+                            fontSize(14f)
+                        }
+                    }
+                }
+
+                View {
+                    attr {
+                        marginTop(12f)
+                        marginLeft(16f)
+                        marginRight(16f)
+                        height(120f)
+                        borderRadius(8f)
+                        border(Border(1f, color = Color(0xFFDDDDDD), lineStyle = BorderStyle.SOLID))
+                        backgroundColor(Color.WHITE)
+                        paddingLeft(12f)
+                        paddingRight(12f)
+                        paddingTop(8f)
+                        paddingBottom(8f)
+                    }
+                    TextArea {
+                        ref {
+                            ctx.inputRef = it
+                        }
+                        attr {
+                            flex(1f)
+                            placeholder("输入文字或点击下方表情按钮")
+                            fontSize(16f)
+                            color(Color(0xFF333333))
+                            textPostProcessor("input")
+                            textInputState(ctx.inputState)
+                        }
+                        event {
+                            textInputStateChange { state ->
+                                ctx.inputState = state
+                                ctx.previewText = state.text
+                            }
+                            selectionChange { state ->
+                                ctx.inputState = state
+                            }
+                            textDidChange {
+                                ctx.previewText = it.text
+                            }
+                        }
+                    }
+                }
+
+                PreviewBlock("预览：") { ctx.previewText }
+
+                View {
+                    attr {
+                        marginTop(16f)
+                        marginLeft(16f)
+                        marginRight(16f)
+                        flexDirectionRow()
+                    }
+                    for (i in ctx.emojiShortcodes.indices) {
+                        Button {
+                            attr {
+                                height(40f)
+                                borderRadius(20f)
+                                backgroundColor(Color.WHITE)
+                                paddingLeft(12f)
+                                paddingRight(12f)
+                                marginRight(8f)
+                                marginBottom(8f)
+                                border(Border(1f, color = Color(0xFFDDDDDD), lineStyle = BorderStyle.SOLID))
+                                titleAttr {
+                                    text(ctx.emojiLabels[i] + " " + ctx.emojiShortcodes[i])
+                                    fontSize(14f)
+                                    color(Color(0xFF333333))
+                                }
+                            }
+                            event {
+                                click {
+                                    ctx.insertEmoji(ctx.emojiShortcodes[i])
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Button {
+                    attr {
+                        marginTop(24f)
+                        marginLeft(16f)
+                        marginRight(16f)
+                        height(44f)
+                        borderRadius(8f)
+                        backgroundColor(Color(0xFFFF4444))
+                        titleAttr {
+                            text("清空输入框")
+                            fontSize(16f)
+                            color(Color.WHITE)
+                            fontWeightBold()
+                        }
+                    }
+                    event {
+                        click {
+                            ctx.commitInputState(TextInputState(text = ""))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun insertEmoji(shortcode: String) {
+        val currentInputRef = inputRef
+        if (currentInputRef == null) {
+            commitInputState(inputState.replaceSelection(shortcode))
+            return
+        }
+        currentInputRef.view?.getTextInputState { nativeState ->
+            commitInputState(nativeState.replaceSelection(shortcode))
+        }
+    }
+
+    private fun commitInputState(state: TextInputState) {
+        inputState = state
+        previewText = state.text
+    }
+}
+
+private fun TextInputState.replaceSelection(insertText: String): TextInputState {
+    val start = selectionStart.coerceIn(0, text.length)
+    val end = selectionEnd.coerceIn(0, text.length)
+    val rangeStart = minOf(start, end)
+    val rangeEnd = maxOf(start, end)
+    val newText = text.substring(0, rangeStart) + insertText + text.substring(rangeEnd)
+    val cursor = rangeStart + insertText.length
+    return copy(
+        text = newText,
+        selectionStart = cursor,
+        selectionEnd = cursor,
+        compositionStart = TextInputState.NO_COMPOSITION,
+        compositionEnd = TextInputState.NO_COMPOSITION,
+        length = null
+    )
+}
+
+private fun ViewContainer<*, *>.PreviewBlock(title: String, textProvider: () -> String) {
+    View {
+        attr {
+            marginTop(12f)
+            marginLeft(16f)
+            marginRight(16f)
+            minHeight(48f)
+            borderRadius(8f)
+            backgroundColor(Color.WHITE)
+            paddingLeft(12f)
+            paddingRight(12f)
+            paddingTop(12f)
+            paddingBottom(12f)
+        }
+        Text {
+            attr {
+                val text = textProvider()
+                text(title + if (text.isEmpty()) "（暂无内容）" else text)
+                fontSize(16f)
+                color(if (text.isEmpty()) Color(0xFFCCCCCC) else Color(0xFF333333))
+                textPostProcessor("input")
+            }
+        }
+    }
+}

--- a/docs/API/components/input.md
+++ b/docs/API/components/input.md
@@ -458,6 +458,107 @@ internal class TestPage : BasePager() {
 }
 ```
 
+### textPostProcessor方法 <Badge text="仅Android支持" type="warn"/>
+
+声明文本后置处理器名称，用于将文本中的特定标记（如表情短码）替换为富文本样式（如 `ImageSpan`）。具体处理逻辑需在 Android 端实现 [`IKRTextPostProcessorAdapter`](../../DevGuide/text-post-processor-guide.md) 适配器。
+
+<div class="table-01">
+
+**textPostProcessor方法**
+
+| 参数  | 描述     | 类型 |
+|:----|:-------|:--|
+| processor | 处理器名称，由业务自定义并在 Android 适配器中实现对应逻辑  | String |
+
+</div>
+
+:::tip 常见处理器名称
+- `"emoji"` / `"input"` — 将 `[smile]` 等短码替换为表情图片（需在适配器中实现映射）
+- 其他名称可自由定义，只要在适配器的 `when` 分支中处理即可
+:::
+
+**示例**
+
+```kotlin{14}
+@Page("demo_page")
+internal class TestPage : BasePager() {
+    override fun body(): ViewBuilder {
+        return {
+            attr {
+                allCenter()
+            }
+
+            Input {
+                attr {
+                    size(200f, 40f)
+                    placeholder("输入表情短码如 [smile]")
+                    textPostProcessor("input")
+                }
+            }
+        }
+    }
+}
+```
+
+> 完整实现请参考 [文本后置处理器实践指南](../../DevGuide/text-post-processor-guide.md)。
+
+### textInputState方法 <Badge text="2.15+" type="info"/>
+
+原子化设置输入框的 raw text、selection、composition 状态。通过 `TextInputState` 数据类一次性设置文本内容和光标/选区位置，避免分开设置导致的闪烁问题。
+
+<div class="table-01">
+
+**textInputState方法**
+
+| 参数  | 描述     | 类型 |
+|:----|:-------|:--|
+| state | 文本输入状态对象  | TextInputState |
+
+</div>
+
+:::tip 关于 TextInputState
+`TextInputState` 是用于 Core/Render 通信的跨层文本输入状态数据类，包含以下字段：
+- `text`: 当前输入的文本（String）
+- `selectionStart`: 选区起始位置（Int）
+- `selectionEnd`: 选区结束位置（Int）
+- `compositionStart`: 组合输入起始位置（Int，使用 `NO_COMPOSITION = -1` 表示无组合输入）
+- `compositionEnd`: 组合输入结束位置（Int）
+
+详细文档请参考 [TextInputState 数据结构说明](#textinputstate-数据结构)。
+:::
+
+**示例**
+
+```kotlin{14}
+@Page("demo_page")
+internal class TestPage : BasePager() {
+    var inputState by observable(TextInputState(text = ""))
+    
+    override fun body(): ViewBuilder {
+        return {
+            attr {
+                allCenter()
+            }
+
+            Input {
+                attr {
+                    size(200f, 40f)
+                    placeholder("输入文字")
+                    textInputState(inputState) // 绑定状态
+                }
+                event {
+                    textInputStateChange { state ->
+                        inputState = state // 状态变化时更新
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+> 常见使用场景：表情短码插入、@提及、光标定位等需要精确控制文本和选区位置的功能。
+
 ### inputSpans方法<Badge text="鸿蒙实现中" type="warn"/><Badge text="H5实现中" type="warn"/> <Badge text="微信小程序实现中" type="warn"/>
 
 设置输入文本的文本样式配合`textDidChange`来更改`spans`实现输入框富文本化。
@@ -592,6 +693,91 @@ internal class TestPage : BasePager() {
                     }
                 }
             }
+        }
+    }
+}
+```
+
+### textInputStateChange事件 <Badge text="2.15+" type="info"/>
+
+``textInputStateChange``事件在 raw text、selection 或 composition 发生变化时触发。与 `textDidChange` 不同，该事件会返回完整的 `TextInputState` 对象，包含文本内容和选区信息。
+
+<div class="table-01">
+
+**TextInputState**
+
+| 参数  | 描述     | 类型 |
+|:----|:-------|:--|
+| text | 当前输入的文本  | String |
+| selectionStart | 选区起始位置  | Int |
+| selectionEnd | 选区结束位置  | Int |
+| compositionStart | 组合输入起始位置（iOS拼音输入时有效）  | Int |
+| compositionEnd | 组合输入结束位置（iOS拼音输入时有效）  | Int |
+
+</div>
+
+:::tip 使用建议
+- 如果需要同时获取文本和选区变化，使用 `textInputStateChange`
+- 如果只需要文本变化，使用 `textDidChange`
+- 建议设置 `isSyncEdit = true`（默认值）以实现同步编辑，避免异步更新带来的光标跳动
+:::
+
+**示例**
+
+```kotlin{14-16}
+Input {
+    attr {
+        size(200f, 40f)
+        placeholder("输入文字")
+        textInputState(inputState)
+    }
+    event {
+        textInputStateChange { state ->
+            // state 包含 text, selectionStart, selectionEnd, compositionStart, compositionEnd
+            inputState = state
+            previewText = state.text
+        }
+    }
+}
+```
+
+### selectionChange事件 <Badge text="2.15+" type="info"/>
+
+``selectionChange``事件在选区范围发生变化时触发（不需要文本发生变化）。例如：用户移动光标、选择文本等操作会触发此事件。返回完整的 `TextInputState` 对象。
+
+<div class="table-01">
+
+**TextInputState**
+
+| 参数  | 描述     | 类型 |
+|:----|:-------|:--|
+| text | 当前输入的文本（未变化）  | String |
+| selectionStart | 新的选区起始位置  | Int |
+| selectionEnd | 新的选区结束位置  | Int |
+| compositionStart | 组合输入起始位置  | Int |
+| compositionEnd | 组合输入结束位置  | Int |
+
+</div>
+
+:::tip 使用场景
+- 监听光标移动，实现 @提及 弹窗的触发
+- 监听选区变化，实现富文本工具栏的状态更新
+- 与 `textInputStateChange` 配合使用，分别处理「选区变化」和「文本+选区变化」
+:::
+
+**示例**
+
+```kotlin{14-16}
+Input {
+    attr {
+        size(200f, 40f)
+        placeholder("输入文字")
+    }
+    event {
+        selectionChange { state ->
+            // 光标或选区发生变化，但文本未变化
+            currentSelectionStart = state.selectionStart
+            currentSelectionEnd = state.selectionEnd
         }
     }
 }
@@ -988,6 +1174,97 @@ internal class TestPage : BasePager() {
     private fun getCursor() {
         ref.view?.cursorIndex {
             KLog.i("Input", "index: $it")
+        }
+    }
+}
+```
+
+### getTextInputState方法 <Badge text="2.15+" type="info"/>
+
+从原生输入框获取当前的 raw text、selection、composition 状态。用于获取输入框的实时状态。
+
+<div class="table-01">
+
+**getTextInputState方法**
+
+| 参数  | 描述     | 类型 |
+|:----|:-------|:--|
+| callback | 回调函数，返回 TextInputState 对象  | (TextInputState) -> Unit |
+
+</div>
+
+:::tip 使用场景
+- 在按钮点击等事件中，获取当前输入框的完整状态
+- 配合 `setTextInputState()` 实现状态的读取-修改-写入流程
+- 例如：插入表情时，先获取当前状态和选区，然后计算新的文本和光标位置
+:::
+
+**示例**
+
+```kotlin{20-24}
+@Page("demo_page")
+internal class TestPage : BasePager() {
+    lateinit var inputRef: ViewRef<InputView>
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            // ... UI布局
+        }
+    }
+
+    private fun insertText(text: String) {
+        inputRef.view?.getTextInputState { state ->
+            // 获取当前状态，计算新状态，然后设置
+            val newState = state.replaceSelection(text)
+            inputRef.view?.setTextInputState(newState)
+        }
+    }
+}
+```
+
+### setTextInputState方法 <Badge text="2.15+" type="info"/>
+
+原子化设置输入框的 raw text、selection、composition 状态。与 `textInputState()` 属性方法不同，此方法可以在任意时刻调用（不限于声明阶段）。
+
+<div class="table-01">
+
+**setTextInputState方法**
+
+| 参数  | 描述     | 类型 |
+|:----|:-------|:--|
+| state | 文本输入状态对象  | TextInputState |
+
+</div>
+
+:::tip 与 textInputState() 属性的区别
+- `textInputState()` 是属性方法，在声明阶段绑定状态，适合响应式更新
+- `setTextInputState()` 是实例方法，可以在任意时刻调用，适合事件处理中动态设置
+:::
+
+**示例**
+
+```kotlin{20-22}
+@Page("demo_page")
+internal class TestPage : BasePager() {
+    lateinit var inputRef: ViewRef<InputView>
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            // ... UI布局
+        }
+    }
+
+    private fun clearInput() {
+        // 清空输入框
+        inputRef.view?.setTextInputState(TextInputState(text = ""))
+    }
+    
+    private fun insertEmoji(shortcode: String) {
+        inputRef.view?.getTextInputState { state ->
+            val newState = state.replaceSelection(shortcode)
+            inputRef.view?.setTextInputState(newState)
         }
     }
 }

--- a/docs/API/components/text-area.md
+++ b/docs/API/components/text-area.md
@@ -1,15 +1,158 @@
 # TextArea(多行输入框)
 
-``TextArea``为多行输入框组件, 该组件除了支持多行输入特性外, 大部分属性、事件和方法都与``Input``组件一样。
+``TextArea`` 为多行输入框组件，支持多行文本输入、滚动等特性。
+
+## 与 Input 组件的差异
+
+`TextArea` 与 `Input` 组件大部分属性、事件和方法都相同，主要差异如下：
+
+| 特性  | Input | TextArea |
+|:----|:-----|:---------|
+| 输入模式 | 单行输入 | 多行输入 |
+| 不支持的属性 | - | `imeNoFullscreen`、`enablesReturnKeyAutomatically` |
+| 不支持的事件 | - | `inputReturn`、`onTextReturn` |
+| 特有属性 | - | `lineHeight()` |
 
 ## 属性
 
-支持除imeNoFullscreen、enablesReturnKeyAutomatically以外[Input组件所有属性](input.md#属性)
+### 基础属性
+
+支持所有[基础属性](basic-attr-event.md#基础属性)
+
+### lineHeight方法 <Badge text="2.15+" type="info"/>
+
+设置多行文本的行高。
+
+<div class="table-01">
+
+**lineHeight方法**
+
+| 参数  | 描述     | 类型 |
+|:----|:-------|:--|
+| lineHeight | 行高值（px）  | Float |
+
+</div>
+
+**示例**
+
+```kotlin{10}
+TextArea {
+    attr {
+        size(200f, 100f)
+        lineHeight(24f) // 设置行高为 24px
+        fontSize(16f)
+    }
+}
+```
+
+### textInputState方法 <Badge text="2.15+" type="info"/>
+
+原子化设置输入框的 raw text、selection、composition 状态。具体说明请参考 [Input#textInputState](input.md#textinputstate方法)。
+
+### textPostProcessor方法
+
+声明文本后置处理器，用于表情短码替换等场景。具体说明请参考 [Input#textPostProcessor](input.md#textpostprocessor方法)。
+
+### 其他属性
+
+`TextArea` 支持除 `imeNoFullscreen`、`enablesReturnKeyAutomatically` 以外 [Input 组件的所有属性](input.md#属性)。
+
+常用属性包括：
+- `text()` - 设置文本内容
+- `fontSize()` - 设置字体大小
+- `color()` - 设置文本颜色
+- `placeholder()` - 设置提示文本
+- `placeholderColor()` - 设置提示文本颜色
+- `tintColor()` - 设置光标颜色
+- `maxTextLength()` - 设置最大输入长度
+- `keyboardTypePassword()` / `keyboardTypeNumber()` / `keyboardTypeEmail()` - 设置键盘类型
+- `returnKeyTypeSearch()` / `returnKeyTypeSend()` / `returnKeyTypeDone()` 等 - 设置返回键类型
+- `autofocus()` - 设置自动获取焦点
+- `editable()` - 设置是否可编辑
+- `inputSpans()` - 设置富文本样式
 
 ## 事件
 
-支持除了onTextReturn, inputReturn以外[Input组件所有事件](input.md#事件)
+`TextArea` 支持除了 `inputReturn`、`onTextReturn` 以外 [Input 组件的所有事件](input.md#事件)。
+
+常用事件包括：
+- `textDidChange` - 文本变化事件
+- `textInputStateChange` - 文本输入状态变化事件（返回 TextInputState）
+- `selectionChange` - 选区变化事件（返回 TextInputState）
+- `inputFocus` - 获取焦点事件
+- `inputBlur` - 失去焦点事件
+- `keyboardHeightChange` - 键盘高度变化事件
+- `textLengthBeyondLimit` - 输入超出限制事件
 
 ## 方法
 
-支持[Input组件所有方法](input.md#方法)
+`TextArea` 支持 [Input 组件的所有方法](input.md#方法)。
+
+常用方法包括：
+- `setText()` - 设置文本内容
+- `focus()` - 获取焦点
+- `blur()` - 失去焦点
+- `cursorIndex()` - 获取光标位置
+- `setCursorIndex()` - 设置光标位置
+- `getTextInputState()` - 获取文本输入状态
+- `setTextInputState()` - 设置文本输入状态
+
+## 完整示例
+
+以下是一个使用 `TextArea` 实现表情插入功能的完整示例：
+
+```kotlin
+@Page("TextAreaDemo")
+internal class TextAreaDemo : Pager() {
+    private var inputState: TextInputState by observable(TextInputState(text = ""))
+    private var inputRef: ViewRef<TextAreaView>? = null
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            View {
+                attr {
+                    size(pagerData.pageViewWidth, pagerData.pageViewHeight)
+                    flexDirectionColumn()
+                }
+
+                TextArea {
+                    ref { ctx.inputRef = it }
+                    attr {
+                        flex(1f)
+                        placeholder("输入文字或点击表情按钮")
+                        fontSize(16f)
+                        lineHeight(24f) // TextArea 特有属性
+                        textPostProcessor("input")
+                        textInputState(ctx.inputState)
+                    }
+                    event {
+                        textInputStateChange { state ->
+                            ctx.inputState = state
+                        }
+                        selectionChange { state ->
+                            // 处理选区变化
+                        }
+                    }
+                }
+
+                Button {
+                    attr { titleAttr { text("插入表情") } }
+                    event {
+                        click {
+                            ctx.insertEmoji("[smile]")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun insertEmoji(shortcode: String) {
+        inputRef?.view?.getTextInputState { state ->
+            val newState = state.replaceSelection(shortcode)
+            inputRef?.view?.setTextInputState(newState)
+        }
+    }
+}
+```

--- a/docs/API/components/text.md
+++ b/docs/API/components/text.md
@@ -1049,6 +1049,50 @@ internal class TestPage : BasePager() {
 
 :::
 
+### textPostProcessor方法 <Badge text="仅Android支持" type="warn"/>
+
+声明文本后置处理器名称，用于将文本中的特定标记（如表情短码）替换为富文本样式（如 `ImageSpan`）。具体处理逻辑需在 Android 端实现 [`IKRTextPostProcessorAdapter`](../../DevGuide/text-post-processor-guide.md) 适配器。
+
+<div class="table-01">
+
+**textPostProcessor方法**
+
+| 参数  | 描述     | 类型 |
+|:----|:-------|:--|
+| processor | 处理器名称，由业务自定义并在 Android 适配器中实现对应逻辑  | String |
+
+</div>
+
+:::tip 常见处理器名称
+- `"emoji"` / `"input"` — 将 `[smile]` 等短码替换为表情图片（需在适配器中实现映射）
+- 其他名称可自由定义，只要在适配器的 `when` 分支中处理即可
+:::
+
+**示例**
+
+```kotlin{14}
+@Page("demo_page")
+internal class TestPage : BasePager() {
+    override fun body(): ViewBuilder {
+        return {
+            attr {
+                allCenter()
+            }
+
+            Text {
+                attr {
+                    text("Hello [smile] World")
+                    fontSize(20f)
+                    textPostProcessor("emoji")
+                }
+            }
+        }
+    }
+}
+```
+
+> 完整实现请参考 [文本后置处理器实践指南](../../DevGuide/text-post-processor-guide.md)。
+
 ## 事件
 
 支持所有[基础事件](basic-attr-event.md#基础事件)

--- a/docs/DevGuide/text-post-processor-guide.md
+++ b/docs/DevGuide/text-post-processor-guide.md
@@ -1,0 +1,566 @@
+# 文本后置处理器实践指南
+
+本文介绍如何在 Kuikly 中使用文本后置处理器（Text Post Processor），实现输入框/文本组件的自定义表情、链接高亮、文本格式化等效果。
+
+:::tip 适用场景
+- **自定义表情**：将 `[smile]` 等短码实时渲染为表情图片
+- **链接高亮**：自动识别 URL 并添加下划线/点击事件
+- **文本格式化**：手机号分段显示（`138-1234-5678`）、金额千分位分隔等
+- **敏感信息脱敏**：密码掩码、身份证号部分隐藏
+:::
+
+## 整体流程
+
+使用文本后置处理器需要三步：
+
+```
+1. DSL 声明 processor 名称  →  2. Android 实现 IKRTextPostProcessorAdapter  →  3. 注册适配器
+```
+
+## DSL 使用方式
+
+### 自研 DSL
+
+在 `Input` 或 `Text` 组件上通过 `textPostProcessor()` 属性声明处理器名称：
+
+```kotlin{14,22}
+@Page("emoji_demo")
+internal class EmojiDemoPage : BasePager() {
+    override fun body(): ViewBuilder {
+        return {
+            attr {
+                allCenter()
+            }
+
+            // Input with post-processor
+            Input {
+                attr {
+                    size(300f, 48f)
+                    placeholder("输入 [smile] 试试")
+                    textPostProcessor("input")
+                }
+            }
+
+            // Text with post-processor (for preview)
+            Text {
+                attr {
+                    text("Hello [smile] World")
+                    fontSize(16f)
+                    textPostProcessor("emoji")
+                }
+            }
+        }
+    }
+}
+```
+
+### Compose DSL
+
+Compose DSL 使用 `textPostProcessor()` Modifier：
+
+```kotlin{12}
+@Composable
+fun EmojiInputDemo() {
+    var text by remember { mutableStateOf("") }
+
+    Column {
+        TextField(
+            value = text,
+            onValueChange = { text = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .textPostProcessor("input"),
+            placeholder = { Text("输入表情短码") }
+        )
+
+        // Preview with processor
+        Text(
+            text = text,
+            modifier = Modifier.textPostProcessor("emoji")
+        )
+    }
+}
+```
+
+:::tip processor 名称说明
+- `"emoji"`、`"input"` 是示例名称，**名称由业务自定义**
+- 同一页面中不同组件可以使用不同 processor 名称，在适配器中按名称路由到不同处理逻辑
+- 未在适配器中实现的 processor 名称会透传原文本，不会报错
+:::
+
+## Android 适配器实现
+
+### 1. 创建适配器类
+
+新建一个类实现 `IKRTextPostProcessorAdapter` 接口，在 `onTextPostProcess` 方法中处理文本：
+
+```kotlin
+package com.example.myapp.adapter
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.text.style.DynamicDrawableSpan
+import android.text.style.ImageSpan
+import androidx.core.content.ContextCompat
+import com.tencent.kuikly.core.render.android.adapter.IKRTextPostProcessorAdapter
+import com.tencent.kuikly.core.render.android.adapter.TextPostProcessorInput
+import com.tencent.kuikly.core.render.android.adapter.TextPostProcessorOutput
+import com.tencent.kuikly.core.render.android.css.ktx.toPxF
+
+/**
+ * 文本后置处理器适配器示例
+ * 支持：emoji 短码替换、链接高亮
+ */
+class MyTextPostProcessorAdapter(context: Context) : IKRTextPostProcessorAdapter {
+
+    private val appContext: Context = context.applicationContext
+
+    companion object {
+        // 短码 → drawable 资源映射
+        private val EMOJI_MAP = mapOf(
+            "[smile]" to R.drawable.emoji_smile,
+            "[heart]" to R.drawable.emoji_heart,
+            "[thumbup]" to R.drawable.emoji_thumbup,
+        )
+
+        // 匹配 [xxx] 格式的短码
+        private val EMOJI_PATTERN = "\\[([^\\]]+)\\]".toRegex()
+
+        // 匹配 URL
+        private val URL_PATTERN = "https?://[^\\s]+".toRegex()
+    }
+
+    override fun onTextPostProcess(
+        kuiklyRenderContext: com.tencent.kuikly.core.render.android.IKuiklyRenderContext?,
+        inputParams: TextPostProcessorInput
+    ): TextPostProcessorOutput {
+        return when (inputParams.processor) {
+            "emoji", "input" -> processEmoji(inputParams)
+            "link" -> processLink(inputParams)
+            else -> TextPostProcessorOutput(inputParams.sourceText)
+        }
+    }
+
+    /**
+     * Emoji 处理：将 [smile] 等短码替换为 ImageSpan 图片
+     */
+    private fun processEmoji(inputParams: TextPostProcessorInput): TextPostProcessorOutput {
+        val sourceText = inputParams.sourceText?.toString() ?: return TextPostProcessorOutput("")
+
+        val matches = EMOJI_PATTERN.findAll(sourceText).toList()
+        if (matches.isEmpty()) {
+            return TextPostProcessorOutput(SpannableStringBuilder(sourceText))
+        }
+
+        // 表情大小基于当前字体大小计算
+        val fontSize = inputParams.textProps.fontSize.toPxF()
+        val emojiSize = fontSize.toInt().coerceAtLeast(48)
+
+        val spannable = SpannableStringBuilder(sourceText)
+
+        for (match in matches) {
+            val shortcode = match.value
+            val drawableRes = EMOJI_MAP[shortcode]
+            if (drawableRes != null) {
+                val drawable: Drawable? = ContextCompat.getDrawable(appContext, drawableRes)
+                drawable?.setBounds(0, 0, emojiSize, emojiSize)
+                if (drawable != null) {
+                    spannable.setSpan(
+                        ImageSpan(drawable, DynamicDrawableSpan.ALIGN_CENTER),
+                        match.range.first,
+                        match.range.last + 1,
+                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                }
+            }
+        }
+
+        return TextPostProcessorOutput(spannable)
+    }
+
+    /**
+     * 链接处理：识别 URL 并添加下划线（示例）
+     */
+    private fun processLink(inputParams: TextPostProcessorInput): TextPostProcessorOutput {
+        val sourceText = inputParams.sourceText?.toString() ?: return TextPostProcessorOutput("")
+        // ... 链接处理逻辑
+        return TextPostProcessorOutput(sourceText)
+    }
+
+    // 兼容旧接口（保留即可）
+    @Deprecated("Use onTextPostProcess(kuiklyRenderContext, inputParams) instead")
+    override fun onTextPostProcess(inputParams: TextPostProcessorInput): TextPostProcessorOutput {
+        return onTextPostProcess(null, inputParams)
+    }
+}
+```
+
+### 2. 注册适配器
+
+在 Application 初始化时，通过 `KuiklyRenderAdapterManager` 注册：
+
+```kotlin
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        // 注册文本后置处理器适配器
+        KuiklyRenderAdapterManager.krTextPostProcessorAdapter = MyTextPostProcessorAdapter(this)
+    }
+}
+```
+
+:::warning 重要提醒
+必须在 **Application.onCreate()** 中注册，确保在页面创建前完成初始化。
+:::
+
+## 关键实现细节
+
+### 为什么返回 SpannableStringBuilder？
+
+`Input`（EditText）组件需要接收 `Editable` 类型的文本才能正常编辑。`SpannableStringBuilder` 同时实现了 `Editable` 和 `Spannable` 接口，因此既能保留 ImageSpan 等样式，又能支持光标定位和文本编辑。
+
+| 返回类型 | 适用场景 | 说明 |
+|:----|:-------|:--|
+| `SpannableStringBuilder` | `Input` 组件 | 支持编辑 + 富文本样式 |
+| `SpannableString` | `Text` 组件展示 | 只读展示场景 |
+| 普通 `String` |  passthrough | 不做任何处理时直接返回原文本 |
+
+### 表情尺寸动态计算
+
+建议基于当前字体大小计算表情尺寸，保证不同字号下表情比例协调：
+
+```kotlin
+val fontSize = inputParams.textProps.fontSize.toPxF()
+val emojiSize = fontSize.toInt().coerceAtLeast(48) // 最小 48px，防止过小
+```
+
+### 保留原始字符
+
+`ImageSpan` 设置后会覆盖对应区域的文本渲染，但底层字符仍然保留。这意味着：
+
+- 用户看到的：😊（图片）
+- 实际存储的：`[smile]`
+- 业务回调获取的：`[smile]`（便于后端存储和跨端同步）
+
+### 多处理器路由
+
+当业务需要多种处理方式时，通过 `when` 分支按 `inputParams.processor` 路由：
+
+```kotlin
+override fun onTextPostProcess(
+    kuiklyRenderContext: IKuiklyRenderContext?,
+    inputParams: TextPostProcessorInput
+): TextPostProcessorOutput {
+    return when (inputParams.processor) {
+        "emoji", "input" -> processEmoji(inputParams)
+        "link" -> processLink(inputParams)
+        "format" -> processFormat(inputParams)
+        else -> TextPostProcessorOutput(inputParams.sourceText) // 未知类型透传
+    }
+}
+```
+
+## 完整示例：自定义表情输入
+
+下面是一个完整的自定义表情输入 Demo，包含表情面板和实时预览：
+
+```kotlin
+@Page("EmojiTextInputDemo")
+internal class EmojiTextInputDemo : Pager() {
+
+    private var inputText: String by observable("")
+    private val emojiShortcodes = listOf("[smile]", "[heart]", "[thumbup]")
+    private val emojiLabels = listOf("😊", "❤️", "👍")
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            View {
+                attr {
+                    size(pagerData.pageViewWidth, pagerData.pageViewHeight)
+                    backgroundColor(Color(0xFFF5F5F5))
+                    flexDirectionColumn()
+                }
+
+                // 输入框
+                Input {
+                    attr {
+                        text(ctx.inputText)
+                        placeholder("输入文字或点击表情")
+                        textPostProcessor("input")
+                    }
+                    event {
+                        textDidChange { params ->
+                            ctx.inputText = params.text
+                        }
+                    }
+                }
+
+                // 预览（使用 Text 组件）
+                Text {
+                    attr {
+                        text("预览：${ctx.inputText}")
+                        textPostProcessor("emoji")
+                    }
+                }
+
+                // 表情按钮
+                View {
+                    attr { flexDirectionRow() }
+                    for (i in ctx.emojiShortcodes.indices) {
+                        View {
+                            event {
+                                click {
+                                    ctx.inputText += ctx.emojiShortcodes[i]
+                                }
+                            }
+                            Text {
+                                attr {
+                                    text(ctx.emojiLabels[i])
+                                    fontSize(24f)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+## 常见问题
+
+### Q: 设置 textPostProcessor 后输入框不显示表情？
+
+A: 检查以下几点：
+1. **适配器是否已注册** — 确认在 Application.onCreate() 中设置了 `KuiklyRenderAdapterManager.krTextPostProcessorAdapter`
+2. **processor 名称是否匹配** — DSL 中 `textPostProcessor("xxx")` 的名称要与适配器 `when` 分支中的名称一致
+3. **drawable 资源是否存在** — 检查 `R.drawable.xxx` 是否引用正确
+
+### Q: 表情显示位置偏移/大小不对？
+
+A: 确认 `drawable.setBounds(0, 0, size, size)` 已正确设置，并且 `ImageSpan` 使用了 `DynamicDrawableSpan.ALIGN_CENTER` 对齐方式。
+
+### Q: 为什么 EditText 需要返回 Editable？
+
+A: EditText 内部使用 `Editable` 接口管理文本和 Span。如果返回普通 String，EditText 会丢失 Span 信息，导致表情图片无法显示。`SpannableStringBuilder` 是 `Editable` 的子类，因此是最佳选择。
+
+### Q: 可以支持网络图片作为表情吗？
+
+A: 可以。在适配器中拿到网络图片 URL 后，使用 Glide/Picasso 等库加载为 `Drawable`，再创建 `ImageSpan`。注意需要在图片加载完成后刷新文本。
+
+```kotlin
+// 异步加载网络图片表情示例
+glide.load(url).into(object : CustomTarget<Drawable>() {
+    override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
+        resource.setBounds(0, 0, emojiSize, emojiSize)
+        spannable.setSpan(ImageSpan(resource), start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        // 通知 UI 刷新
+        editText.text = spannable
+    }
+    // ...
+})
+```
+
+## 迁移：从追加式输入到光标插入
+
+旧写法通常直接拼接短码，只能追加到末尾：
+
+```kotlin
+EmojiGrid { shortcode ->
+    text += shortcode
+}
+```
+
+新的 Compose DSL 推荐使用 `TextFieldState.edit {}`，框架会根据当前 selection 替换选区或在光标处插入：
+
+```kotlin
+val state = rememberTextFieldState()
+
+BasicTextField(
+    state = state,
+    outputTransformation = TextPostProcessorOutputTransformation("input"),
+)
+
+EmojiGrid { shortcode ->
+    state.edit {
+        replace(selection.start, selection.end, shortcode)
+    }
+}
+```
+
+自研 DSL 可使用 `TextInputState` 保存 raw text 与 selection：
+
+```kotlin
+private var inputState by observable(TextInputState(text = ""))
+
+Input {
+    attr {
+        textPostProcessor("input")
+        textInputState(inputState)
+    }
+    event {
+        textInputStateChange { state ->
+            inputState = state
+        }
+    }
+}
+```
+
+> `textPostProcessor` 仍然保留；`TextPostProcessorOutputTransformation` 是 Compose DSL 对现有渲染链路的声明式包装。
+
+## TextInputState 数据结构
+
+`TextInputState` 是用于 Core/Render 通信的跨层文本输入状态数据类，用于在 DSL 层精确控制输入框的文本内容、光标位置和组合输入状态。
+
+### 字段说明
+
+| 字段  | 类型 | 说明 |
+|:----|:-----|:-----|
+| `text` | `String` | 当前输入的文本内容（raw text，如表情短码 `[smile]`） |
+| `selectionStart` | `Int` | 选区起始位置（光标位置或选区开始） |
+| `selectionEnd` | `Int` | 选区结束位置（与 selectionStart 相等表示无选区） |
+| `compositionStart` | `Int` | 组合输入起始位置（如 iOS 拼音输入时高亮的拼音范围） |
+| `compositionEnd` | `Int` | 组合输入结束位置 |
+| `length` | `Int?` | 文本长度（可选，与 `maxTextLength` 的计算方式一致） |
+
+### 常量
+
+| 常量  | 值 | 说明 |
+|:----|:-----|:-----|
+| `NO_COMPOSITION` | `-1` | 表示当前没有组合输入（如拼音输入时的拼音高亮状态） |
+
+### 构造方法
+
+```kotlin
+TextInputState(
+    text: String = "",
+    selectionStart: Int = 0,
+    selectionEnd: Int = 0,
+    compositionStart: Int = NO_COMPOSITION,
+    compositionEnd: Int = NO_COMPOSITION,
+    length: Int? = null
+)
+```
+
+### encode/decode 方法
+
+`TextInputState` 内部使用 `encode()` 和 `decode()` 方法进行 JSON 序列化和反序列化，用于跨层通信。
+
+```kotlin
+// 内部使用，一般无需直接调用
+val jsonString = state.encode()  // 编码为 JSON 字符串
+val state = TextInputState.decode(jsonObject)  // 从 JSONObject 解码
+```
+
+### replaceSelection 扩展函数
+
+`replaceSelection()` 是一个便捷的扩展函数，用于在当前选区位置插入或替换文本，并自动计算新的光标位置。
+
+```kotlin
+/**
+ * 在当前选区位置插入或替换文本
+ * @param insertText 要插入的文本
+ * @return 新的 TextInputState 对象
+ */
+fun TextInputState.replaceSelection(insertText: String): TextInputState
+```
+
+**实现逻辑**：
+
+```kotlin
+private fun TextInputState.replaceSelection(insertText: String): TextInputState {
+    val start = selectionStart.coerceIn(0, text.length)
+    val end = selectionEnd.coerceIn(0, text.length)
+    val rangeStart = minOf(start, end)
+    val rangeEnd = maxOf(start, end)
+    val newText = text.substring(0, rangeStart) + insertText + text.substring(rangeEnd)
+    val cursor = rangeStart + insertText.length
+    return copy(
+        text = newText,
+        selectionStart = cursor,
+        selectionEnd = cursor,
+        compositionStart = TextInputState.NO_COMPOSITION,
+        compositionEnd = TextInputState.NO_COMPOSITION,
+        length = null
+    )
+}
+```
+
+**使用示例**：
+
+```kotlin
+// 插入表情短码
+private fun insertEmoji(shortcode: String) {
+    inputRef?.view?.getTextInputState { state ->
+        val newState = state.replaceSelection(shortcode)
+        inputRef?.view?.setTextInputState(newState)
+    }
+}
+```
+
+### 完整使用示例
+
+```kotlin
+@Page("TextInputStateDemo")
+internal class TextInputStateDemo : Pager() {
+    private var inputState: TextInputState by observable(TextInputState(text = ""))
+    private var inputRef: ViewRef<InputView>? = null
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            Input {
+                ref { ctx.inputRef = it }
+                attr {
+                    textPostProcessor("input")
+                    textInputState(ctx.inputState)
+                }
+                event {
+                    // 监听文本和选区变化
+                    textInputStateChange { state ->
+                        ctx.inputState = state
+                    }
+                    // 监听选区变化（不需要文本变化）
+                    selectionChange { state ->
+                        ctx.inputState = state
+                    }
+                }
+            }
+
+            Button {
+                attr { titleAttr { text("插入 [smile]") } }
+                event {
+                    click {
+                        ctx.insertText("[smile]")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun insertText(text: String) {
+        val currentRef = inputRef
+        if (currentRef == null) {
+            // 组件未挂载，直接修改状态
+            inputState = inputState.replaceSelection(text)
+        } else {
+            // 从原生输入框获取最新状态，然后插入
+            currentRef.view?.getTextInputState { state ->
+                inputState = state.replaceSelection(text)
+            }
+        }
+    }
+}
+```
+
+## 参考
+
+- [Input 组件文档](../API/components/input.md)
+- [TextArea 组件文档](../API/components/text-area.md)
+- [Text 组件文档](../API/components/text.md)
+- [扩展原生 UI 文档](./expand-native-ui.md)

--- a/docs/sidebar/zh.ts
+++ b/docs/sidebar/zh.ts
@@ -106,6 +106,7 @@ export const zhSidebar = sidebar({
                         },
                         "view-external-prop.md",
                         "text-measure.md",
+                        "text-post-processor-guide.md",
                         "get-component-size-and-position.md",
                         "protobuf.md",
                         "thread-and-coroutines.md",

--- a/openspec/changes/textfield-custom-emoji/.openspec.yaml
+++ b/openspec/changes/textfield-custom-emoji/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/textfield-custom-emoji/design.md
+++ b/openspec/changes/textfield-custom-emoji/design.md
@@ -1,0 +1,259 @@
+## Context
+
+This change applies to both DSL modes:
+
+- Compose DSL: primary API alignment target, matching Compose Foundation 1.7.x state-based TextField semantics under Kuikly package names.
+- Self DSL: semantic alignment through `TextInputState` and state-change events on `Input` / `TextArea`, not API-shape equivalence with Compose.
+
+Current state:
+
+- Compose `CoreTextField` sends only `value.text` to native input views.
+- Compose `onValueChange` reconstructs `TextFieldValue(it.text)` and drops selection/composition.
+- Core has `cursorIndex` / `setCursorIndex`, but no selection range, composition range, or atomic text+selection state payload.
+- Latest custom emoji commit added `textPostProcessor` on Compose modifiers and self-DSL `InputAttr`, plus Android `EditText` `ImageSpan` rendering in `KRTextFieldView`.
+- Current emoji demos append shortcode text to the end because Kotlin cannot observe the current native cursor.
+
+NativeBridge interactions required:
+
+- Kotlin core sends `setTextInputState` to render views with raw text, selection start/end, and composition start/end.
+- Kotlin core receives `textInputStateChange` from render views with raw text, selection, composition, and optional length.
+- Kotlin core receives `selectionChange` when user moves cursor/selection without text changes.
+- Render layers MUST convert platform display coordinates back to raw-text coordinates before firing events.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve existing `textPostProcessor` custom emoji behavior and documentation.
+- Add raw text + selection + composition synchronization through `TextInputState`.
+- Make `TextFieldValue` callbacks include selection/composition.
+- Add Kuikly Compose `TextFieldState`, `TextFieldBuffer`, `InputTransformation`, and `OutputTransformation` target APIs.
+- Bridge `textPostProcessor` into `OutputTransformation` for custom emoji so existing Android `ImageSpan` logic is reused.
+- Support insertion/replacement at current cursor or selected range using official-aligned state editing.
+- Define behavior for Android, iOS, HarmonyOS, Web, miniApp, and macOS with explicit degradation for unsupported composition APIs.
+
+**Non-Goals:**
+
+- Do not import or delegate to AndroidX Foundation TextField implementation directly.
+- Do not delete `Modifier.textPostProcessor()` or `InputAttr.textPostProcessor()`.
+- Do not require full IME composition parity on every platform in the first implementation.
+- Do not introduce a full cross-platform inline content replacement for every rich text use case in the first phase.
+- Do not change unrelated Text/RichText rendering except for shared post-processor compatibility.
+
+## Decisions
+
+### Decision 1: Introduce `TextInputState` as the core/render payload
+
+Use an internal framework payload rather than exposing `TextFieldState` through the NativeBridge.
+
+Rationale:
+
+- `TextFieldState` is a Compose-layer API with snapshot semantics.
+- Self DSL needs a plain state object that can be stored with `observable`.
+- Render layers only need raw text, selection, composition, and length metadata.
+
+Alternative considered: use `TextFieldValue` directly in core. Rejected because core must not depend on Compose UI text types and must also support self DSL.
+
+### Decision 2: Keep `textPostProcessor` as a compatibility and rendering backend
+
+The latest custom emoji commit already provides Android runtime behavior and docs. The first transformation implementation will wrap this path rather than replace it.
+
+Rationale:
+
+- Avoids regressing existing demos and Android behavior.
+- Allows `OutputTransformation` to become the official-aligned API while still using platform-native spans/attachments.
+- Gives iOS/OHOS/Web a clear parity target.
+
+Alternative considered: replace `textPostProcessor` with a new inline content protocol immediately. Rejected due to cross-platform complexity and unnecessary churn.
+
+### Decision 3: Compose DSL gets official-aligned API names under Kuikly packages
+
+Add APIs such as `rememberTextFieldState`, `TextFieldState`, `TextFieldBuffer`, `InputTransformation`, and `OutputTransformation` under `com.tencent.kuikly.compose.*` packages.
+
+Rationale:
+
+- Kuikly Compose cannot mix official AndroidX Foundation rendering implementation.
+- Keeping official-like names reduces migration cost for Compose users.
+- Kuikly package names preserve module boundaries.
+
+Alternative considered: expose only `TextFieldValue` selection sync. Rejected because it does not cover official state-based APIs or transformation semantics.
+
+### Decision 4: All Kotlin-facing selection indices use raw text coordinates
+
+Even when display uses `ImageSpan`, `NSTextAttachment`, or formatted output, Kotlin state and callbacks use raw shortcode/text coordinates.
+
+Rationale:
+
+- Business state remains serializable and deterministic.
+- Existing Android emoji adapter preserves shortcode text in `Editable`.
+- iOS can use `KRTextAttachmentStringProtocol` and `p_outputText` to restore raw text.
+
+Alternative considered: expose display coordinates. Rejected because display coordinates vary by platform and transformation.
+
+### Decision 5: Implement in layers with value-based API first
+
+The safest path is `TextInputState` + `TextFieldValue` selection sync first, then state API and transformations.
+
+Rationale:
+
+- Cursor insertion for emoji can be validated before full transformation support.
+- Existing value-based demos continue to work.
+- Later `TextFieldState` can be layered over the same core/render state payload.
+
+## Implementation Status (Updated 2026-05-08)
+
+Based on commit `da232115` (feat: compose TextField support custom emoji), the implementation is partially complete with the following status:
+
+### ✅ Completed (Phase 1)
+
+**Core Module:**
+- `TextInputState` data model with raw text, selection, composition, and length metadata
+- `setTextInputState` and `getTextInputState` methods for `InputView`, `TextAreaView`, `AutoHeightTextAreaView`
+- `textInputStateChange` event support in `InputEvent` and `TextAreaEvent`
+- `selectionChange` event support for cursor/selection-only changes
+
+**Compose Module:**
+- `CoreTextField` sends `TextFieldValue.text`, `selection`, and `composition` through `TextInputState`
+- `CoreTextField` converts native `TextInputState` callbacks into full `TextFieldValue` callbacks
+- Loop prevention for programmatic state updates in `CoreTextField`
+- `TextFieldState` and `rememberTextFieldState` under Kuikly Compose packages
+- `TextFieldBuffer` with insert, replace, delete, append, selectAll, placeCursorAtEnd, and revert support
+- State-based `BasicTextField(state = ...)` overload wired to existing `CoreTextField`
+- `InputTransformation` with `then` and `maxLength` support
+- `TextPostProcessorOutputTransformation` bridge that reuses existing `textPostProcessor` semantics
+- Preserved `Modifier.textPostProcessor(processor)` as compatibility API
+
+**Android Renderer:**
+- `KRTextFieldView` supports `setTextInputState` and `getTextInputState`
+- `KRTextFieldView` emits `textInputStateChange` with text, selection, length, and composition metadata
+- `KRTextFieldView` emits `selectionChange` from `onSelectionChanged`
+- `KRTextFieldView` preserves `textPostProcessor` and `applyEmojiSpans` behavior
+- Programmatic text+selection updates do not force cursor to text end
+
+**Demo and Documentation:**
+- `TextFieldEmojiDemo` shows `textPostProcessor` usage and state/edit usage
+- `EmojiTextInputDemo` shows self DSL `TextInputState` usage
+- Compose demo for `TextFieldState.edit {}` inserting custom emoji at cursor
+- Text post-processor docs with compatibility and transformation-bridge guidance
+- Migration notes from append-style emoji input to state/edit insertion
+
+### ⏳ Pending (Future Phases)
+
+**Android Renderer:**
+- Raw/display mapping tests around `ImageSpan` deletion and cursor movement (Task 3.6)
+
+**iOS Renderer:** (All tasks 4.1-4.6 pending)
+- `css_setTextInputState` and `css_getTextInputState` for `KRTextAreaView` and `KRTextFieldView`
+- Emit `textInputStateChange` and `selectionChange` from iOS text delegates
+- Reuse `p_outputText` and cursor mapping for attachment display
+- Add input-view `textPostProcessor` application with `NSTextAttachment`
+- Guard `_ignoreTextDidChanged` paths against recursive callback loops
+
+**HarmonyOS Renderer:** (All tasks 5.1-5.4 pending)
+- State payload method handling for text input and text area views
+- Emit text and selection state changes using ArkUI selection APIs
+- Represent unsupported composition as empty composition metadata
+
+**Web and miniApp Renderers:** (All tasks 6.1-6.4 pending)
+- Web input/textarea state payload support using `selectionStart` and `selectionEnd`
+- Web composition event handling for composition metadata
+- miniApp best-effort state payload support
+
+**Additional Compose Demos:** (Tasks 7.3, 7.5, 7.6 pending)
+- Compose demo for `TextFieldValue` selection synchronization
+- Compose demo for `InputTransformation.maxLength` and digit-only filtering
+- Compose demo for `OutputTransformation` phone formatting
+
+**Validation:** (Most tasks 8.4-8.10 pending)
+- Manual verification of Android cursor insert, selected-range replace, emoji delete, paste, and Chinese IME cases
+- iOS build and verification
+- HarmonyOS build and verification
+- Web development build and verification
+- Compatibility verification for old APIs
+- `openspec validate --change textfield-custom-emoji --strict` before completion
+
+## File Changes by Module
+
+### `compose/`
+
+- `compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/CoreTextField.kt`
+  - Send and receive `TextInputState`.
+  - Preserve `TextFieldValue.selection` and `composition`.
+  - Add state-based overload wiring.
+- `compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/input/*.kt`
+  - Add `TextFieldState`, `TextFieldBuffer`, `InputTransformation`, `OutputTransformation`, and helpers.
+- `compose/src/commonMain/kotlin/com/tencent/kuikly/compose/extension/ModifierSetProp.kt`
+  - Keep `textPostProcessor` compatibility.
+
+### `core/`
+
+- `core/src/commonMain/kotlin/com/tencent/kuikly/core/views/InputView.kt`
+- `core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextAreaView.kt`
+- `core/src/commonMain/kotlin/com/tencent/kuikly/core/views/AutoHeightTextAreaView.kt`
+  - Add `TextInputState` methods and events.
+  - Keep old `textDidChange`, `cursorIndex`, and `setCursorIndex`.
+- `core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextInputState.kt`
+  - New file: `TextInputState` data model.
+
+### `core-render-android/`
+
+- `core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRTextFieldView.kt`
+  - Reuse existing `textPostProcessor` and `applyEmojiSpans`.
+  - Add selection range callbacks and state payload support.
+  - Prevent programmatic set loops.
+
+### `core-render-ios/` (Pending)
+
+- `core-render-ios/Extension/Components/KRTextAreaView.m`
+- `core-render-ios/Extension/Components/KRTextFieldView.m`
+  - Add state payload methods/events.
+  - Add post-processor support for input views via `NSTextAttachment` where needed.
+  - Use raw/display cursor mapping.
+
+### `core-render-ohos/` (Pending), `core-render-web/` (Pending)
+
+- Add text/selection/composition payload support where platform APIs allow.
+- Document composition limitations when unavailable.
+
+### `demo/`
+
+- `TextFieldEmojiDemo.kt` - Updated with `textPostProcessor` and state/edit usage.
+- `EmojiTextInputDemo.kt` - Shows self DSL `TextInputState` usage.
+- `ComposeAllSample.kt` - Added Demo entry.
+
+### `docs/`
+
+- `docs/API/components/input.md` - Updated with `textPostProcessor` and `TextInputState` API.
+- `docs/API/components/text-area.md` - Updated with state API.
+- `docs/API/components/text.md` - Added `textPostProcessor` documentation.
+- `docs/DevGuide/text-post-processor-guide.md` - New guide for text post-processor usage and migration.
+
+## Risks / Trade-offs
+
+- [Risk] Platform composition APIs differ or are unavailable → Mitigation: represent unsupported composition as `null` / `-1` and avoid destructive transformations during active composition.
+- [Risk] Raw/display offset mapping around emoji attachments is error-prone → Mitigation: start with shortcode-preserving spans/attachments and add focused tests for insert, delete, selection, and paste.
+- [Risk] Programmatic state updates can trigger callback loops → Mitigation: use render-side ignore flags and Compose-side last-state comparison.
+- [Risk] New state APIs may diverge from official Compose details → Mitigation: match Compose 1.7.x names and semantics where possible; document Kuikly-specific differences.
+- [Risk] Self DSL users may confuse `TextInputState` with official `TextFieldState` → Mitigation: keep naming explicit and document it as core/render payload semantics.
+- [Risk] iOS/HarmonyOS/Web/miniApp platforms not yet implemented → Mitigation: Phase 1 focuses on Android + Compose; other platforms can be added in future phases while keeping API compatibility.
+
+## Migration Plan
+
+1. Keep existing `textPostProcessor` APIs and demos working.
+2. Add `TextInputState` alongside old `textDidChange` APIs.
+3. Update Compose value-based `TextFieldValue` path to synchronize selection.
+4. Add `TextFieldState` and `edit {}` APIs on top of the same payload.
+5. Add `OutputTransformation` wrapper for current `textPostProcessor` custom emoji.
+6. Update demos and docs to show both current compatibility usage and recommended final usage.
+7. Rollback strategy: disable new state-based overloads and keep existing value-based text + `textPostProcessor` path unchanged.
+8. Future phases: implement iOS/HarmonyOS/Web/miniApp renderers following the same `TextInputState` payload protocol.
+
+## Open Questions
+
+- Which platforms must provide full composition range in the first implementation versus explicitly returning `null`?
+  - **Answer (2026-05-08):** Android provides composition metadata; iOS/HarmonyOS/Web/miniApp will return `null`/`-1` for composition in future phases.
+- Should `TextAreaView` self DSL expose `TextInputState` as public stable API or experimental API first?
+- Should the bridge wrapper be named `TextPostProcessorOutputTransformation`, `KuiklyTextPostProcessorTransformation`, or a shorter API name?
+  - **Answer (2026-05-08):** Named `TextPostProcessorOutputTransformation`.
+- Should deletion of a displayed emoji token delete the complete shortcode by default on all platforms, or only where platform span/attachment metadata can map it safely?
+  - **Answer (2026-05-08):** Android handles this via `applyEmojiSpans`; other platforms need investigation in future phases.

--- a/openspec/changes/textfield-custom-emoji/proposal.md
+++ b/openspec/changes/textfield-custom-emoji/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+KuiklyUI Compose TextField currently only synchronizes text, so business code cannot observe cursor/selection changes or insert custom emoji shortcode at the user-selected position. The latest custom emoji commit has proven the `textPostProcessor` display path on Android, but it remains append-only and lacks official Compose-style state, selection, and transformation semantics.
+
+## What Changes
+
+- Add a cross-layer text input state contract for raw text, selection, and composition synchronization.
+- Extend Compose DSL TextField toward official Compose 1.7.x state-based usage with `TextFieldValue` compatibility and a `TextFieldState`/`edit {}` target API.
+- Bridge the existing `textPostProcessor` custom emoji implementation into the target `OutputTransformation` path instead of replacing it immediately.
+- Preserve existing `Modifier.textPostProcessor()` and `InputAttr.textPostProcessor()` behavior as compatibility and platform-rendering backends.
+- Enable custom emoji insertion at the current cursor or selected range rather than only appending shortcode text.
+- Add renderer support expectations for Android, iOS, HarmonyOS, Web, miniApp, and macOS where platform capability permits.
+- Add demos and documentation that distinguish current append-style usage from the final official-aligned usage.
+
+## Capabilities
+
+### New Capabilities
+- `textfield-state-editing`: Covers TextField raw text, selection, composition, state synchronization, and programmatic editing semantics across Compose DSL, core, and renderers.
+- `textfield-transformations`: Covers input filtering, output-only display transformation, and bridging existing `textPostProcessor` custom emoji rendering into the transformation pipeline.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Modules impacted:
+  - `compose/`: `CoreTextField`, `BasicTextField` overloads, TextField state/buffer/transformation APIs, modifier compatibility.
+  - `core/`: `TextInputState`, text input state methods/events for `InputView`, `TextAreaView`, and `AutoHeightTextAreaView`.
+  - `core-render-android/`: preserve and adapt current `KRTextFieldView` `textPostProcessor` / `ImageSpan` behavior; add selection/composition state synchronization.
+  - `core-render-ios/`: add equivalent TextField/TextArea state synchronization and shortcode-to-attachment display support.
+  - `core-render-ohos/`, `core-render-web/`: add text/selection/composition event and state setting support as platform APIs allow.
+  - `demo/`: update current emoji demos and add official-aligned state/edit demos.
+  - `docs/`: update text post-processor guidance and add migration guidance.
+- Affected APIs:
+  - Existing value-based `BasicTextField` remains compatible.
+  - Existing `textPostProcessor` remains supported.
+  - New official-aligned APIs are added under Kuikly Compose packages, not by importing AndroidX Foundation directly.
+- Affected platforms: Android, iOS, HarmonyOS, Web, miniApp, and macOS.
+
+## Non-goals
+
+- Do not remove or break the latest `textPostProcessor` custom emoji commit.
+- Do not directly depend on official AndroidX Foundation TextField implementation inside KuiklyUI Compose.
+- Do not require all platforms to support full IME composition semantics in the first implementation; unsupported platforms may report `composition = null`.
+- Do not replace every rich text/input span mechanism with a new inline content system in the first phase.
+- Do not change unrelated Text, RichText, layout, or keyboard action behavior except where required for TextField state synchronization.

--- a/openspec/changes/textfield-custom-emoji/specs/textfield-state-editing/spec.md
+++ b/openspec/changes/textfield-custom-emoji/specs/textfield-state-editing/spec.md
@@ -1,0 +1,163 @@
+## ADDED Requirements
+
+### Requirement: Core text input state payload
+The system SHALL define a `TextInputState` payload containing raw text, selection start/end, optional composition start/end, and optional length metadata for communication between Compose DSL, self DSL, core views, and render views.
+
+#### Scenario: Android reports text input state
+- **WHEN** an Android `EditText` changes text or selection
+- **THEN** the renderer SHALL emit raw text with selection start/end and composition metadata when available
+
+#### Scenario: iOS reports text input state
+- **WHEN** an iOS `UITextView` or `UITextField` changes text or selection
+- **THEN** the renderer SHALL emit raw text with selection start/end and composition metadata when available
+
+#### Scenario: HarmonyOS reports text input state
+- **WHEN** a HarmonyOS text input changes text or selection
+- **THEN** the renderer SHALL emit raw text with selection start/end and SHALL report empty composition when composition APIs are unavailable
+
+#### Scenario: Web reports text input state
+- **WHEN** a Web input or textarea receives input, selection, or composition events
+- **THEN** the renderer SHALL emit raw text with selection start/end and composition metadata when available
+
+#### Scenario: miniApp reports text input state
+- **WHEN** a miniApp input receives text changes
+- **THEN** the renderer SHALL emit raw text and best-effort selection metadata, with composition empty when unavailable
+
+#### Scenario: macOS reports text input state
+- **WHEN** macOS text input changes text or selection
+- **THEN** the renderer SHALL emit raw text with selection start/end and composition metadata when available
+
+### Requirement: Atomic text and selection updates
+Core input views SHALL support setting raw text and selection atomically so programmatic updates do not move the cursor to the end unless requested.
+
+#### Scenario: Android receives programmatic state
+- **WHEN** Kotlin sets `TextInputState(text = "abc", selectionStart = 1, selectionEnd = 1)` on Android
+- **THEN** the native input SHALL display `abc` and place the cursor at raw index `1`
+
+#### Scenario: iOS receives programmatic state
+- **WHEN** Kotlin sets `TextInputState(text = "abc", selectionStart = 1, selectionEnd = 1)` on iOS
+- **THEN** the native input SHALL display `abc` and place the cursor at raw index `1`
+
+#### Scenario: HarmonyOS receives programmatic state
+- **WHEN** Kotlin sets `TextInputState` on HarmonyOS
+- **THEN** the native input SHALL update text and selection consistently where platform selection APIs permit
+
+#### Scenario: Web receives programmatic state
+- **WHEN** Kotlin sets `TextInputState` on Web
+- **THEN** the input value and `selectionStart` / `selectionEnd` SHALL match the raw state
+
+#### Scenario: miniApp receives programmatic state
+- **WHEN** Kotlin sets `TextInputState` on miniApp
+- **THEN** the input SHALL update text and SHALL apply selection when the miniApp runtime exposes selection APIs
+
+#### Scenario: macOS receives programmatic state
+- **WHEN** Kotlin sets `TextInputState` on macOS
+- **THEN** the native input SHALL update text and selection consistently where platform selection APIs permit
+
+### Requirement: TextFieldValue selection compatibility
+Compose value-based TextField APIs SHALL preserve `TextFieldValue.text`, `TextFieldValue.selection`, and `TextFieldValue.composition` when synchronizing with native input views.
+
+#### Scenario: Android TextFieldValue cursor move
+- **WHEN** the user taps the middle of a value-based TextField on Android
+- **THEN** `onValueChange` SHALL receive a `TextFieldValue` with unchanged text and updated selection
+
+#### Scenario: iOS TextFieldValue cursor move
+- **WHEN** the user taps the middle of a value-based TextField on iOS
+- **THEN** `onValueChange` SHALL receive a `TextFieldValue` with unchanged text and updated selection
+
+#### Scenario: HarmonyOS TextFieldValue cursor move
+- **WHEN** the user changes cursor position on HarmonyOS
+- **THEN** `onValueChange` SHALL receive updated selection when the platform reports it
+
+#### Scenario: Web TextFieldValue cursor move
+- **WHEN** the user changes cursor position on Web
+- **THEN** `onValueChange` SHALL receive updated selection
+
+#### Scenario: miniApp TextFieldValue cursor move
+- **WHEN** the user changes cursor position on miniApp
+- **THEN** `onValueChange` SHALL receive updated selection when the runtime reports it
+
+#### Scenario: macOS TextFieldValue cursor move
+- **WHEN** the user changes cursor position on macOS
+- **THEN** `onValueChange` SHALL receive updated selection when the platform reports it
+
+### Requirement: State-based Compose TextField editing
+Compose DSL SHALL provide a Kuikly package `TextFieldState` API with `rememberTextFieldState` and `edit {}` operations for insert, replace, delete, append, cursor placement, and selection updates.
+
+#### Scenario: Android state edit inserts at cursor
+- **WHEN** business code calls `state.edit { insert(selection.start, "[smile]") }` on Android
+- **THEN** the shortcode SHALL be inserted at the current raw cursor position
+
+#### Scenario: iOS state edit inserts at cursor
+- **WHEN** business code calls `state.edit { insert(selection.start, "[smile]") }` on iOS
+- **THEN** the shortcode SHALL be inserted at the current raw cursor position
+
+#### Scenario: HarmonyOS state edit inserts at cursor
+- **WHEN** business code calls `state.edit { insert(selection.start, "[smile]") }` on HarmonyOS
+- **THEN** the shortcode SHALL be inserted at the current raw cursor position when selection is available
+
+#### Scenario: Web state edit inserts at cursor
+- **WHEN** business code calls `state.edit { insert(selection.start, "[smile]") }` on Web
+- **THEN** the shortcode SHALL be inserted at the current raw cursor position
+
+#### Scenario: miniApp state edit inserts at cursor
+- **WHEN** business code calls `state.edit { insert(selection.start, "[smile]") }` on miniApp
+- **THEN** the shortcode SHALL be inserted at the best-known raw cursor position
+
+#### Scenario: macOS state edit inserts at cursor
+- **WHEN** business code calls `state.edit { insert(selection.start, "[smile]") }` on macOS
+- **THEN** the shortcode SHALL be inserted at the current raw cursor position when selection is available
+
+### Requirement: Self DSL text input state binding
+Self DSL `Input` and `TextArea` SHALL expose semantic state binding through `TextInputState` methods/events while keeping existing `textDidChange`, `cursorIndex`, and `setCursorIndex` APIs compatible.
+
+#### Scenario: Android self DSL state binding
+- **WHEN** self DSL binds `TextInputState` to an Android input
+- **THEN** text and selection SHALL stay synchronized through state-change events
+
+#### Scenario: iOS self DSL state binding
+- **WHEN** self DSL binds `TextInputState` to an iOS input
+- **THEN** text and selection SHALL stay synchronized through state-change events
+
+#### Scenario: HarmonyOS self DSL state binding
+- **WHEN** self DSL binds `TextInputState` to a HarmonyOS input
+- **THEN** text and available selection SHALL stay synchronized through state-change events
+
+#### Scenario: Web self DSL state binding
+- **WHEN** self DSL binds `TextInputState` to a Web input
+- **THEN** text and selection SHALL stay synchronized through state-change events
+
+#### Scenario: miniApp self DSL state binding
+- **WHEN** self DSL binds `TextInputState` to a miniApp input
+- **THEN** text and available selection SHALL stay synchronized through state-change events
+
+#### Scenario: macOS self DSL state binding
+- **WHEN** self DSL binds `TextInputState` to a macOS input
+- **THEN** text and available selection SHALL stay synchronized through state-change events
+
+### Requirement: Backward compatibility for existing text input APIs
+Existing text-only TextField, `textDidChange`, `cursorIndex`, `setCursorIndex`, `Modifier.textPostProcessor`, and `InputAttr.textPostProcessor` behavior SHALL remain compatible.
+
+#### Scenario: Android existing emoji demo remains valid
+- **WHEN** the existing Android emoji demo uses `Modifier.textPostProcessor("input")`
+- **THEN** shortcode rendering through `ImageSpan` SHALL continue to work
+
+#### Scenario: iOS existing text input remains valid
+- **WHEN** an existing iOS text input uses only `text` and `textDidChange`
+- **THEN** text input behavior SHALL remain unchanged
+
+#### Scenario: HarmonyOS existing text input remains valid
+- **WHEN** an existing HarmonyOS text input uses only `text` and `textDidChange`
+- **THEN** text input behavior SHALL remain unchanged
+
+#### Scenario: Web existing text input remains valid
+- **WHEN** an existing Web text input uses only `text` and `textDidChange`
+- **THEN** text input behavior SHALL remain unchanged
+
+#### Scenario: miniApp existing text input remains valid
+- **WHEN** an existing miniApp text input uses only `text` and `textDidChange`
+- **THEN** text input behavior SHALL remain unchanged
+
+#### Scenario: macOS existing text input remains valid
+- **WHEN** an existing macOS text input uses only `text` and `textDidChange`
+- **THEN** text input behavior SHALL remain unchanged

--- a/openspec/changes/textfield-custom-emoji/specs/textfield-transformations/spec.md
+++ b/openspec/changes/textfield-custom-emoji/specs/textfield-transformations/spec.md
@@ -1,0 +1,163 @@
+## ADDED Requirements
+
+### Requirement: InputTransformation filters raw user input
+Compose DSL state-based TextField SHALL support `InputTransformation` that transforms or rejects raw user edits before committing them to `TextFieldState`.
+
+#### Scenario: Android max length transformation
+- **WHEN** Android user input exceeds `InputTransformation.maxLength(10)`
+- **THEN** the extra raw input SHALL be rejected or truncated before state commit
+
+#### Scenario: iOS max length transformation
+- **WHEN** iOS user input exceeds `InputTransformation.maxLength(10)`
+- **THEN** the extra raw input SHALL be rejected or truncated before state commit
+
+#### Scenario: HarmonyOS max length transformation
+- **WHEN** HarmonyOS user input exceeds `InputTransformation.maxLength(10)`
+- **THEN** the extra raw input SHALL be rejected or truncated before state commit
+
+#### Scenario: Web max length transformation
+- **WHEN** Web user input exceeds `InputTransformation.maxLength(10)`
+- **THEN** the extra raw input SHALL be rejected or truncated before state commit
+
+#### Scenario: miniApp max length transformation
+- **WHEN** miniApp user input exceeds `InputTransformation.maxLength(10)`
+- **THEN** the extra raw input SHALL be rejected or truncated before state commit
+
+#### Scenario: macOS max length transformation
+- **WHEN** macOS user input exceeds `InputTransformation.maxLength(10)`
+- **THEN** the extra raw input SHALL be rejected or truncated before state commit
+
+### Requirement: OutputTransformation preserves raw state
+Compose DSL state-based TextField SHALL support `OutputTransformation` that changes displayed content without changing `TextFieldState.text`.
+
+#### Scenario: Android formatted display preserves raw state
+- **WHEN** Android displays `13800138000` as `138 0013 8000`
+- **THEN** `TextFieldState.text` SHALL remain `13800138000`
+
+#### Scenario: iOS formatted display preserves raw state
+- **WHEN** iOS displays `13800138000` as `138 0013 8000`
+- **THEN** `TextFieldState.text` SHALL remain `13800138000`
+
+#### Scenario: HarmonyOS formatted display preserves raw state
+- **WHEN** HarmonyOS displays formatted text
+- **THEN** `TextFieldState.text` SHALL remain the unformatted raw text
+
+#### Scenario: Web formatted display preserves raw state
+- **WHEN** Web displays formatted text
+- **THEN** `TextFieldState.text` SHALL remain the unformatted raw text
+
+#### Scenario: miniApp formatted display preserves raw state
+- **WHEN** miniApp displays formatted text
+- **THEN** `TextFieldState.text` SHALL remain the unformatted raw text
+
+#### Scenario: macOS formatted display preserves raw state
+- **WHEN** macOS displays formatted text
+- **THEN** `TextFieldState.text` SHALL remain the unformatted raw text
+
+### Requirement: Text post-processor transformation bridge
+The system SHALL provide a transformation bridge that maps a Kuikly text post-processor name to output rendering while keeping raw shortcode text in state.
+
+#### Scenario: Android bridge uses existing ImageSpan path
+- **WHEN** `TextPostProcessorOutputTransformation("input")` processes `[smile]` on Android
+- **THEN** the existing `KRTextFieldView` post-processor path SHALL display an `ImageSpan` while raw state remains `[smile]`
+
+#### Scenario: iOS bridge uses attachment path
+- **WHEN** `TextPostProcessorOutputTransformation("input")` processes `[smile]` on iOS
+- **THEN** the renderer SHALL display an `NSTextAttachment` and restore raw `[smile]` for callbacks
+
+#### Scenario: HarmonyOS bridge handles unsupported image spans
+- **WHEN** `TextPostProcessorOutputTransformation("input")` processes `[smile]` on HarmonyOS before image-span support exists
+- **THEN** the renderer SHALL preserve raw text and SHALL NOT corrupt input state
+
+#### Scenario: Web bridge handles display output
+- **WHEN** `TextPostProcessorOutputTransformation("input")` processes `[smile]` on Web
+- **THEN** the renderer SHALL display transformed content where supported and keep raw text for callbacks
+
+#### Scenario: miniApp bridge handles display output
+- **WHEN** `TextPostProcessorOutputTransformation("input")` processes `[smile]` on miniApp
+- **THEN** the renderer SHALL preserve raw text and apply display transformation where runtime support permits
+
+#### Scenario: macOS bridge uses available attachment path
+- **WHEN** `TextPostProcessorOutputTransformation("input")` processes `[smile]` on macOS
+- **THEN** the renderer SHALL display attachment content where supported and restore raw `[smile]` for callbacks
+
+### Requirement: Emoji insertion uses current selection
+Custom emoji insertion SHALL use current raw selection and SHALL replace the selected raw range or insert at the raw cursor position.
+
+#### Scenario: Android emoji replaces selected range
+- **WHEN** Android selection covers raw text `abc` and business inserts `[smile]`
+- **THEN** raw state SHALL replace `abc` with `[smile]`
+
+#### Scenario: iOS emoji replaces selected range
+- **WHEN** iOS selection covers raw text `abc` and business inserts `[smile]`
+- **THEN** raw state SHALL replace `abc` with `[smile]`
+
+#### Scenario: HarmonyOS emoji inserts at cursor
+- **WHEN** HarmonyOS has a known cursor position and business inserts `[smile]`
+- **THEN** raw state SHALL insert `[smile]` at that position
+
+#### Scenario: Web emoji replaces selected range
+- **WHEN** Web selection covers raw text `abc` and business inserts `[smile]`
+- **THEN** raw state SHALL replace `abc` with `[smile]`
+
+#### Scenario: miniApp emoji uses best-known cursor
+- **WHEN** miniApp has a best-known cursor position and business inserts `[smile]`
+- **THEN** raw state SHALL insert `[smile]` at that position
+
+#### Scenario: macOS emoji inserts at cursor
+- **WHEN** macOS has a known cursor position and business inserts `[smile]`
+- **THEN** raw state SHALL insert `[smile]` at that position
+
+### Requirement: Emoji deletion preserves shortcode boundaries
+When display output represents a shortcode as a single visual emoji token, deletion of that token SHALL remove the full shortcode from raw state when raw/display mapping is available.
+
+#### Scenario: Android deletes ImageSpan token
+- **WHEN** the user deletes a displayed Android `ImageSpan` for `[smile]`
+- **THEN** raw state SHALL remove the complete `[smile]` shortcode
+
+#### Scenario: iOS deletes attachment token
+- **WHEN** the user deletes an iOS attachment for `[smile]`
+- **THEN** raw state SHALL remove the complete `[smile]` shortcode
+
+#### Scenario: HarmonyOS deletes unsupported token as text
+- **WHEN** HarmonyOS lacks visual token mapping and user deletes shortcode text
+- **THEN** raw state SHALL remain valid text and SHALL NOT emit attachment placeholders
+
+#### Scenario: Web deletes transformed token
+- **WHEN** Web has raw/display mapping for a displayed emoji token and the user deletes it
+- **THEN** raw state SHALL remove the complete shortcode
+
+#### Scenario: miniApp deletes shortcode text
+- **WHEN** miniApp lacks visual token mapping and user deletes shortcode text
+- **THEN** raw state SHALL remain valid text and SHALL NOT emit attachment placeholders
+
+#### Scenario: macOS deletes attachment token
+- **WHEN** macOS has attachment mapping for `[smile]` and the user deletes it
+- **THEN** raw state SHALL remove the complete shortcode
+
+### Requirement: Existing post-processor usage remains compatible
+Existing `Modifier.textPostProcessor(processor)` and `InputAttr.textPostProcessor(processor)` usage SHALL remain supported after transformation APIs are introduced.
+
+#### Scenario: Android current Compose emoji demo remains compatible
+- **WHEN** `TextFieldEmojiDemo` uses `Modifier.textPostProcessor("input")` on Android
+- **THEN** the demo SHALL continue rendering shortcode emoji images
+
+#### Scenario: iOS post-processor compatibility
+- **WHEN** existing iOS text rendering uses `textPostProcessor`
+- **THEN** the existing text post-processing behavior SHALL remain available
+
+#### Scenario: HarmonyOS post-processor compatibility
+- **WHEN** existing HarmonyOS text rendering uses `textPostProcessor`
+- **THEN** the existing behavior SHALL remain available or safely no-op where unsupported
+
+#### Scenario: Web post-processor compatibility
+- **WHEN** existing Web text rendering uses `textPostProcessor`
+- **THEN** the existing behavior SHALL remain available
+
+#### Scenario: miniApp post-processor compatibility
+- **WHEN** existing miniApp text rendering uses `textPostProcessor`
+- **THEN** the existing behavior SHALL remain available
+
+#### Scenario: macOS post-processor compatibility
+- **WHEN** existing macOS text rendering uses `textPostProcessor`
+- **THEN** the existing behavior SHALL remain available

--- a/openspec/changes/textfield-custom-emoji/tasks.md
+++ b/openspec/changes/textfield-custom-emoji/tasks.md
@@ -1,0 +1,79 @@
+## 1. Core Module
+
+- [x] 1.1 Add `TextInputState` data model with raw text, selection, composition, and length metadata.
+- [x] 1.2 Add `setTextInputState` and `getTextInputState` methods to `InputView`.
+- [x] 1.3 Add `setTextInputState` and `getTextInputState` methods to `TextAreaView`.
+- [x] 1.4 Add `setTextInputState` and `getTextInputState` methods to `AutoHeightTextAreaView`.
+- [x] 1.5 Add `textInputStateChange` event support to `InputEvent` without breaking `textDidChange`.
+- [x] 1.6 Add `textInputStateChange` event support to `TextAreaEvent` without breaking `textDidChange`.
+- [x] 1.7 Add `selectionChange` event support for cursor/selection-only changes.
+- [x] 1.8 Keep `cursorIndex`, `setCursorIndex`, and `textDidChange` compatibility paths intact.
+
+## 2. Compose Module
+
+- [x] 2.1 Update `CoreTextField` to send `TextFieldValue.text`, `selection`, and `composition` through `TextInputState`.
+- [x] 2.2 Update `CoreTextField` to convert native `TextInputState` callbacks into full `TextFieldValue` callbacks.
+- [x] 2.3 Add loop prevention for programmatic state updates in `CoreTextField`.
+- [x] 2.4 Add `TextFieldState` and `rememberTextFieldState` under Kuikly Compose packages.
+- [x] 2.5 Add `TextFieldBuffer` with insert, replace, delete, append, selectAll, placeCursorAtEnd, and revert support.
+- [x] 2.6 Add state-based `BasicTextField(state = ...)` overload wired to existing `CoreTextField`.
+- [x] 2.7 Add `InputTransformation` with `then` and `maxLength` support.
+- [ ] 2.8 Add `OutputTransformation` display-only pipeline.
+- [x] 2.9 Add `TextPostProcessorOutputTransformation` bridge that reuses existing `textPostProcessor` semantics.
+- [x] 2.10 Preserve `Modifier.textPostProcessor(processor)` as compatibility API.
+
+## 3. Android Renderer
+
+- [x] 3.1 Extend `KRTextFieldView` call handling for `setTextInputState` and `getTextInputState`.
+- [x] 3.2 Emit `textInputStateChange` with text, selection start/end, length, and best-effort composition metadata.
+- [x] 3.3 Emit `selectionChange` from `onSelectionChanged` when text is unchanged.
+- [x] 3.4 Preserve current `textPostProcessor` and `applyEmojiSpans` behavior for existing emoji demos.
+- [x] 3.5 Ensure programmatic text+selection updates do not force cursor to text end.
+- [ ] 3.6 Add raw/display mapping tests around `ImageSpan` deletion and cursor movement.
+
+## 4. iOS Renderer
+
+- [ ] 4.1 Add `css_setTextInputState` and `css_getTextInputState` to `KRTextAreaView`.
+- [ ] 4.2 Add `css_setTextInputState` and `css_getTextInputState` to `KRTextFieldView`.
+- [ ] 4.3 Emit `textInputStateChange` and `selectionChange` from iOS text delegates.
+- [ ] 4.4 Reuse `p_outputText` and cursor mapping so attachment display returns raw shortcode text.
+- [ ] 4.5 Add input-view `textPostProcessor` application with `NSTextAttachment` and `KRTextAttachmentStringProtocol`.
+- [ ] 4.6 Guard `_ignoreTextDidChanged` paths against recursive callback loops.
+
+## 5. HarmonyOS Renderer
+
+- [ ] 5.1 Add state payload method handling to HarmonyOS text input and text area views.
+- [ ] 5.2 Emit text and selection state changes using ArkUI selection APIs where available.
+- [ ] 5.3 Represent unsupported composition as empty composition metadata.
+- [ ] 5.4 Verify existing text input behavior remains unchanged when new state APIs are unused.
+
+## 6. Web and miniApp Renderers
+
+- [ ] 6.1 Add Web input/textarea state payload support using `selectionStart` and `selectionEnd`.
+- [ ] 6.2 Add Web composition event handling for composition metadata.
+- [ ] 6.3 Add miniApp best-effort state payload support for text and selection.
+- [ ] 6.4 Preserve existing Web and miniApp text input behavior when state APIs are unused.
+
+## 7. Demo and Documentation
+
+- [x] 7.1 Update `TextFieldEmojiDemo` to show current `textPostProcessor` usage and target state/edit usage.
+- [x] 7.2 Update `EmojiTextInputDemo` to show self DSL `TextInputState` usage when available.
+- [ ] 7.3 Add Compose demo for `TextFieldValue` selection synchronization.
+- [x] 7.4 Add Compose demo for `TextFieldState.edit {}` inserting custom emoji at cursor.
+- [ ] 7.5 Add Compose demo for `InputTransformation.maxLength` and digit-only filtering.
+- [ ] 7.6 Add Compose demo for `OutputTransformation` phone formatting.
+- [x] 7.7 Update text post-processor docs with compatibility and transformation-bridge guidance.
+- [x] 7.8 Add migration notes from append-style emoji input to state/edit insertion.
+
+## 8. Validation
+
+- [x] 8.1 Run `./gradlew :core:compileDebugKotlinAndroid`.
+- [x] 8.2 Run `./gradlew :compose:compileDebugKotlinAndroid`.
+- [x] 8.3 Run `./gradlew :androidApp:assembleDebug` and verify Android emoji demos.
+- [ ] 8.4 Verify Android cursor insert, selected-range replace, emoji delete, paste, and Chinese IME cases manually.
+- [ ] 8.5 Build and verify iOS TextArea cursor insert, selected-range replace, emoji delete, paste, and Chinese IME cases.
+- [ ] 8.6 Build and verify iOS TextField single-line state synchronization.
+- [ ] 8.7 Build and verify HarmonyOS text input state synchronization and graceful composition degradation.
+- [ ] 8.8 Run Web development build and verify text/selection state synchronization.
+- [ ] 8.9 Verify old `textDidChange`, `cursorIndex`, `setCursorIndex`, and `textPostProcessor` usages remain compatible.
+- [ ] 8.10 Run `openspec validate --change textfield-custom-emoji --strict` before implementation completion.

--- a/openspec/specs/textfield-state-editing/spec.md
+++ b/openspec/specs/textfield-state-editing/spec.md
@@ -1,0 +1,163 @@
+## Requirements
+
+### Requirement: Core text input state payload
+The system SHALL define a `TextInputState` payload containing raw text, selection start/end, optional composition start/end, and optional length metadata for communication between Compose DSL, self DSL, core views, and render views.
+
+#### Scenario: Android reports text input state
+- **WHEN** an Android `EditText` changes text or selection
+- **THEN** the renderer SHALL emit raw text with selection start/end and composition metadata when available
+
+#### Scenario: iOS reports text input state
+- **WHEN** an iOS `UITextView` or `UITextField` changes text or selection
+- **THEN** the renderer SHALL emit raw text with selection start/end and composition metadata when available
+
+#### Scenario: HarmonyOS reports text input state
+- **WHEN** a HarmonyOS text input changes text or selection
+- **THEN** the renderer SHALL emit raw text with selection start/end and SHALL report empty composition when composition APIs are unavailable
+
+#### Scenario: Web reports text input state
+- **WHEN** a Web input or textarea receives input, selection, or composition events
+- **THEN** the renderer SHALL emit raw text with selection start/end and composition metadata when available
+
+#### Scenario: miniApp reports text input state
+- **WHEN** a miniApp input receives text changes
+- **THEN** the renderer SHALL emit raw text and best-effort selection metadata, with composition empty when unavailable
+
+#### Scenario: macOS reports text input state
+- **WHEN** macOS text input changes text or selection
+- **THEN** the renderer SHALL emit raw text with selection start/end and composition metadata when available
+
+### Requirement: Atomic text and selection updates
+Core input views SHALL support setting raw text and selection atomically so programmatic updates do not move the cursor to the end unless requested.
+
+#### Scenario: Android receives programmatic state
+- **WHEN** Kotlin sets `TextInputState(text = "abc", selectionStart = 1, selectionEnd = 1)` on Android
+- **THEN** the native input SHALL display `abc` and place the cursor at raw index `1`
+
+#### Scenario: iOS receives programmatic state
+- **WHEN** Kotlin sets `TextInputState(text = "abc", selectionStart = 1, selectionEnd = 1)` on iOS
+- **THEN** the native input SHALL display `abc` and place the cursor at raw index `1`
+
+#### Scenario: HarmonyOS receives programmatic state
+- **WHEN** Kotlin sets `TextInputState` on HarmonyOS
+- **THEN** the native input SHALL update text and selection consistently where platform selection APIs permit
+
+#### Scenario: Web receives programmatic state
+- **WHEN** Kotlin sets `TextInputState` on Web
+- **THEN** the input value and `selectionStart` / `selectionEnd` SHALL match the raw state
+
+#### Scenario: miniApp receives programmatic state
+- **WHEN** Kotlin sets `TextInputState` on miniApp
+- **THEN** the input SHALL update text and SHALL apply selection when the miniApp runtime exposes selection APIs
+
+#### Scenario: macOS receives programmatic state
+- **WHEN** Kotlin sets `TextInputState` on macOS
+- **THEN** the native input SHALL update text and selection consistently where platform selection APIs permit
+
+### Requirement: TextFieldValue selection compatibility
+Compose value-based TextField APIs SHALL preserve `TextFieldValue.text`, `TextFieldValue.selection`, and `TextFieldValue.composition` when synchronizing with native input views.
+
+#### Scenario: Android TextFieldValue cursor move
+- **WHEN** the user taps the middle of a value-based TextField on Android
+- **THEN** `onValueChange` SHALL receive a `TextFieldValue` with unchanged text and updated selection
+
+#### Scenario: iOS TextFieldValue cursor move
+- **WHEN** the user taps the middle of a value-based TextField on iOS
+- **THEN** `onValueChange` SHALL receive a `TextFieldValue` with unchanged text and updated selection
+
+#### Scenario: HarmonyOS TextFieldValue cursor move
+- **WHEN** the user changes cursor position on HarmonyOS
+- **THEN** `onValueChange` SHALL receive updated selection when the platform reports it
+
+#### Scenario: Web TextFieldValue cursor move
+- **WHEN** the user changes cursor position on Web
+- **THEN** `onValueChange` SHALL receive updated selection
+
+#### Scenario: miniApp TextFieldValue cursor move
+- **WHEN** the user changes cursor position on miniApp
+- **THEN** `onValueChange` SHALL receive updated selection when the runtime reports it
+
+#### Scenario: macOS TextFieldValue cursor move
+- **WHEN** the user changes cursor position on macOS
+- **THEN** `onValueChange` SHALL receive updated selection when the platform reports it
+
+### Requirement: State-based Compose TextField editing
+Compose DSL SHALL provide a Kuikly package `TextFieldState` API with `rememberTextFieldState` and `edit {}` operations for insert, replace, delete, append, cursor placement, and selection updates.
+
+#### Scenario: Android state edit inserts at cursor
+- **WHEN** business code calls `state.edit { insert(selection.start, "[smile]") }` on Android
+- **THEN** the shortcode SHALL be inserted at the current raw cursor position
+
+#### Scenario: iOS state edit inserts at cursor
+- **WHEN** business code calls `state.edit { insert(selection.start, "[smile]") }` on iOS
+- **THEN** the shortcode SHALL be inserted at the current raw cursor position
+
+#### Scenario: HarmonyOS state edit inserts at cursor
+- **WHEN** business code calls `state.edit { insert(selection.start, "[smile]") }` on HarmonyOS
+- **THEN** the shortcode SHALL be inserted at the current raw cursor position when selection is available
+
+#### Scenario: Web state edit inserts at cursor
+- **WHEN** business code calls `state.edit { insert(selection.start, "[smile]") }` on Web
+- **THEN** the shortcode SHALL be inserted at the current raw cursor position
+
+#### Scenario: miniApp state edit inserts at cursor
+- **WHEN** business code calls `state.edit { insert(selection.start, "[smile]") }` on miniApp
+- **THEN** the shortcode SHALL be inserted at the best-known raw cursor position
+
+#### Scenario: macOS state edit inserts at cursor
+- **WHEN** business code calls `state.edit { insert(selection.start, "[smile]") }` on macOS
+- **THEN** the shortcode SHALL be inserted at the current raw cursor position when selection is available
+
+### Requirement: Self DSL text input state binding
+Self DSL `Input` and `TextArea` SHALL expose semantic state binding through `TextInputState` methods/events while keeping existing `textDidChange`, `cursorIndex`, and `setCursorIndex` APIs compatible.
+
+#### Scenario: Android self DSL state binding
+- **WHEN** self DSL binds `TextInputState` to an Android input
+- **THEN** text and selection SHALL stay synchronized through state-change events
+
+#### Scenario: iOS self DSL state binding
+- **WHEN** self DSL binds `TextInputState` to an iOS input
+- **THEN** text and selection SHALL stay synchronized through state-change events
+
+#### Scenario: HarmonyOS self DSL state binding
+- **WHEN** self DSL binds `TextInputState` to a HarmonyOS input
+- **THEN** text and available selection SHALL stay synchronized through state-change events
+
+#### Scenario: Web self DSL state binding
+- **WHEN** self DSL binds `TextInputState` to a Web input
+- **THEN** text and selection SHALL stay synchronized through state-change events
+
+#### Scenario: miniApp self DSL state binding
+- **WHEN** self DSL binds `TextInputState` to a miniApp input
+- **THEN** text and available selection SHALL stay synchronized through state-change events
+
+#### Scenario: macOS self DSL state binding
+- **WHEN** self DSL binds `TextInputState` to a macOS input
+- **THEN** text and available selection SHALL stay synchronized through state-change events
+
+### Requirement: Backward compatibility for existing text input APIs
+Existing text-only TextField, `textDidChange`, `cursorIndex`, `setCursorIndex`, `Modifier.textPostProcessor`, and `InputAttr.textPostProcessor` behavior SHALL remain compatible.
+
+#### Scenario: Android existing emoji demo remains valid
+- **WHEN** the existing Android emoji demo uses `Modifier.textPostProcessor("input")`
+- **THEN** shortcode rendering through `ImageSpan` SHALL continue to work
+
+#### Scenario: iOS existing text input remains valid
+- **WHEN** an existing iOS text input uses only `text` and `textDidChange`
+- **THEN** text input behavior SHALL remain unchanged
+
+#### Scenario: HarmonyOS existing text input remains valid
+- **WHEN** an existing HarmonyOS text input uses only `text` and `textDidChange`
+- **THEN** text input behavior SHALL remain unchanged
+
+#### Scenario: Web existing text input remains valid
+- **WHEN** an existing Web text input uses only `text` and `textDidChange`
+- **THEN** text input behavior SHALL remain unchanged
+
+#### Scenario: miniApp existing text input remains valid
+- **WHEN** an existing miniApp text input uses only `text` and `textDidChange`
+- **THEN** text input behavior SHALL remain unchanged
+
+#### Scenario: macOS existing text input remains valid
+- **WHEN** an existing macOS text input uses only `text` and `textDidChange`
+- **THEN** text input behavior SHALL remain unchanged

--- a/openspec/specs/textfield-transformations/spec.md
+++ b/openspec/specs/textfield-transformations/spec.md
@@ -1,0 +1,163 @@
+## Requirements
+
+### Requirement: InputTransformation filters raw user input
+Compose DSL state-based TextField SHALL support `InputTransformation` that transforms or rejects raw user edits before committing them to `TextFieldState`.
+
+#### Scenario: Android max length transformation
+- **WHEN** Android user input exceeds `InputTransformation.maxLength(10)`
+- **THEN** the extra raw input SHALL be rejected or truncated before state commit
+
+#### Scenario: iOS max length transformation
+- **WHEN** iOS user input exceeds `InputTransformation.maxLength(10)`
+- **THEN** the extra raw input SHALL be rejected or truncated before state commit
+
+#### Scenario: HarmonyOS max length transformation
+- **WHEN** HarmonyOS user input exceeds `InputTransformation.maxLength(10)`
+- **THEN** the extra raw input SHALL be rejected or truncated before state commit
+
+#### Scenario: Web max length transformation
+- **WHEN** Web user input exceeds `InputTransformation.maxLength(10)`
+- **THEN** the extra raw input SHALL be rejected or truncated before state commit
+
+#### Scenario: miniApp max length transformation
+- **WHEN** miniApp user input exceeds `InputTransformation.maxLength(10)`
+- **THEN** the extra raw input SHALL be rejected or truncated before state commit
+
+#### Scenario: macOS max length transformation
+- **WHEN** macOS user input exceeds `InputTransformation.maxLength(10)`
+- **THEN** the extra raw input SHALL be rejected or truncated before state commit
+
+### Requirement: OutputTransformation preserves raw state
+Compose DSL state-based TextField SHALL support `OutputTransformation` that changes displayed content without changing `TextFieldState.text`.
+
+#### Scenario: Android formatted display preserves raw state
+- **WHEN** Android displays `13800138000` as `138 0013 8000`
+- **THEN** `TextFieldState.text` SHALL remain `13800138000`
+
+#### Scenario: iOS formatted display preserves raw state
+- **WHEN** iOS displays `13800138000` as `138 0013 8000`
+- **THEN** `TextFieldState.text` SHALL remain `13800138000`
+
+#### Scenario: HarmonyOS formatted display preserves raw state
+- **WHEN** HarmonyOS displays formatted text
+- **THEN** `TextFieldState.text` SHALL remain the unformatted raw text
+
+#### Scenario: Web formatted display preserves raw state
+- **WHEN** Web displays formatted text
+- **THEN** `TextFieldState.text` SHALL remain the unformatted raw text
+
+#### Scenario: miniApp formatted display preserves raw state
+- **WHEN** miniApp displays formatted text
+- **THEN** `TextFieldState.text` SHALL remain the unformatted raw text
+
+#### Scenario: macOS formatted display preserves raw state
+- **WHEN** macOS displays formatted text
+- **THEN** `TextFieldState.text` SHALL remain the unformatted raw text
+
+### Requirement: Text post-processor transformation bridge
+The system SHALL provide a transformation bridge that maps a Kuikly text post-processor name to output rendering while keeping raw shortcode text in state.
+
+#### Scenario: Android bridge uses existing ImageSpan path
+- **WHEN** `TextPostProcessorOutputTransformation("input")` processes `[smile]` on Android
+- **THEN** the existing `KRTextFieldView` post-processor path SHALL display an `ImageSpan` while raw state remains `[smile]`
+
+#### Scenario: iOS bridge uses attachment path
+- **WHEN** `TextPostProcessorOutputTransformation("input")` processes `[smile]` on iOS
+- **THEN** the renderer SHALL display an `NSTextAttachment` and restore raw `[smile]` for callbacks
+
+#### Scenario: HarmonyOS bridge handles unsupported image spans
+- **WHEN** `TextPostProcessorOutputTransformation("input")` processes `[smile]` on HarmonyOS before image-span support exists
+- **THEN** the renderer SHALL preserve raw text and SHALL NOT corrupt input state
+
+#### Scenario: Web bridge handles display output
+- **WHEN** `TextPostProcessorOutputTransformation("input")` processes `[smile]` on Web
+- **THEN** the renderer SHALL display transformed content where supported and keep raw text for callbacks
+
+#### Scenario: miniApp bridge handles display output
+- **WHEN** `TextPostProcessorOutputTransformation("input")` processes `[smile]` on miniApp
+- **THEN** the renderer SHALL preserve raw text and apply display transformation where runtime support permits
+
+#### Scenario: macOS bridge uses available attachment path
+- **WHEN** `TextPostProcessorOutputTransformation("input")` processes `[smile]` on macOS
+- **THEN** the renderer SHALL display attachment content where supported and restore raw `[smile]` for callbacks
+
+### Requirement: Emoji insertion uses current selection
+Custom emoji insertion SHALL use current raw selection and SHALL replace the selected raw range or insert at the raw cursor position.
+
+#### Scenario: Android emoji replaces selected range
+- **WHEN** Android selection covers raw text `abc` and business inserts `[smile]`
+- **THEN** raw state SHALL replace `abc` with `[smile]`
+
+#### Scenario: iOS emoji replaces selected range
+- **WHEN** iOS selection covers raw text `abc` and business inserts `[smile]`
+- **THEN** raw state SHALL replace `abc` with `[smile]`
+
+#### Scenario: HarmonyOS emoji inserts at cursor
+- **WHEN** HarmonyOS has a known cursor position and business inserts `[smile]`
+- **THEN** raw state SHALL insert `[smile]` at that position
+
+#### Scenario: Web emoji replaces selected range
+- **WHEN** Web selection covers raw text `abc` and business inserts `[smile]`
+- **THEN** raw state SHALL replace `abc` with `[smile]`
+
+#### Scenario: miniApp emoji uses best-known cursor
+- **WHEN** miniApp has a best-known cursor position and business inserts `[smile]`
+- **THEN** raw state SHALL insert `[smile]` at that position
+
+#### Scenario: macOS emoji inserts at cursor
+- **WHEN** macOS has a known cursor position and business inserts `[smile]`
+- **THEN** raw state SHALL insert `[smile]` at that position
+
+### Requirement: Emoji deletion preserves shortcode boundaries
+When display output represents a shortcode as a single visual emoji token, deletion of that token SHALL remove the full shortcode from raw state when raw/display mapping is available.
+
+#### Scenario: Android deletes ImageSpan token
+- **WHEN** the user deletes a displayed Android `ImageSpan` for `[smile]`
+- **THEN** raw state SHALL remove the complete `[smile]` shortcode
+
+#### Scenario: iOS deletes attachment token
+- **WHEN** the user deletes an iOS attachment for `[smile]`
+- **THEN** raw state SHALL remove the complete `[smile]` shortcode
+
+#### Scenario: HarmonyOS deletes unsupported token as text
+- **WHEN** HarmonyOS lacks visual token mapping and user deletes shortcode text
+- **THEN** raw state SHALL remain valid text and SHALL NOT emit attachment placeholders
+
+#### Scenario: Web deletes transformed token
+- **WHEN** Web has raw/display mapping for a displayed emoji token and the user deletes it
+- **THEN** raw state SHALL remove the complete shortcode
+
+#### Scenario: miniApp deletes shortcode text
+- **WHEN** miniApp lacks visual token mapping and user deletes shortcode text
+- **THEN** raw state SHALL remain valid text and SHALL NOT emit attachment placeholders
+
+#### Scenario: macOS deletes attachment token
+- **WHEN** macOS has attachment mapping for `[smile]` and the user deletes it
+- **THEN** raw state SHALL remove the complete shortcode
+
+### Requirement: Existing post-processor usage remains compatible
+Existing `Modifier.textPostProcessor(processor)` and `InputAttr.textPostProcessor(processor)` usage SHALL remain supported after transformation APIs are introduced.
+
+#### Scenario: Android current Compose emoji demo remains compatible
+- **WHEN** `TextFieldEmojiDemo` uses `Modifier.textPostProcessor("input")` on Android
+- **THEN** the demo SHALL continue rendering shortcode emoji images
+
+#### Scenario: iOS post-processor compatibility
+- **WHEN** existing iOS text rendering uses `textPostProcessor`
+- **THEN** the existing text post-processing behavior SHALL remain available
+
+#### Scenario: HarmonyOS post-processor compatibility
+- **WHEN** existing HarmonyOS text rendering uses `textPostProcessor`
+- **THEN** the existing behavior SHALL remain available or safely no-op where unsupported
+
+#### Scenario: Web post-processor compatibility
+- **WHEN** existing Web text rendering uses `textPostProcessor`
+- **THEN** the existing behavior SHALL remain available
+
+#### Scenario: miniApp post-processor compatibility
+- **WHEN** existing miniApp text rendering uses `textPostProcessor`
+- **THEN** the existing behavior SHALL remain available
+
+#### Scenario: macOS post-processor compatibility
+- **WHEN** existing macOS text rendering uses `textPostProcessor`
+- **THEN** the existing behavior SHALL remain available


### PR DESCRIPTION
- ModifierSetProp.kt 新增 textPostProcessor() 扩展
- TextFieldEmojiDemo.kt 使用短码 [smile]/[heart] 等，TextField 和预览 Text 均支持解析
- ComposeAllSample.kt 添加 Demo 入口
- KuiklyRenderActivity.kt 修复 KRTextPostProcessorAdapter 构造参数
- 实现 KRTextPostProcessorAdapter，将 [smile]/[heart]/[thumbup]/[star]/[fire] 短码替换为对应 drawable 的 ImageSpan
- KRTextFieldView 支持 textPostProcessor 属性，在 afterTextChanged 中实时应用表情 span
- InputView DSL 新增 textPostProcessor() 方法
- EmojiTextInputDemo 演示输入框与预览区域的表情显示效果
- 添加 5 个表情矢量图标资源