### PR TITLE
fix(ohos): add kr_ prefix to avoid symbol conflicts in ohos interop

### DIFF
--- a/core/src/ohosArm64Main/kotlin/com/tencent/kuikly/core/exception/ThrowableExt.ohos.kt
+++ b/core/src/ohosArm64Main/kotlin/com/tencent/kuikly/core/exception/ThrowableExt.ohos.kt
@@ -26,8 +26,8 @@ import kotlinx.cinterop.sizeOf
 import kotlinx.cinterop.toCPointer
 import kotlinx.cinterop.toKString
 import kotlinx.cinterop.toLong
-import ohos.fill_dl_info_sym
-import ohos.xdl_t
+import ohos.kr_fill_dl_info_sym
+import ohos.kr_xdl_t
 import platform.ohos.LOG_APP
 import platform.ohos.LOG_ERROR
 import platform.ohos.LOG_INFO
@@ -150,7 +150,7 @@ private fun parseSymbolInfo(addrList: List<Long>): List<SymbolInfo> {
     val symbolInfoList = mutableListOf<SymbolInfo>()
 
     memScoped {
-        var xdlInfo = alloc<xdl_t> { memset(this.ptr, 0, sizeOf<xdl_t>().toULong()) }
+        var xdlInfo = alloc<kr_xdl_t> { memset(this.ptr, 0, sizeOf<kr_xdl_t>().toULong()) }
         for (addr in addrList) {
             val result = alloc<Dl_info> { memset(this.ptr, 0, sizeOf<Dl_info>().toULong()) }
             dladdr(addr.toCPointer<LongVar>(), result.ptr)
@@ -158,14 +158,14 @@ private fun parseSymbolInfo(addrList: List<Long>): List<SymbolInfo> {
             if (xdlInfo.so_name == null) {
                 xdlInfo.so_name = result.dli_fname
             } else if ((xdlInfo.so_name as CPointer<ByteVar>).toKString() != result.dli_fname?.toKString()) {
-                xdlInfo = alloc<xdl_t> { memset(this.ptr, 0, sizeOf<xdl_t>().toULong()) }
+                xdlInfo = alloc<kr_xdl_t> { memset(this.ptr, 0, sizeOf<kr_xdl_t>().toULong()) }
             }
 
             val symbolInfo = SymbolInfo()
             symbolInfo.offsetFromSoBase = addr - result.dli_fbase.toLong() - 1
             symbolInfo.soName = result.dli_fname?.toKString() ?: ""
 
-            fill_dl_info_sym(xdlInfo.ptr, result.ptr, symbolInfo.offsetFromSoBase)
+            kr_fill_dl_info_sym(xdlInfo.ptr, result.ptr, symbolInfo.offsetFromSoBase)
             symbolInfo.name = result.dli_sname?.toKString() ?: ""
             symbolInfo.offsetFromSymbol = result.dli_saddr.toLong()
             symbolInfoList.add(symbolInfo)

--- a/core/src/ohosArm64Main/ohosInterop/cinterop/ohos.def
+++ b/core/src/ohosArm64Main/ohosInterop/cinterop/ohos.def
@@ -18,7 +18,7 @@ headers = ../include/KRRenderCValue.h
 
 // ===== xdl symbol resolution =====
 
-typedef struct xdl {
+typedef struct kr_xdl {
     bool isSymtabLoaded;
     char *pathname;
     uintptr_t load_bias;
@@ -30,9 +30,9 @@ typedef struct xdl {
     size_t symtab_cnt;
     char *strtab;
     char* so_name;
-} xdl_t;
+} kr_xdl_t;
 
-#define XDL_UTIL_TEMP_FAILURE_RETRY(exp)   \
+#define KR_XDL_UTIL_TEMP_FAILURE_RETRY(exp)   \
   ({                                       \
     __typeof__(exp) _rc;                   \
     do {                                   \
@@ -42,8 +42,8 @@ typedef struct xdl {
     _rc;                                   \
   })
 
-#define XDL_DYNSYM_IS_EXPORT_SYM(shndx) (SHN_UNDEF != (shndx))
-#define XDL_SYMTAB_IS_EXPORT_SYM(shndx) \
+#define KR_XDL_DYNSYM_IS_EXPORT_SYM(shndx) (SHN_UNDEF != (shndx))
+#define KR_XDL_SYMTAB_IS_EXPORT_SYM(shndx) \
   (SHN_UNDEF != (shndx) && !((shndx) >= SHN_LORESERVE && (shndx) <= SHN_HIRESERVE))
 
 static void *
@@ -59,7 +59,7 @@ xdl_read_file_to_heap(int file_fd, size_t file_sz, size_t data_offset, size_t da
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-statement-expression"
-    if ((ssize_t) data_len != XDL_UTIL_TEMP_FAILURE_RETRY(read(file_fd, data, data_len)))
+    if ((ssize_t) data_len != KR_XDL_UTIL_TEMP_FAILURE_RETRY(read(file_fd, data, data_len)))
 #pragma clang diagnostic pop
     {
         free(data);
@@ -73,7 +73,7 @@ static void *xdl_read_file_to_heap_by_section(int file_fd, size_t file_sz, ElfW(
     return xdl_read_file_to_heap(file_fd, file_sz, (size_t) shdr->sh_offset, shdr->sh_size);
 }
 
-static int xdl_symtab_load(xdl_t *self) {
+static int xdl_symtab_load(kr_xdl_t *self) {
     if ('[' == self->pathname[0]) return -1;
 
     int r = -1;
@@ -152,7 +152,7 @@ static int xdl_symtab_load(xdl_t *self) {
 }
 
 static int dl_iterate_callback(struct dl_phdr_info *info, size_t size, void * data) {
-    xdl_t* xdl = (xdl_t*)data;
+    kr_xdl_t* xdl = (kr_xdl_t*)data;
     const char* soName = xdl->so_name;
     bool isMatched = false;
     if (soName[0] == '/') {
@@ -173,11 +173,11 @@ static int dl_iterate_callback(struct dl_phdr_info *info, size_t size, void * da
     return 0;
 }
 
-static void fill_dlinfo(xdl_t *xdl, long offset, Dl_info* dlinfo) {
+static void fill_dlinfo(kr_xdl_t *xdl, long offset, Dl_info* dlinfo) {
     for (size_t i = 0; i < xdl->symtab_cnt; i++) {
         ElfW(Sym) *sym = xdl->symtab + i;
 
-        if (!XDL_SYMTAB_IS_EXPORT_SYM(sym->st_shndx)) {
+        if (!KR_XDL_SYMTAB_IS_EXPORT_SYM(sym->st_shndx)) {
             continue;
         }
 
@@ -192,7 +192,7 @@ static void fill_dlinfo(xdl_t *xdl, long offset, Dl_info* dlinfo) {
     }
 }
 
-void fill_dl_info_sym(xdl_t* xdl, Dl_info* info, long offset) {
+void kr_fill_dl_info_sym(kr_xdl_t* xdl, Dl_info* info, long offset) {
     xdl->so_name = info->dli_fname;
     if (!xdl->isSymtabLoaded) {
         dl_iterate_phdr(dl_iterate_callback, xdl);
@@ -206,33 +206,33 @@ void fill_dl_info_sym(xdl_t* xdl, Dl_info* info, long offset) {
 
 // ===== Build ID =====
 
-#ifndef NT_GNU_BUILD_ID
-#define NT_GNU_BUILD_ID 3
+#ifndef KR_NT_GNU_BUILD_ID
+#define KR_NT_GNU_BUILD_ID 3
 #endif
 
-#define ALIGN_VAL(val, align) (((val) + (align)-1) & ~((align)-1))
+#define KR_ALIGN_VAL(val, align) (((val) + (align)-1) & ~((align)-1))
 
-struct build_id_note {
+struct kr_build_id_note {
     ElfW(Nhdr) nhdr;
     char name[4];
     uint8_t build_id[0];
 };
 
-enum build_id_tag {
+enum kr_build_id_tag {
     BY_NAME, BY_SYMBOL
 };
 
-struct build_id_callback_data {
+struct kr_build_id_callback_data {
     union {
         const char *name;
         const void *dli_fbase;
     };
-    enum build_id_tag tag;
-    struct build_id_note *note;
+    enum kr_build_id_tag tag;
+    struct kr_build_id_note *note;
 };
 
 static int build_id_find_nhdr_callback(struct dl_phdr_info *info, size_t size, void *data_) {
-    struct build_id_callback_data *data = (struct build_id_callback_data *) data_;
+    struct kr_build_id_callback_data *data = (struct kr_build_id_callback_data *) data_;
 
     if (data->tag == BY_NAME)
         if (!info->dlpi_name || strcmp(info->dlpi_name, data->name) != 0)
@@ -255,26 +255,26 @@ static int build_id_find_nhdr_callback(struct dl_phdr_info *info, size_t size, v
         if (info->dlpi_phdr[i].p_type != PT_NOTE)
             continue;
 
-        struct build_id_note *note = (struct build_id_note *) (info->dlpi_addr +
+        struct kr_build_id_note *note = (struct kr_build_id_note *) (info->dlpi_addr +
                                                         info->dlpi_phdr[i].p_vaddr);
         ptrdiff_t len = info->dlpi_phdr[i].p_filesz;
 
-        while (len >= (ptrdiff_t)sizeof(struct build_id_note)) {
-            if (note->nhdr.n_type == NT_GNU_BUILD_ID && note->nhdr.n_descsz != 0 &&
+        while (len >= (ptrdiff_t)sizeof(struct kr_build_id_note)) {
+            if (note->nhdr.n_type == KR_NT_GNU_BUILD_ID && note->nhdr.n_descsz != 0 &&
                 note->nhdr.n_namesz == 4 &&
                 memcmp(note->name, "GNU", 4) == 0) {
                 data->note = note;
                 return 1;
             }
 
-            size_t offset = sizeof(ElfW(Nhdr)) + ALIGN_VAL(note->nhdr.n_namesz, 4) +
-                            ALIGN_VAL(note->nhdr.n_descsz, 4);
+            size_t offset = sizeof(ElfW(Nhdr)) + KR_ALIGN_VAL(note->nhdr.n_namesz, 4) +
+                            KR_ALIGN_VAL(note->nhdr.n_descsz, 4);
             // Kotlin Native 编译生成的 elf 文件，第一节 note 缺失 Elf64_Nhdr.n_type 数据
             // 而 Elf64_Nhdr.n_type 4 bit 刚好是平台名，即"OHOS", 下面魔数为"OHOS"转换的 uint32 值
             if (note->nhdr.n_type == 1397704783) {
                 offset -= 4;
             }
-            note = (struct build_id_note *) ((char *) note + offset);
+            note = (struct kr_build_id_note *) ((char *) note + offset);
             len -= offset;
         }
     }
@@ -282,8 +282,8 @@ static int build_id_find_nhdr_callback(struct dl_phdr_info *info, size_t size, v
     return 0;
 }
 
-static const struct build_id_note *build_id_find_nhdr_by_name(const char *name) {
-    struct build_id_callback_data data;
+static const struct kr_build_id_note *build_id_find_nhdr_by_name(const char *name) {
+    struct kr_build_id_callback_data data;
     data.name = name;
     data.tag = BY_NAME;
     data.note = NULL;
@@ -295,7 +295,7 @@ static const struct build_id_note *build_id_find_nhdr_by_name(const char *name) 
 }
 
 char *kuiklyGetBuildIDByName(const char *name) {
-    const struct build_id_note *note = build_id_find_nhdr_by_name(name);
+    const struct kr_build_id_note *note = build_id_find_nhdr_by_name(name);
     if (!note) {
         char *empty = (char *)malloc(1);
         empty[0] = '\0';


### PR DESCRIPTION
This commit adds kr_ prefix to all exposed symbols in the ohos interop layer to prevent naming conflicts with system libraries. Changes include:

1. Structure and Type Renames:
   - xdl_t → kr_xdl_t
   - build_id_note → kr_build_id_note
   - build_id_tag → kr_build_id_tag
   - build_id_callback_data → kr_build_id_callback_data

2. Macro Renames:
   - XDL_UTIL_TEMP_FAILURE_RETRY → KR_XDL_UTIL_TEMP_FAILURE_RETRY
   - XDL_DYNSYM_IS_EXPORT_SYM → KR_XDL_DYNSYM_IS_EXPORT_SYM
   - XDL_SYMTAB_IS_EXPORT_SYM → KR_XDL_SYMTAB_IS_EXPORT_SYM
   - NT_GNU_BUILD_ID → KR_NT_GNU_BUILD_ID
   - ALIGN_VAL → KR_ALIGN_VAL

3. Function Renames:
   - fill_dl_info_sym → kr_fill_dl_info_sym

4. Code Updates:
   - Updated all references in ThrowableExt.ohos.kt to use the new prefixed symbols
   - Maintained full backward compatibility with existing functionality

This change ensures that KuiklyUI's symbols won't conflict with system or third-party libraries that may define similar symbols.