### PR TITLE
fix: iOS nested scroll lock work for spring branch

### DIFF
--- a/core-render-ios/Extension/Components/KRScrollView.m
+++ b/core-render-ios/Extension/Components/KRScrollView.m
@@ -449,6 +449,7 @@ KUIKLY_NESTEDSCROLL_PROTOCOL_PROPERTY_IMP
     int curve = curveSpecified ? [points[6] intValue] : 0;
     CGPoint contentOffset = CGPointMake([points.firstObject doubleValue], [points[1] doubleValue]);
     [self p_setTargetContentOffsetIfNeed:contentOffset];
+    self.skipNestScrollLock = YES;
     if (damping || curveSpecified) {
         [self p_springAnimationWithContentOffset:contentOffset duration:duration damping:damping velocity:velocity curve:curve];
         return ;
@@ -457,7 +458,6 @@ KUIKLY_NESTEDSCROLL_PROTOCOL_PROPERTY_IMP
     if (!UIEdgeInsetsEqualToEdgeInsets(self.contentInset, newContentInsets)) {
         self.contentInset = newContentInsets;
     }
-    self.skipNestScrollLock = YES;
     [self setContentOffset:contentOffset animated:animated];
 }
 


### PR DESCRIPTION
修改原因：嵌套 scrollView 场景下，内部视图发生滚动后，外部视图带弹簧动画的 setContentOffset 失效
实现方式：skipNestScrollLock 赋值提前到弹簧动画分支上方，对弹簧和非弹簧分支都起作用