### PR TITLE
fix(ohos): fix toImage CACHE_KEY crash when Image loads cached snapshot

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/manager/KRSnapshotManager.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/manager/KRSnapshotManager.cpp
@@ -29,15 +29,33 @@
 #include "libohos_render/scheduler/KRContextScheduler.h"
 #include "libohos_render/utils/KRBase64Util.h"
 
-constexpr static int TIME_TO_REMOVE_SNAPSHOT_DRAWABLE_MS = 100;  // remove the cached drawable after 6 frames
+constexpr static int TIME_TO_UPDATE_SNAPSHOT_URI_MS = 100;
 constexpr static int MAX_DELAY_DURATION_MS = 1000;
 
-static void DisposeItem(struct KRSnapshotItem *item) {
+static void ReleaseDrawableItem(struct KRSnapshotItem *item) {
     if (item) {
         if (item->drawableDescriptor) {
             OH_ArkUI_DrawableDescriptor_Dispose(item->drawableDescriptor);
             item->drawableDescriptor = nullptr;
         }
+        if (item->env) {
+            ArkTS arkTs(item->env);
+            if (item->drawableDescriptorRef) {
+                arkTs.DeleteReference(item->drawableDescriptorRef);
+                item->drawableDescriptorRef = nullptr;
+            }
+            if (item->pixelMapRef) {
+                arkTs.DeleteReference(item->pixelMapRef);
+                item->pixelMapRef = nullptr;
+            }
+        }
+        item->env = nullptr;
+    }
+}
+
+static void DisposeItem(struct KRSnapshotItem *item) {
+    if (item) {
+        ReleaseDrawableItem(item);
         item->uri = "";
     }
 }
@@ -48,15 +66,20 @@ KRSnapshotManager::~KRSnapshotManager() {
     drawableDescriptorCache_.clear();
 }
 
-void KRSnapshotManager::CacheSnapshot(ArkUI_DrawableDescriptor *descriptor, const std::string &key) {
+void KRSnapshotManager::CacheSnapshot(napi_env env, napi_value drawableDescriptor, napi_value pixelMap,
+                                      ArkUI_DrawableDescriptor *descriptor, const std::string &key) {
     auto item = drawableDescriptorCache_.find(key);
     if (item != drawableDescriptorCache_.end()) {
         DisposeItem(&item->second);
     }
 
     if (descriptor) {
+        ArkTS arkTs(env);
         struct KRSnapshotItem item;
         item.drawableDescriptor = descriptor;
+        item.env = env;
+        item.drawableDescriptorRef = arkTs.CreateReference(drawableDescriptor);
+        item.pixelMapRef = arkTs.CreateReference(pixelMap);
         drawableDescriptorCache_[key] = item;
     } else {
         drawableDescriptorCache_.erase(key);
@@ -66,29 +89,23 @@ void KRSnapshotManager::CacheSnapshot(ArkUI_DrawableDescriptor *descriptor, cons
 void KRSnapshotManager::UpdateSnapshot(const std::string &uri, const std::string &key) {
     auto item = drawableDescriptorCache_.find(key);
     if (item != drawableDescriptorCache_.end()) {
-        if (item->second.drawableDescriptor) {
-            OH_ArkUI_DrawableDescriptor_Dispose(item->second.drawableDescriptor);
-            item->second.drawableDescriptor = nullptr;
-        }
         item->second.uri = uri;
     }
 }
 
-void KRSnapshotManager::SetCachedSnapshotToNode(ArkUI_NodeHandle node, const std::string &key) {
+bool KRSnapshotManager::SetCachedSnapshotToNode(ArkUI_NodeHandle node, const std::string &key) {
     auto item = drawableDescriptorCache_.find(key);
     if (item != drawableDescriptorCache_.end()) {
         if (item->second.uri.length() > 0) {
-            // when uri become valid, the cached drawable descriptor must had been disposed
             kuikly::util::SetArkUIImageSrc(node, item->second.uri);
-            return;
+            return true;
         }
         if (item->second.drawableDescriptor) {
-            // FIXME: using drawable would cause memory leak.
-            // Looks lie the internal pixelmap is retained somewhere by the system internally
             kuikly::util::SetArkUIImageSrc(node, item->second.drawableDescriptor);
-            return;
+            return true;
         }
     }
+    return false;
 }
 
 struct KRSnapshotManager::ResultData KRSnapshotManager::ProcessSnapshotResultWithDataType(
@@ -122,16 +139,15 @@ struct KRSnapshotManager::ResultData KRSnapshotManager::ProcessSnapshotResultWit
     return resultData;
 }
 
-void KRSnapshotManager::RemoveCachedDrawableAfterDelay(int delayMS, const std::string &key, const std::string &path,
-                                                       const std::string &pathUri,
-                                                       std::weak_ptr<IKRRenderViewExport> weak_view) {
+void KRSnapshotManager::UpdateCachedSnapshotUriAfterDelay(int delayMS, const std::string &key,
+                                                          const std::string &path, const std::string &pathUri,
+                                                          std::weak_ptr<IKRRenderViewExport> weak_view) {
     KRContextScheduler::ScheduleTask(false, delayMS, [delayMS, weak_view, path, pathUri, key]() {
         if (access(path.c_str(), F_OK) == 0) {
-            KRContextScheduler::ScheduleTaskOnMainThread(false, [delayMS, weak_view, pathUri, key] {
+            KRContextScheduler::ScheduleTaskOnMainThread(false, [weak_view, pathUri, key] {
                 if (auto strong_view = weak_view.lock()) {
                     if (auto strong_root = strong_view->GetRootView().lock()) {
-                        auto snapshotManager = strong_root->GetSnapshotManager();
-                        snapshotManager->UpdateSnapshot(pathUri, key);
+                        strong_root->GetSnapshotManager()->UpdateSnapshot(pathUri, key);
                     }
                 }
             });
@@ -142,15 +158,16 @@ void KRSnapshotManager::RemoveCachedDrawableAfterDelay(int delayMS, const std::s
             }
             if (auto root = strongView->GetRootView().lock()) {
                 auto snapshotManager = root->GetSnapshotManager();
-                snapshotManager->RemoveCachedDrawableAfterDelay(delayMS * 2, key, path, pathUri, weak_view);
+                snapshotManager->UpdateCachedSnapshotUriAfterDelay(delayMS * 2, key, path, pathUri, weak_view);
             }
         }
     });
 }
 
 struct KRSnapshotManager::ResultData KRSnapshotManager::ProcessSnapshotResultWithCacheKeyType(
-    napi_env env, napi_value pixelMap, const std::string &path, const std::string &pathUri,
-    ArkUI_DrawableDescriptor *drawableDescriptorPtr, std::weak_ptr<IKRRenderViewExport> weak_view) {
+    napi_env env, napi_value pixelMap, napi_value drawableDescriptor, const std::string &path,
+    const std::string &pathUri, ArkUI_DrawableDescriptor *drawableDescriptorPtr,
+    std::weak_ptr<IKRRenderViewExport> weak_view) {
     struct ResultData resultData;
     std::stringstream kss;
     kss << "data:image_Md5_Pixelmap" << drawableDescriptorPtr;
@@ -158,11 +175,9 @@ struct KRSnapshotManager::ResultData KRSnapshotManager::ProcessSnapshotResultWit
     if (auto strong_view = weak_view.lock()) {
         if (auto strong_root = strong_view->GetRootView().lock()) {
             auto snapshotManager = strong_root->GetSnapshotManager();
-            snapshotManager->CacheSnapshot(drawableDescriptorPtr, key);
-            // users would typically use the result immediately,
-            // keep the drawable for a while, and remove it after the disk copy is ready
-            snapshotManager->RemoveCachedDrawableAfterDelay(TIME_TO_REMOVE_SNAPSHOT_DRAWABLE_MS, key, path, pathUri,
-                                                            weak_view);
+            snapshotManager->CacheSnapshot(env, drawableDescriptor, pixelMap, drawableDescriptorPtr, key);
+            snapshotManager->UpdateCachedSnapshotUriAfterDelay(TIME_TO_UPDATE_SNAPSHOT_URI_MS, key, path, pathUri,
+                                                               weak_view);
         }
     }
     resultData.data = key;
@@ -237,7 +252,8 @@ void KRSnapshotManager::TakeSnapshot(const std::string &instance_id, const std::
                             pathURI = arkTs.GetString(uri);
                             if (type == "cacheKey") {
                                 resultData = snapshotManager->ProcessSnapshotResultWithCacheKeyType(
-                                    env, pixelMap, pathStr, pathURI, drawableDescriptorPtr, weak_view);
+                                    env, pixelMap, drawableDescriptor, pathStr, pathURI, drawableDescriptorPtr,
+                                    weak_view);
                             } else if (type == "file") {
                                 resultData = snapshotManager->ProcessSnapshotResultWithFileType(
                                     env, pixelMap, pathStr, pathURI, drawableDescriptorPtr, weak_view);

--- a/core-render-ohos/src/main/cpp/libohos_render/manager/KRSnapshotManager.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/manager/KRSnapshotManager.h
@@ -16,14 +16,18 @@
 #ifndef CORE_RENDER_OHOS_KRSNAPSHOTMANAGER_H
 #define CORE_RENDER_OHOS_KRSNAPSHOTMANAGER_H
 #include <arkui/drawable_descriptor.h>
+#include <js_native_api.h>
 #include <string>
 #include <unordered_map>
 #include "libohos_render/expand/components/view/KRView.h"
 #include "libohos_render/foundation/KRCommon.h"
 
 struct KRSnapshotItem {
-    KRSnapshotItem() : drawableDescriptor(nullptr) {}
+    KRSnapshotItem() : drawableDescriptor(nullptr), env(nullptr), drawableDescriptorRef(nullptr), pixelMapRef(nullptr) {}
     ArkUI_DrawableDescriptor *drawableDescriptor;
+    napi_env env;
+    napi_ref drawableDescriptorRef;
+    napi_ref pixelMapRef;
     std::string uri;
 };
 
@@ -31,7 +35,7 @@ class KRSnapshotManager {
  public:
     ~KRSnapshotManager();
 
-    void SetCachedSnapshotToNode(ArkUI_NodeHandle node, const std::string &key);
+    bool SetCachedSnapshotToNode(ArkUI_NodeHandle node, const std::string &key);
     void TakeSnapshot(const std::string &instance_id, const std::string &method_name, const std::string &nodeId,
                       const KRAnyValue &params, const KRRenderCallback &cb,
                       std::weak_ptr<IKRRenderViewExport> weak_view);
@@ -47,7 +51,8 @@ class KRSnapshotManager {
                                                         const std::string &pathUri,
                                                         ArkUI_DrawableDescriptor *drawableDescriptorPtr,
                                                         std::weak_ptr<IKRRenderViewExport> weak_view);
-    struct ResultData ProcessSnapshotResultWithCacheKeyType(napi_env env, napi_value pixelMap, const std::string &path,
+    struct ResultData ProcessSnapshotResultWithCacheKeyType(napi_env env, napi_value pixelMap,
+                                                            napi_value drawableDescriptor, const std::string &path,
                                                             const std::string &pathUri,
                                                             ArkUI_DrawableDescriptor *drawableDescriptorPtr,
                                                             std::weak_ptr<IKRRenderViewExport> weak_view);
@@ -56,10 +61,11 @@ class KRSnapshotManager {
                                                         ArkUI_DrawableDescriptor *drawableDescriptorPtr,
                                                         std::weak_ptr<IKRRenderViewExport> weak_view);
 
-    void CacheSnapshot(ArkUI_DrawableDescriptor *descriptor, const std::string &key);
+    void CacheSnapshot(napi_env env, napi_value drawableDescriptor, napi_value pixelMap,
+                       ArkUI_DrawableDescriptor *descriptor, const std::string &key);
     void UpdateSnapshot(const std::string &uri, const std::string &key);
-    void RemoveCachedDrawableAfterDelay(int delayMS, const std::string &key, const std::string &path,
-                                        const std::string &pathUri, std::weak_ptr<IKRRenderViewExport> weak_view);
+    void UpdateCachedSnapshotUriAfterDelay(int delayMS, const std::string &key, const std::string &path,
+                                           const std::string &pathUri, std::weak_ptr<IKRRenderViewExport> weak_view);
 
     std::unordered_map<std::string, struct KRSnapshotItem> drawableDescriptorCache_;
 };

--- a/core-render-ohos/src/main/ets/utils/KRPixelMapUtil.ets
+++ b/core-render-ohos/src/main/ets/utils/KRPixelMapUtil.ets
@@ -35,12 +35,25 @@ export class KRPixelMapUtil {
     const mimeType = 'image/png';
     const imagePackerApi = image.createImagePacker();
     const packOpts: image.PackingOption = { format: mimeType, quality: 100 }
-    return fs.open(filePath, fs.OpenMode.CREATE | fs.OpenMode.READ_WRITE)
-      .then((file) => {
-        return imagePackerApi.packToFile(pixelMap, file.fd, packOpts)
+    const tempFilePath = `${filePath}.tmp`;
+    let file: fs.File | null = null;
+    return fs.open(tempFilePath, fs.OpenMode.CREATE | fs.OpenMode.READ_WRITE)
+      .then((openedFile) => {
+        file = openedFile;
+        return imagePackerApi.packToFile(pixelMap, openedFile.fd, packOpts)
+      })
+      .then(() => {
+        if (file != null) {
+          fs.closeSync(file);
+          file = null;
+        }
+        return fs.rename(tempFilePath, filePath);
       })
       .then(() => filePath)
       .finally(() => {
+        if (file != null) {
+          fs.closeSync(file);
+        }
         imagePackerApi.release();
       });
   }

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/RootDemoPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/RootDemoPage.kt
@@ -137,6 +137,12 @@ internal class RootDemoPage: BasePager() {
             jumUrl = generateJumpUrl("image_demo")
             itemList.add(this)
         }
+        // ToImage Crash Repro
+        ButtonDataItem().apply {
+            title = "ToImageCrashRepro"
+            jumUrl = generateJumpUrl("ToImageCrashRepro")
+            itemList.add(this)
+        }
         // ViewDemo
         ButtonDataItem().apply {
             title = "ViewDemo"

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/ToImageCrashReproPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/ToImageCrashReproPage.kt
@@ -1,0 +1,283 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.demo.pages.demo
+
+import com.tencent.kuikly.core.annotations.Page
+import com.tencent.kuikly.core.base.Color
+import com.tencent.kuikly.core.base.DeclarativeBaseView
+import com.tencent.kuikly.core.base.ViewBuilder
+import com.tencent.kuikly.core.base.ViewRef
+import com.tencent.kuikly.core.log.KLog
+import com.tencent.kuikly.core.reactive.handler.observable
+import com.tencent.kuikly.core.timer.setTimeout
+import com.tencent.kuikly.core.views.DivView
+import com.tencent.kuikly.core.views.Image
+import com.tencent.kuikly.core.views.Scroller
+import com.tencent.kuikly.core.views.Text
+import com.tencent.kuikly.core.views.View
+import com.tencent.kuikly.demo.pages.base.BasePager
+import com.tencent.kuikly.demo.pages.demo.base.NavBar
+
+/**
+ * 复现 KRImageView::LoadFromBase64 中 SIGSEGV crash 的页面。
+ *
+ * 根因分析：
+ * 1. toImage(CACHE_KEY) 截图后，native 层会缓存 ArkUI_DrawableDescriptor* 并返回 cacheKey
+ * 2. cacheKey 对应的文件 uri 写入完成前，Image.src 会优先使用缓存中的 drawableDescriptor
+ * 3. drawableDescriptor 是从 ArkTS PixelMapDrawableDescriptor NAPI 对象转出的 raw pointer；
+ *    如果对象生命周期已经结束或 descriptor 已失效，ArkUI 在 GetPixelMap 时会触发 SIGSEGV
+ *
+ * 复现方式：
+ * - 对一个大 View 截图获取 cacheKey，拖慢异步写文件速度
+ * - cacheKey 返回后立刻设置 Image.src，并在 0~100ms 内多次重设
+ * - 或者快速连续截图，使多个 cacheKey 的 drawableDescriptor 生命周期交错
+ */
+@Page("ToImageCrashRepro")
+internal class ToImageCrashReproPage : BasePager() {
+
+    companion object {
+        private const val TAG = "ToImageCrashRepro"
+    }
+
+    private var viewRef: ViewRef<DivView>? = null
+    private var imageSrc by observable("")
+    private var statusText by observable("点击按钮开始复现")
+    private var counter by observable(0)
+    private var lastCacheKey by observable("")
+
+    private fun log(message: String) {
+        println("[$TAG] $message")
+        KLog.i(TAG, message)
+    }
+
+    private fun scheduleSetImageSrc(cacheKey: String, delays: IntArray, label: String) {
+        delays.forEach { delay ->
+            setTimeout(delay) {
+                log("$label set Image.src after ${delay}ms, cacheKey=$cacheKey")
+                imageSrc = ""
+                setTimeout(0) {
+                    imageSrc = cacheKey
+                    statusText = "$label: ${delay}ms 设置 Image.src"
+                }
+            }
+        }
+    }
+
+    private fun snapshotAndSchedule(delays: IntArray, label: String, sampleSize: Int = 1) {
+        counter++
+        statusText = "$label: 截图中..."
+        viewRef?.view?.toImage(DeclarativeBaseView.ImageType.CACHE_KEY, sampleSize) { result ->
+            val code = result?.optInt("code") ?: -1
+            val data = result?.optString("data") ?: ""
+            log("$label toImage result: code=$code, data=$data")
+            if (code == 0 && data.isNotEmpty()) {
+                lastCacheKey = data
+                statusText = "$label: cacheKey已返回，立即设置src"
+                imageSrc = data
+                scheduleSetImageSrc(data, delays, label)
+            } else {
+                statusText = "$label: 截图失败 code=$code"
+            }
+        }
+    }
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            NavBar { attr { title = "ToImage Crash 复现" } }
+
+            Scroller {
+                attr {
+                    flex(1f)
+                    alignSelfStretch()
+                    paddingBottom(30f)
+                }
+
+                // 被截图的目标 View：尽量做大并包含多层子节点，拖慢 cacheKey 对应文件落盘
+                View {
+                    ref { ctx.viewRef = it }
+                    attr {
+                        margin(10f)
+                        padding(10f)
+                        height(720f)
+                        alignSelfStretch()
+                        backgroundColor(Color(0xFF4CAF50))
+                        borderRadius(8f)
+                    }
+                    Text {
+                        attr {
+                            fontSize(16f)
+                            color(Color.WHITE)
+                            text("大截图目标区域 counter=${ctx.counter}")
+                        }
+                    }
+                    repeat(18) { index ->
+                        View {
+                            attr {
+                                marginTop(8f)
+                                height(28f)
+                                alignSelfStretch()
+                                backgroundColor(Color(0xFF00695C + index * 0x000505))
+                                borderRadius(4f)
+                            }
+                            Text {
+                                attr {
+                                    marginLeft(8f)
+                                    fontSize(12f)
+                                    color(Color.WHITE)
+                                    text("snapshot row $index / counter=${ctx.counter}")
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // 显示截图结果的 Image
+                View {
+                    attr {
+                        margin(10f)
+                        height(150f)
+                        allCenter()
+                        backgroundColor(Color(0xFFEEEEEE))
+                        borderRadius(8f)
+                    }
+                    Image {
+                        attr {
+                            size(260f, 130f)
+                            src(ctx.imageSrc)
+                        }
+                    }
+                }
+
+                // 状态文本
+                Text {
+                    attr {
+                        margin(10f)
+                        fontSize(14f)
+                        color(Color(0xFF666666))
+                        text(ctx.statusText)
+                    }
+                }
+                Text {
+                    attr {
+                        marginLeft(10f)
+                        marginRight(10f)
+                        marginBottom(8f)
+                        fontSize(12f)
+                        color(Color(0xFF999999))
+                        text("lastCacheKey=${ctx.lastCacheKey}")
+                    }
+                }
+
+                // 方式1：cacheKey 返回后在 URI 替换前多窗口设置 Image.src
+                View {
+                    attr {
+                        margin(10f)
+                        padding(15f)
+                        allCenter()
+                        backgroundColor(Color(0xFFFF5722))
+                        borderRadius(8f)
+                    }
+                    Text {
+                        attr {
+                            fontSize(14f)
+                            color(Color.WHITE)
+                            text("方式1: 返回后0/16/32/64/90ms设置src")
+                        }
+                    }
+                    event {
+                        click {
+                            ctx.snapshotAndSchedule(intArrayOf(0, 16, 32, 64, 90), "短窗口")
+                        }
+                    }
+                }
+
+                // 方式2：快速连续截图并使用每次返回的 cacheKey
+                View {
+                    attr {
+                        margin(10f)
+                        padding(15f)
+                        allCenter()
+                        backgroundColor(Color(0xFF2196F3))
+                        borderRadius(8f)
+                    }
+                    Text {
+                        attr {
+                            fontSize(14f)
+                            color(Color.WHITE)
+                            text("方式2: 连续8次截图 + 多窗口设置src")
+                        }
+                    }
+                    event {
+                        click {
+                            ctx.statusText = "连续截图压测中..."
+                            repeat(8) { i ->
+                                setTimeout(i * 24) {
+                                    ctx.snapshotAndSchedule(intArrayOf(0, 16, 48, 96), "连续$i")
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // 方式3：复用同一个 cacheKey 高频重设 Image.src
+                View {
+                    attr {
+                        margin(10f)
+                        padding(15f)
+                        allCenter()
+                        backgroundColor(Color(0xFF9C27B0))
+                        borderRadius(8f)
+                    }
+                    Text {
+                        attr {
+                            fontSize(14f)
+                            color(Color.WHITE)
+                            text("方式3: 单个cacheKey高频重设40次")
+                        }
+                    }
+                    event {
+                        click {
+                            ctx.counter++
+                            ctx.statusText = "高频重设准备截图中..."
+                            ctx.viewRef?.view?.toImage(DeclarativeBaseView.ImageType.CACHE_KEY, 1) { result ->
+                                val code = result?.optInt("code") ?: -1
+                                val key = result?.optString("data") ?: ""
+                                ctx.log("高频重设 toImage result: code=$code, data=$key")
+                                if (code == 0 && key.isNotEmpty()) {
+                                    ctx.lastCacheKey = key
+                                    ctx.imageSrc = key
+                                    repeat(40) { i ->
+                                        setTimeout(i * 8) {
+                                            ctx.log("高频重设[$i], cacheKey=$key")
+                                            ctx.imageSrc = ""
+                                            setTimeout(0) {
+                                                ctx.imageSrc = key
+                                                ctx.statusText = "高频重设第${i}次"
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    ctx.statusText = "高频重设截图失败 code=$code"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/catalog/ExampleIndexPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/catalog/ExampleIndexPage.kt
@@ -118,6 +118,13 @@ internal class ExampleIndexPage : BasePager() {
         })
 
         itemList.add(ExampleItemData().apply {
+            avatarText = "Cr"
+            titleText = "ToImage Crash Repro"
+            subtitleText = "复现鸿蒙 toImage(CACHE_KEY) 延迟设置 Image src 的 crash"
+            declarativeExampleUrl = generateJumpUrl("ToImageCrashRepro")
+        })
+
+        itemList.add(ExampleItemData().apply {
             avatarText = "In"
             titleText = "InputView"
             subtitleText = "单行输入框组件"


### PR DESCRIPTION
The HarmonyOS renderer cached the raw ArkUI_DrawableDescriptor returned from toImage(CACHE_KEY), then immediately allowed Image.src to consume the cache key before the async file copy completed. Because the descriptor was backed by ArkTS PixelMap/PixelMapDrawableDescriptor objects whose lifetime was not retained by native, ArkUI could crash with SIGSEGV while resolving the cached descriptor.

Fix this by retaining the ArkTS drawable descriptor and pixelMap through napi_ref for the lifetime of the snapshot cache item. The cache now keeps the drawable path as a fast fallback and updates the file URI once the snapshot file is available, without prematurely releasing the descriptor.