### PR TITLE
fix(compose/js): add @file:NoLiveLiterals to fix LiveLiteralTransformer duplicate key error

### DIFF
--- a/compose/src/jsMain/kotlin/com/tencent/kuikly/compose/ui/util/InlineClassHelper.js.kt
+++ b/compose/src/jsMain/kotlin/com/tencent/kuikly/compose/ui/util/InlineClassHelper.js.kt
@@ -5,8 +5,11 @@
  * you may not use this file except in compliance with the License.
  */
 
+@file:NoLiveLiterals
+
 package com.tencent.kuikly.compose.ui.util
 
+import androidx.compose.runtime.NoLiveLiterals
 import kotlin.math.floor
 
 /*


### PR DESCRIPTION
## Summary

- Add `@file:NoLiveLiterals` annotation to `InlineClassHelper.js.kt` to fix a Compose compiler crash during JS compilation
- The `LiveLiteralTransformer` throws `IllegalStateException: Duplicate live literal key found: Int$fun-packFloatsP` when encountering repeated numeric constants (`INT_PACKED_FAST_BASE`, `INT_PACKED_FAST_MIN`, etc.) in the packed-value helper functions
- `@file:NoLiveLiterals` tells the Compose compiler to skip live literal transformation for this file, which is safe since this file contains no UI composables — only pure bit-manipulation utilities

## Root Cause

The Compose compiler's `LiveLiteralTransformer` generates a unique key per literal per function. When the same constant value (e.g. `67108864.0`) appears in multiple functions across the file, the transformer incorrectly detects duplicate keys and throws an internal error.

## Verification

Verified locally with `./gradlew -c settings.compose-js-only.gradle.kts :compose:compileKotlinJs`: **BUILD SUCCESSFUL**

🤖 Generated with [Claude Code](https://claude.com/claude-code)