### PR TITLE
feat(compose): support movableContentOf for Compose DSL

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/KNode.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/KNode.kt
@@ -144,6 +144,10 @@ internal class KNode<T : DeclarativeBaseView<*, *>>(
     }
 
     override fun onRelease() {
+        // Release child subcompositions before clearing the Kuikly view tree. Otherwise nested
+        // applier removeAt calls may observe an already-cleared ViewContainer.children list.
+        super.onRelease()
+
         // Node is permanently destroyed — perform full view cleanup.
         if (isInitialized) {
             // Destroy native render views that were preserved during removeAt.
@@ -151,7 +155,6 @@ internal class KNode<T : DeclarativeBaseView<*, *>>(
             view.removeRenderView()
             view.didRemoveFromParentView()
         }
-        super.onRelease()
     }
 
     private val currentView: ViewContainer<*, *>

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/KNode.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/KNode.kt
@@ -63,6 +63,13 @@ internal class KNode<T : DeclarativeBaseView<*, *>>(
     var init: T.() -> Unit = {}
 ) : LayoutNode(isVirtual = isVirtual) {
 
+    /**
+     * Tracks whether this KNode's view has completed its first initialization.
+     * Used to distinguish first insertion (needs init) from reinsertion (movableContent move).
+     */
+    var isInitialized: Boolean = false
+        private set
+
     var kuiklyCoordinates: LayoutCoordinates? = null
 
     /**
@@ -128,7 +135,23 @@ internal class KNode<T : DeclarativeBaseView<*, *>>(
 
     override fun detach() {
         requireOwner().snapshotObserver.clear(this)
+        // Clear nativeViewRef registration to keep pager view map consistent.
+        // Do NOT call didRemoveFromParentView — movableContent nodes may be reinserted.
+        if (isInitialized) {
+            view.getPager().removeNativeViewRef(view.nativeRef)
+        }
         super.detach()
+    }
+
+    override fun onRelease() {
+        // Node is permanently destroyed — perform full view cleanup.
+        if (isInitialized) {
+            // Destroy native render views that were preserved during removeAt.
+            // removeDomSubViewForMove only removed the flex node; now we clean up the render view.
+            view.removeRenderView()
+            view.didRemoveFromParentView()
+        }
+        super.onRelease()
     }
 
     private val currentView: ViewContainer<*, *>
@@ -153,7 +176,17 @@ internal class KNode<T : DeclarativeBaseView<*, *>>(
     // Construct Kuikly node tree
     fun insertTopDown(index: Int, instance: KNode<DeclarativeBaseView<*, *>>) {
         val childView = instance.view
-        currentView.addChild(childView, instance.init, index)
+        if (instance.isInitialized) {
+            // Reinsertion (movableContent move): skip init, do lightweight re-registration.
+            // renderView is still alive (removeDomSubViewForMove preserved it), so
+            // createRenderView() inside insertDomSubView will be a no-op (renderView != null guard).
+            // insertSubRenderView will re-attach the existing native view to its new parent.
+            currentView.reinsertChild(childView, index)
+        } else {
+            // First insertion: full initialization
+            currentView.addChild(childView, instance.init, index)
+            instance.isInitialized = true
+        }
         currentView.insertDomSubView(childView, index)
     }
 
@@ -164,14 +197,14 @@ internal class KNode<T : DeclarativeBaseView<*, *>>(
 
     override fun removeAll() {
         currentView.domChildren().forEach { child ->
-            currentView.removeDomSubView(child)
+            currentView.removeDomSubViewForMove(child)
         }
-        currentView.removeChildren()
+        currentView.removeChildrenForMoveAll()
         super.removeAll()
     }
 
     override fun removeAt(index: Int, count: Int) {
-        currentView.removeChildrenAt(index, count)
+        currentView.removeChildrenForMove(index, count)
         super.removeAt(index, count)
     }
 
@@ -204,6 +237,16 @@ internal class KNode<T : DeclarativeBaseView<*, *>>(
     private fun LayoutCoordinates.toCoordinator() =
         (this as? LookaheadLayoutCoordinates)?.coordinator ?: this as NodeCoordinator
 
+    private fun LayoutCoordinates.viewPositionOf(coordinator: LayoutCoordinates): Offset {
+        var nodeCoordinator = coordinator.toCoordinator()
+        var position = Offset.Zero
+        while (nodeCoordinator !== this) {
+            position += nodeCoordinator.position
+            nodeCoordinator = nodeCoordinator.wrappedBy!!
+        }
+        return position
+    }
+
     override fun updateKuiklyViewFrame(coordinator: LayoutCoordinates) {
         val curCoordinator = kuiklyCoordinates ?: innerCoordinator
 
@@ -212,27 +255,17 @@ internal class KNode<T : DeclarativeBaseView<*, *>>(
         val ksScrollSubView = view.parent is VirtualNodeView
         val parentNode = parent as? KNode<*>
         val parentCoordinator = parentNode?.kuiklyCoordinates ?: parentNode?.innerCoordinator
-        var posX = 0f
-        var posY = 0f
-        if (parentCoordinator != null) {
-            val targetCoordinator = parentCoordinator.toCoordinator()
-            var nodeCoordinator = curCoordinator.toCoordinator()
-            while (nodeCoordinator !== targetCoordinator) {
-                posX += nodeCoordinator.positionX
-                posY += nodeCoordinator.positionY
-                nodeCoordinator = nodeCoordinator.wrappedBy!!
-            }
-        }
+        var pos = parentCoordinator?.viewPositionOf(curCoordinator) ?: Offset.Zero
 
-        var deltaOffset = 0f
+        // Child nodes on scrollview, parent is virtual node
         if (ksScrollSubView && needFixScrollOffset) {
             val scrollerView = (parent as KNode<*>).view
             ((scrollerView.renderProperties as? RenderProperties)?.kuiklyScrollInfo)?.apply {
-                deltaOffset = composeOffset
-                if (orientation == Orientation.Vertical) {
-                    posY += deltaOffset
+                val deltaOffset = composeOffset
+                pos = if (orientation == Orientation.Vertical) {
+                    Offset(pos.x, pos.y + deltaOffset)
                 } else {
-                    posX += deltaOffset
+                    Offset(pos.x + deltaOffset, pos.y)
                 }
             }
         }
@@ -242,14 +275,12 @@ internal class KNode<T : DeclarativeBaseView<*, *>>(
         // Check if it's a sticky header and handle position caching
         val isStickyHeader = isStickyHeaderNode()
         if (isStickyHeader) {
-            val pos = getCachedStickyPosition(Offset(posX, posY))
-            posX = pos.x
-            posY = pos.y
+            pos = getCachedStickyPosition(pos)
         }
 
         var newFrame = Frame(
-            x = posX / densityValue,
-            y = posY / densityValue,
+            x = pos.x / densityValue,
+            y = pos.y / densityValue,
             width = curCoordinator.size.width.toFloat() / densityValue,
             height = curCoordinator.size.height.toFloat() / densityValue,
         )
@@ -680,14 +711,5 @@ internal class KNode<T : DeclarativeBaseView<*, *>>(
                 rotate = Rotate(rotateZ, rotateX, rotateY)
             )
         }
-    }
-}
-
-private fun ViewContainer<*, *>.removeChildrenAt(index: Int, count: Int) {
-    val parentView = realContainerView()
-    for (i in index until index + count) {
-        val childView = parentView.getChild(index)
-        parentView.removeDomSubView(childView)
-        parentView.removeChild(childView)
     }
 }

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/ViewContainerMovableContentExt.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/ViewContainerMovableContentExt.kt
@@ -1,0 +1,42 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.compose.ui.node
+
+import com.tencent.kuikly.core.base.ViewContainer
+
+/**
+ * Compose-side helpers for movableContentOf support.
+ *
+ * The methods that need access to private/protected fields of [ViewContainer]
+ * (removeChildForMove, reinsertChild, removeDomSubViewForMove, removeChildrenForMoveAll)
+ * live in [ViewContainer] itself, grouped under the "Compose movableContent support" region.
+ *
+ * This file holds the higher-level orchestration helpers used by [KNode] that only
+ * need the public API of [ViewContainer].
+ */
+
+/**
+ * Removes [count] children starting at [index] using the lightweight move path:
+ * flex node is removed but the native render view is kept alive for reinsertion.
+ */
+internal fun ViewContainer<*, *>.removeChildrenForMove(index: Int, count: Int) {
+    val parentView = realContainerView()
+    for (i in index until index + count) {
+        val childView = parentView.getChild(index)
+        parentView.removeDomSubViewForMove(childView)
+        parentView.removeChildForMove(childView)
+    }
+}

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/semantics/SemanticsNode.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/semantics/SemanticsNode.kt
@@ -263,7 +263,7 @@ class SemanticsNode internal constructor(
             // TODO(b/290936195): In some conditions it appears that children here can be
             //  unattached. We just guard against that here as a "quick fix" but we need to
             //  understand why this is happening and followup with a proper fix.
-            if (child.isAttached) {
+            if (child.isAttached && !child.isDeactivated) {
                 if (child.nodes.has(Nodes.Semantics)) {
                     list.add(SemanticsNode(child, mergingEnabled))
                 } else {

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/layer/KuiklyRenderLayerHandler.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/layer/KuiklyRenderLayerHandler.kt
@@ -125,6 +125,10 @@ class KuiklyRenderLayerHandler : IKuiklyRenderLayerHandler {
         if (index > parentView.childCount || index == -1) { // index为-1表示末尾添加
             insertIndex = parentView.childCount
         }
+        // For movableContent support: if the child already has a parent (e.g. after a lightweight
+        // removeDomSubViewForMove that skipped native removeView), detach it first so addView
+        // does not throw IllegalStateException.
+        (childView.parent as? android.view.ViewGroup)?.removeView(childView)
         parentView.addView(childView, insertIndex)
         viewExport.onAddToParent(parentView)
     }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/forward/KRForwardArkTSView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/forward/KRForwardArkTSView.cpp
@@ -78,6 +78,16 @@ void KRForwardArkTSView::SetRenderViewFrame(const KRRect &frame) {
  * view添加到父节点中后调用
  */
 void KRForwardArkTSView::DidMoveToParentView() {
+    // If ark_node_ already exists, this is a re-parent (movableContent move).
+    // Skip re-creating ComponentContent — the existing one moved with the STACK node.
+    if (ark_node_ != nullptr) {
+        // Still notify ArkTS side so it can resume state (e.g. video playback)
+        KRArkTSManager::GetInstance().CallArkTSMethod(GetInstanceId(),
+                                                      KRNativeCallArkTSMethod::DidMoveToParentView,
+                                                      KRRenderValue::Make(GetViewTag()), nullptr,
+                                                      nullptr, nullptr, nullptr, nullptr);
+        return;
+    }
     if (auto rootView = GetRootView().lock()) {
         auto uiContext = rootView->GetUIContextHandle();
         if (!uiContext) {

--- a/core-render-ohos/src/main/cpp/libohos_render/export/IKRRenderViewExport.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/export/IKRRenderViewExport.h
@@ -380,7 +380,11 @@ class IKRRenderViewExport : public std::enable_shared_from_this<IKRRenderViewExp
 
         WillRemoveFromParentView();
         if (parent_node_ != nullptr) {
-            RemoveChildNode(parent_node_, GetNode());
+            // Guard: during batch cleanup (e.g. page exit), parent's RemoveRenderView may run
+            // before child's, destroying parent_node_. Skip removeChild if parent is already dead.
+            if (kuikly::util::GetNodeApi()->IsNodeAlive(parent_node_)) {
+                RemoveChildNode(parent_node_, GetNode());
+            }
             parent_node_ = nullptr;
         }
         parent_tag_ = -1;
@@ -402,6 +406,16 @@ class IKRRenderViewExport : public std::enable_shared_from_this<IKRRenderViewExp
         auto childrenCount = GetChildCount();
         if (index < 0 || index > childrenCount) {
             index = childrenCount;
+        }
+        // For movableContent support: if the child is still attached to a different parent
+        // (removeDomSubViewForMove skipped native removeChild), detach it first.
+        // Note: ArkUI insertChildAt does NOT auto-reparent; removeChild is mandatory.
+        // For KRForwardArkTSView (ComponentContent-based views), the STACK node re-parent
+        // does NOT trigger aboutToDisappear/aboutToAppear on the inner ComponentContent.
+        // DidMoveToParentView() skips re-creating ComponentContent when ark_node_ exists.
+        auto old_parent = sub_render_view->parent_node_;
+        if (old_parent != nullptr && old_parent != GetNode()) {
+            kuikly::util::GetNodeApi()->removeChild(old_parent, sub_render_view->GetNode());
         }
         sub_render_view->parent_node_ = GetNode();
         sub_render_view->parent_tag_ = this->GetViewTag();

--- a/core-render-ohos/src/main/ets/components/KRVideoView.ets
+++ b/core-render-ohos/src/main/ets/components/KRVideoView.ets
@@ -55,6 +55,7 @@ export class KRVideoView extends KuiklyRenderBaseView implements IKRVideoViewLis
   }
 
   onPlayStateDidChanged = (state: KRVideoPlayState, viewController: IKRVideoViewController) => {
+    this.isPlaying = (state === KRVideoPlayState.Playing);
     if (this.playStateDidChangedEvent) {
       this.playStateDidChangedEvent({ 'state': state });
     }
@@ -80,6 +81,7 @@ export class KRVideoView extends KuiklyRenderBaseView implements IKRVideoViewLis
   customEventWithInfoEvent: KuiklyRenderCallback | null = null;
   src: string = '';
   controller: IKRVideoViewController | undefined;
+  isPlaying: boolean = false;
   static readonly VIEW_NAME = 'KRVideoView';
   private static readonly PROP_SRC = 'src';
   private static readonly PROP_PLAY_CONTROL = 'playControl';
@@ -162,6 +164,14 @@ export class KRVideoView extends KuiklyRenderBaseView implements IKRVideoViewLis
 
   call(method: string, params: KRAny, callback: KuiklyRenderCallback | null): void {
 
+  }
+
+  override didMoveToParentView() {
+    // After movableContent re-parent, Video gets paused by ArkUI.
+    // Resume playback if it was playing before the move.
+    if (this.isPlaying && this.controller) {
+      this.controller.play();
+    }
   }
 
   createArkUIView(): ComponentContent<KuiklyRenderBaseView> {

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/base/ViewContainer.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/base/ViewContainer.kt
@@ -63,6 +63,68 @@ abstract class ViewContainer<A : ContainerAttr, E : Event> : DeclarativeBaseView
         child.didInit()
     }
 
+    // region Compose movableContent support
+    //
+    // These methods are called exclusively by KNode (compose module) to implement
+    // movableContentOf semantics: lightweight removal that preserves native view resources,
+    // and reinsertion that reattaches the existing native view to a new parent.
+    // They access private/protected fields and therefore must live in this class.
+
+    /**
+     * Lightweight removal for Compose movableContent support.
+     * Does NOT call didRemoveFromParentView() — preserves view state for potential reinsertion.
+     */
+    open fun removeChildForMove(child: DeclarativeBaseView<*, *>) {
+        child.willRemoveFromParentView()
+        children.remove(child)
+        child.parentRef = 0
+    }
+
+    /**
+     * Batch lightweight removal for all children.
+     */
+    open fun removeChildrenForMoveAll() {
+        forEachChild { child ->
+            removeChildForMove(child)
+        }
+    }
+
+    /**
+     * Reinsert a previously initialized child into a new parent.
+     * Used by Compose movableContent when a node moves between containers.
+     *
+     * After KNode.detach() runs on every node in the subtree, each view's nativeRef is removed
+     * from the pager viewMap. We must re-register the entire subtree so native messages can reach
+     * all views again.
+     */
+    open fun <T : DeclarativeBaseView<*, *>> reinsertChild(child: T, index: Int) {
+        child.pagerId = pagerId
+        child.willMoveToParentComponent()
+        if (index < 0) {
+            children.add(child)
+        } else {
+            children.add(index, child)
+        }
+        child.parentRef = nativeRef
+        reRegisterViewTree(child)
+    }
+
+    /**
+     * Recursively re-registers a view and all its descendants in the pager viewMap.
+     * Called after movableContent moves a subtree, because KNode.detach() removes
+     * every node's nativeRef from the map.
+     */
+    private fun reRegisterViewTree(view: DeclarativeBaseView<*, *>) {
+        view.didMoveToParentView()
+        if (view is ViewContainer<*, *>) {
+            view.forEachChild { child ->
+                reRegisterViewTree(child)
+            }
+        }
+    }
+
+    // endregion
+
     open fun removeChild(child: DeclarativeBaseView<*, *>) {
         internalRemoveChild(child)
     }
@@ -176,6 +238,24 @@ abstract class ViewContainer<A : ContainerAttr, E : Event> : DeclarativeBaseView
         subView.removeFlexNode()
         flexNode.markDirty()
     }
+
+    // region Compose movableContent support (DOM layer)
+
+    /**
+     * Lightweight DOM removal for movableContent support.
+     * Removes only the flex layout node — does NOT destroy the native render view.
+     * The render view stays alive so it can be reattached to a new parent during reinsertion.
+     * Final render view cleanup happens in KNode.onRelease() when the node is permanently destroyed.
+     */
+    open fun removeDomSubViewForMove(subView: DeclarativeBaseView<*, *>) {
+        if (!didCreateFlexNode) {
+            return
+        }
+        subView.removeFlexNode()
+        flexNode.markDirty()
+    }
+
+    // endregion
 
     override fun createRenderView() {
         createRenderViewing = true

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/MovableContentDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/MovableContentDemo.kt
@@ -1,0 +1,927 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.demo.pages.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.movableContentOf
+import com.tencent.kuikly.core.views.VideoPlayControl
+import com.tencent.kuikly.core.views.PlayState
+import com.tencent.kuikly.compose.ComposeContainer
+import com.tencent.kuikly.compose.setContent
+import com.tencent.kuikly.compose.foundation.background
+import com.tencent.kuikly.compose.foundation.border
+import com.tencent.kuikly.compose.foundation.clickable
+import com.tencent.kuikly.compose.foundation.layout.Arrangement
+import com.tencent.kuikly.compose.foundation.layout.Box
+import com.tencent.kuikly.compose.foundation.layout.Column
+import com.tencent.kuikly.compose.foundation.layout.Row
+import com.tencent.kuikly.compose.foundation.layout.Spacer
+import com.tencent.kuikly.compose.foundation.layout.fillMaxSize
+import com.tencent.kuikly.compose.foundation.layout.fillMaxWidth
+import com.tencent.kuikly.compose.foundation.layout.height
+import com.tencent.kuikly.compose.foundation.layout.padding
+import com.tencent.kuikly.compose.foundation.layout.size
+import com.tencent.kuikly.compose.foundation.layout.width
+import com.tencent.kuikly.compose.foundation.lazy.LazyColumn
+import com.tencent.kuikly.compose.foundation.lazy.items
+import com.tencent.kuikly.compose.foundation.shape.RoundedCornerShape
+import com.tencent.kuikly.compose.material3.Button
+import com.tencent.kuikly.compose.material3.Card
+import com.tencent.kuikly.compose.material3.CardDefaults
+import com.tencent.kuikly.compose.material3.Text
+import com.tencent.kuikly.compose.ui.Alignment
+import com.tencent.kuikly.compose.ui.Modifier
+import com.tencent.kuikly.compose.ui.graphics.Color
+import com.tencent.kuikly.compose.ui.text.font.FontWeight
+import com.tencent.kuikly.compose.ui.unit.Dp
+import com.tencent.kuikly.compose.ui.unit.dp
+import com.tencent.kuikly.compose.ui.unit.sp
+import com.tencent.kuikly.compose.ui.semantics.testTag
+import com.tencent.kuikly.core.annotations.Page
+
+@Page("MovableContentDemo")
+class MovableContentDemo : ComposeContainer() {
+    override fun willInit() {
+        super.willInit()
+        setContent {
+            MovableContentDemoContent()
+        }
+    }
+}
+
+@Composable
+private fun MovableContentDemoContent() {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+            .background(Color(0xFFF5F5F5)),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        item {
+            Text(
+                "movableContentOf 示例",
+                fontSize = 22.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF333333),
+                modifier = Modifier.padding(bottom = 8.dp, top = 40.dp),
+            )
+        }
+
+        item {
+            DemoCard(title = "1. 基础：内容在 Column/Row 间移动") {
+                BasicMoveDemo()
+            }
+        }
+
+        item {
+            DemoCard(title = "2. 状态保持：移动时保留 remember 状态") {
+                StatePreservationDemo()
+            }
+        }
+
+        item {
+            DemoCard(title = "3. 多个 movableContent：列表项重排") {
+                MultiMovableContentDemo()
+            }
+        }
+
+        item {
+            DemoCard(title = "4. movableContentOf 带参数") {
+            ParameterizedMovableContentDemo()
+            }
+        }
+
+        item {
+            DemoCard(title = "5. 跨容器移动：左右面板切换") {
+                CrossContainerMoveDemo()
+            }
+        }
+
+        item {
+            DemoCard(title = "6. VideoView 播放器跨容器移动验证") {
+                VideoViewMoveDemo()
+            }
+        }
+
+        item {
+            DemoCard(title = "7. LazyColumn item 内含 movableContent：回收后重进入") {
+                LazyItemMovableContentDemo()
+            }
+        }
+
+        item {
+            DemoCard(title = "8. 快速连续 move（竞态压测）") {
+                RapidMoveDemo()
+            }
+        }
+
+        item {
+            DemoCard(title = "9. 条件渲染：if(visible) 包裹的 movableContent") {
+                ConditionalMovableDemo()
+            }
+        }
+    }
+}
+
+@Composable
+private fun DemoCard(
+    title: String,
+    content: @Composable () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = title,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF333333),
+                modifier = Modifier.padding(bottom = 12.dp),
+            )
+            content()
+        }
+    }
+}
+
+@Composable
+private fun BasicMoveDemo() {
+    var isVertical by remember { mutableStateOf(true) }
+
+    // Three differently-sized, differently-colored boxes — in Column they stack top-to-bottom,
+    // in Row they line up left-to-right, making the layout change obvious.
+    val movableContent = remember {
+        movableContentOf {
+            MovableBox("红", Color(0xFFE53935), 56.dp, 40.dp)
+            MovableBox("绿", Color(0xFF43A047), 72.dp, 52.dp)
+            MovableBox("蓝", Color(0xFF1E88E5), 88.dp, 64.dp)
+        }
+    }
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Button(onClick = { isVertical = !isVertical }) {
+            Text(if (isVertical) "切换为 Row（横排）" else "切换为 Column（竖排）")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            if (isVertical) "当前：Column — 三色块竖排" else "当前：Row — 三色块横排",
+            fontSize = 12.sp,
+            color = Color(0xFF757575),
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+                .background(Color(0xFFF5F5F5), RoundedCornerShape(8.dp))
+                .border(2.dp, if (isVertical) Color(0xFF1E88E5) else Color(0xFFE53935), RoundedCornerShape(8.dp))
+                .padding(12.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (isVertical) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    movableContent()
+                }
+            } else {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    movableContent()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MovableBox(
+    label: String,
+    color: Color,
+    width: Dp,
+    height: Dp,
+) {
+    Box(
+        modifier = Modifier
+            .width(width)
+            .height(height)
+            .background(color, RoundedCornerShape(6.dp)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(label, color = Color.White, fontSize = 14.sp, fontWeight = FontWeight.Bold)
+    }
+}
+
+@Composable
+private fun StatePreservationDemo() {
+    var isTop by remember { mutableStateOf(true) }
+    val movableCounter = remember {
+        movableContentOf {
+            var count by remember { mutableStateOf(0) }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Button(
+                    onClick = { count++ },
+                    modifier = Modifier.testTag("demo2_btn_increment"),
+                ) { Text("+") }
+                Text(
+                    "计数: $count",
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF673AB7),
+                    modifier = Modifier.testTag("demo2_counter_text"),
+                )
+                Button(
+                    onClick = { count-- },
+                    modifier = Modifier.testTag("demo2_btn_decrement"),
+                ) { Text("-") }
+            }
+        }
+    }
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Button(
+            onClick = { isTop = !isTop },
+            modifier = Modifier.testTag("demo2_btn_move"),
+        ) {
+            Text(if (isTop) "移到底部" else "移到顶部")
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(160.dp)
+                .border(1.dp, Color.LightGray, RoundedCornerShape(8.dp))
+                .padding(8.dp),
+        ) {
+            if (isTop) {
+                Column {
+                    movableCounter()
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text("↓ 占位区域 ↓", color = Color.Gray, fontSize = 12.sp)
+                }
+            } else {
+                Column {
+                    Text("↑ 占位区域 ↑", color = Color.Gray, fontSize = 12.sp)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    movableCounter()
+                }
+            }
+        }
+
+        Text("移动后计数应保持不变", fontSize = 12.sp, color = Color(0xFF999999))
+    }
+}
+
+@Composable
+private fun MultiMovableContentDemo() {
+    var items by remember { mutableStateOf(listOf("A", "B", "C", "D")) }
+    val movableMap = remember { mutableMapOf<String, @Composable () -> Unit>() }
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            Button(onClick = {
+                if (items.size >= 2) {
+                    items = items.toMutableList().also {
+                        val first = it.removeAt(0)
+                        it.add(first)
+                    }
+                }
+            }) { Text("循环左移") }
+
+            Button(onClick = {
+                if (items.size >= 2) {
+                    items = items.toMutableList().also {
+                        val last = it.removeAt(it.lastIndex)
+                        it.add(0, last)
+                    }
+                }
+            }) { Text("循环右移") }
+
+            Button(onClick = {
+                items = items.reversed()
+            }) { Text("反转") }
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+                .border(1.dp, Color.LightGray, RoundedCornerShape(8.dp))
+                .padding(8.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            items.forEach { item ->
+                val movable = movableMap.getOrPut(item) {
+                    var clickCount by remember { mutableStateOf(0) }
+                    movableContentOf {
+                        Box(
+                            modifier = Modifier
+                                .size(56.dp)
+                                .background(itemColor(item), RoundedCornerShape(8.dp))
+                                .clickable { clickCount++ },
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text("$item\n$clickCount", color = Color.White, fontSize = 12.sp)
+                        }
+                    }
+                }
+                movable()
+            }
+        }
+
+        Text("每个 item 的点击计数在移动后保持", fontSize = 12.sp, color = Color(0xFF999999))
+    }
+}
+
+private fun itemColor(label: String): Color = when (label) {
+    "A" -> Color(0xFFE91E63)
+    "B" -> Color(0xFF2196F3)
+    "C" -> Color(0xFF4CAF50)
+    "D" -> Color(0xFFFF9800)
+    else -> Color.Gray
+}
+
+@Composable
+private fun ParameterizedMovableContentDemo() {
+    var currentIndex by remember { mutableStateOf(0) }
+    val colors = listOf(Color(0xFF2196F3), Color(0xFFE91E63), Color(0xFF4CAF50), Color(0xFFFF9800))
+    val labels = listOf("蓝", "粉", "绿", "橙")
+
+    val movableItem = remember {
+        movableContentOf { index: Int ->
+            var tapCount by remember { mutableStateOf(0) }
+            Box(
+                modifier = Modifier
+                    .size(100.dp, 60.dp)
+                    .background(colors[index], RoundedCornerShape(8.dp))
+                    .clickable { tapCount++ },
+                contentAlignment = Alignment.Center,
+            ) {
+                Text("${labels[index]} - 点击$tapCount", color = Color.White, fontSize = 14.sp)
+            }
+        }
+    }
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            Button(onClick = { currentIndex = (currentIndex + 1) % colors.size }) {
+                Text("切换参数")
+            }
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(80.dp)
+                .border(1.dp, Color.LightGray, RoundedCornerShape(8.dp))
+                .padding(8.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            movableItem(currentIndex)
+        }
+
+        Text("参数变化时内容重组，点击计数因 remember 而累加", fontSize = 12.sp, color = Color(0xFF999999))
+    }
+}
+
+@Composable
+private fun CrossContainerMoveDemo() {
+    var inLeft by remember { mutableStateOf(true) }
+    val movablePanel = remember {
+        movableContentOf {
+            var toggleCount by remember { mutableStateOf(0) }
+            Column(
+                modifier = Modifier
+                    .background(Color(0xFFE8F5E9), RoundedCornerShape(8.dp))
+                    .padding(12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text("可移动面板", fontSize = 16.sp, fontWeight = FontWeight.Bold, color = Color(0xFF2E7D32))
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    "切换次数: $toggleCount",
+                    fontSize = 14.sp,
+                    color = Color(0xFF388E3C),
+                    modifier = Modifier.testTag("demo5_toggle_count_text"),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    onClick = { toggleCount++ },
+                    modifier = Modifier.testTag("demo5_btn_increment"),
+                ) { Text("点击+1") }
+            }
+        }
+    }
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Button(
+            onClick = { inLeft = !inLeft },
+            modifier = Modifier.testTag("demo5_btn_move_panel"),
+        ) {
+            Text(if (inLeft) "移到右面板" else "移到左面板")
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+                .border(1.dp, Color.LightGray, RoundedCornerShape(8.dp))
+                .padding(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxSize()
+                    .background(Color(0xFFE3F2FD), RoundedCornerShape(8.dp))
+                    .padding(8.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (inLeft) {
+                    movablePanel()
+                } else {
+                    Text("空面板", color = Color(0xFF90CAF9), fontSize = 14.sp)
+                }
+            }
+
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxSize()
+                    .background(Color(0xFFFCE4EC), RoundedCornerShape(8.dp))
+                    .padding(8.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (!inLeft) {
+                    movablePanel()
+                } else {
+                    Text("空面板", color = Color(0xFFF48FB1), fontSize = 14.sp)
+                }
+            }
+        }
+
+        Text("面板在左右容器间移动，状态保持", fontSize = 12.sp, color = Color(0xFF999999))
+    }
+}
+
+/**
+ * Demo6: VideoView 播放器在容器间移动验证
+ *
+ * 验证思路：
+ *   - movableContent 内嵌真实的 VideoView（KRVideoView）播放网络视频
+ *   - playTimeDidChanged 回调把当前播放进度暴露到 Compose 状态，显示在 UI 上
+ *   - 若 move 后播放时间继续递增（不归零）→ native player 实例没有重建，资源保留
+ *   - 若 move 后时间归零/停止 → view 被重建了，native player 资源丢失
+ *
+ * 这是真正的 native view 资源连续性验证，不依赖 Compose remember 状态。
+ */
+@Composable
+private fun VideoViewMoveDemo() {
+    // 当前视频所在容器：true = 上方，false = 下方
+    var isTop by remember { mutableStateOf(true) }
+    // move 次数
+    var moveCount by remember { mutableIntStateOf(0) }
+    // 播放进度（ms），由 VideoView 内部的 playTimeDidChanged 回调写入
+    var playTimeMs by remember { mutableIntStateOf(0) }
+    // 播放状态文字
+    var statusText by remember { mutableStateOf("加载中...") }
+
+    val movableVideo = remember {
+        movableContentOf {
+            Video(
+                src = "http://vjs.zencdn.net/v/oceans.mp4",
+                playControl = VideoPlayControl.PLAY,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(180.dp),
+                onPlayStateChanged = { state, _ ->
+                    statusText = when (state) {
+                        PlayState.PLAYING -> "▶ 播放中"
+                        PlayState.BUFFERING -> "⏳ 缓冲中"
+                        PlayState.PAUSED -> "⏸ 已暂停"
+                        PlayState.PLAY_END -> "⏹ 播放结束"
+                        PlayState.ERROR -> "❌ 播放错误"
+                        else -> "..."
+                    }
+                },
+                onPlayTimeChanged = { curTime, _ ->
+                    playTimeMs = curTime
+                },
+            )
+        }
+    }
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        // 控制栏
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Button(
+                onClick = { isTop = !isTop; moveCount++ },
+                modifier = Modifier.testTag("demo6_btn_move"),
+            ) {
+                Text(if (isTop) "移到下方" else "移到上方")
+            }
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    "移动次数: $moveCount",
+                    fontSize = 12.sp,
+                    color = Color(0xFF555555),
+                    modifier = Modifier.testTag("demo6_move_count_text"),
+                )
+                Text(
+                    "播放进度: ${playTimeMs / 1000}s",
+                    fontSize = 12.sp,
+                    color = Color(0xFF1565C0),
+                    modifier = Modifier.testTag("demo6_play_time_text"),
+                )
+                Text(
+                    statusText,
+                    fontSize = 12.sp,
+                    color = Color(0xFF388E3C),
+                    modifier = Modifier.testTag("demo6_status_text"),
+                )
+            }
+        }
+
+        // 上方容器
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color(0xFFE8EAF6), RoundedCornerShape(8.dp))
+                .padding(4.dp),
+        ) {
+            if (isTop) {
+                movableVideo()
+            } else {
+                Box(
+                    modifier = Modifier.fillMaxWidth().height(180.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text("上方容器（空）", color = Color(0xFF9FA8DA), fontSize = 13.sp)
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // 下方容器
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color(0xFFFCE4EC), RoundedCornerShape(8.dp))
+                .padding(4.dp),
+        ) {
+            if (!isTop) {
+                movableVideo()
+            } else {
+                Box(
+                    modifier = Modifier.fillMaxWidth().height(180.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text("下方容器（空）", color = Color(0xFFF48FB1), fontSize = 13.sp)
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            "move 后进度继续递增 = native player 未重建 ✓",
+            fontSize = 11.sp,
+            color = Color(0xFF999999),
+        )
+    }
+}
+
+/**
+ * Demo7: LazyColumn item 内含 movableContent
+ *
+ * 验证：LazyColumn 回收某行 item 后，该行的 movableContent 被销毁；
+ * 再次滚动回来时重建，remember 状态应该重置（因为是全新 composition），
+ * 不应崩溃或出现错乱。
+ */
+@Composable
+private fun LazyItemMovableContentDemo() {
+    var showList by remember { mutableStateOf(true) }
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            Button(onClick = { showList = !showList }) {
+                Text(if (showList) "隐藏列表" else "显示列表")
+            }
+        }
+
+        Text(
+            "滚动让 item 回收，再滚回来，不应崩溃",
+            fontSize = 12.sp,
+            color = Color(0xFF999999),
+            modifier = Modifier.padding(vertical = 4.dp),
+        )
+
+        if (showList) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(240.dp)
+                    .border(1.dp, Color.LightGray, RoundedCornerShape(8.dp)),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                items(20) { index ->
+                    // 每个 item 内部都用 movableContentOf 包裹计数器
+                    // LazyColumn 回收时对应的 movableContent 会被销毁，
+                    // 再次进入屏幕时重建——验证不会崩溃且状态正确初始化
+                    val movableItem = remember(index) {
+                        movableContentOf {
+                            var count by remember { mutableStateOf(0) }
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                            ) {
+                                Text(
+                                    "Item #$index",
+                                    fontSize = 14.sp,
+                                    color = Color(0xFF333333),
+                                )
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    Button(onClick = { count++ }, modifier = Modifier.size(36.dp, 28.dp)) {
+                                        Text("+", fontSize = 12.sp)
+                                    }
+                                    Text(
+                                        "$count",
+                                        fontSize = 14.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        color = Color(0xFF1565C0),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    movableItem()
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Demo8: 快速连续 move（竞态压测）
+ *
+ * 验证：用户快速点击移动按钮 10+ 次时，Compose runtime 多帧叠加，
+ * 不应出现 parentRef 不一致、崩溃或 view 消失等问题。
+ */
+@Composable
+private fun RapidMoveDemo() {
+    var isLeft by remember { mutableStateOf(true) }
+    var moveCount by remember { mutableIntStateOf(0) }
+
+    val movableContent = remember {
+        movableContentOf {
+            var innerCount by remember { mutableStateOf(0) }
+            Column(
+                modifier = Modifier
+                    .size(120.dp, 80.dp)
+                    .background(Color(0xFF7C4DFF), RoundedCornerShape(8.dp))
+                    .padding(8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text("内部计数: $innerCount", color = Color.White, fontSize = 12.sp)
+                Spacer(modifier = Modifier.height(4.dp))
+                Button(
+                    onClick = { innerCount++ },
+                    modifier = Modifier.size(80.dp, 28.dp),
+                ) {
+                    Text("+", fontSize = 12.sp)
+                }
+            }
+        }
+    }
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            Button(onClick = {
+                isLeft = !isLeft
+                moveCount++
+            }) {
+                Text(if (isLeft) "→ 右" else "← 左")
+            }
+            // 连续快速 move 按钮
+            Button(onClick = {
+                // 触发 5 次状态变更（Compose 会批量处理，但要确保最终状态一致）
+                repeat(5) { isLeft = !isLeft }
+                moveCount += 5
+            }) {
+                Text("快速×5")
+            }
+        }
+
+        Text(
+            "已移动 $moveCount 次，内部计数应保持",
+            fontSize = 12.sp,
+            color = Color(0xFF999999),
+            modifier = Modifier.padding(vertical = 4.dp),
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(120.dp)
+                .border(1.dp, Color.LightGray, RoundedCornerShape(8.dp))
+                .padding(8.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxSize()
+                    .background(Color(0xFFE8EAF6), RoundedCornerShape(6.dp)),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (isLeft) {
+                    movableContent()
+                } else {
+                    Text("左（空）", color = Color(0xFF9FA8DA), fontSize = 12.sp)
+                }
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxSize()
+                    .background(Color(0xFFFCE4EC), RoundedCornerShape(6.dp)),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (!isLeft) {
+                    movableContent()
+                } else {
+                    Text("右（空）", color = Color(0xFFF48FB1), fontSize = 12.sp)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Demo9: 条件渲染 —— movableContent 的保留 vs 重置边界
+ *
+ * movableContentOf 的语义：
+ *   ✅ A → B（可见且在同一帧内换 slot）：状态保留
+ *   ❌ 完全不在任何 slot（visible=false）→ Runtime 调 onRelease 销毁 → 重新出现时状态重置
+ *
+ * 验证：
+ *   1. 在 A/B 间 move（始终可见）→ 计数保留，不崩溃
+ *   2. 隐藏再显示 → 计数归零（Runtime 销毁重建，这是正确行为）
+ */
+@Composable
+private fun ConditionalMovableDemo() {
+    var visible by remember { mutableStateOf(true) }
+    var inBoxA by remember { mutableStateOf(true) }
+
+    val movableContent = remember {
+        movableContentOf {
+            var count by remember { mutableStateOf(0) }
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color(0xFFE0F2F1), RoundedCornerShape(8.dp))
+                    .padding(12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text("条件内容", fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color(0xFF00695C))
+                Spacer(modifier = Modifier.height(4.dp))
+                Text("计数: $count", fontSize = 16.sp, color = Color(0xFF00897B))
+                Spacer(modifier = Modifier.height(4.dp))
+                Button(onClick = { count++ }) { Text("点击+1") }
+            }
+        }
+    }
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            Button(onClick = { visible = !visible }) {
+                Text(if (visible) "隐藏" else "显示")
+            }
+            Button(
+                onClick = { inBoxA = !inBoxA },
+                enabled = visible,
+            ) {
+                Text(if (inBoxA) "移到 B ✅保留" else "移到 A ✅保留")
+            }
+        }
+
+        Column(modifier = Modifier.padding(vertical = 4.dp)) {
+            Text(
+                "✅ 可见时 A↔B 移动：计数保留（movableContent 语义）",
+                fontSize = 11.sp,
+                color = Color(0xFF388E3C),
+            )
+            Text(
+                "⚠️ 隐藏再显示：计数归零（无 slot 持有 → Runtime 销毁重建，符合预期）",
+                fontSize = 11.sp,
+                color = Color(0xFFE65100),
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(160.dp)
+                .border(1.dp, Color.LightGray, RoundedCornerShape(8.dp))
+                .padding(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxSize()
+                    .background(Color(0xFFE8F5E9), RoundedCornerShape(6.dp))
+                    .padding(4.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (visible && inBoxA) {
+                    movableContent()
+                } else {
+                    Text("A（空）", color = Color(0xFFA5D6A7), fontSize = 12.sp)
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxSize()
+                    .background(Color(0xFFFFF3E0), RoundedCornerShape(6.dp))
+                    .padding(4.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (visible && !inBoxA) {
+                    movableContent()
+                } else {
+                    Text("B（空）", color = Color(0xFFFFCC80), fontSize = 12.sp)
+                }
+            }
+        }
+    }
+}

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/VideoView.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/VideoView.kt
@@ -18,6 +18,8 @@ package com.tencent.kuikly.demo.pages.compose
 import androidx.compose.runtime.Composable
 import com.tencent.kuikly.compose.extension.MakeKuiklyComposeNode
 import com.tencent.kuikly.compose.ui.Modifier
+import com.tencent.kuikly.core.nvi.serialization.json.JSONObject
+import com.tencent.kuikly.core.views.PlayState
 import com.tencent.kuikly.core.views.VideoPlayControl
 import com.tencent.kuikly.core.views.VideoView
 
@@ -26,20 +28,26 @@ fun Video(
     src: String,
     playControl: VideoPlayControl,
     modifier: Modifier = Modifier,
+    onPlayStateChanged: ((state: PlayState, extInfo: JSONObject) -> Unit)? = null,
+    onPlayTimeChanged: ((curTime: Int, totalTime: Int) -> Unit)? = null,
 ) {
     MakeKuiklyComposeNode<VideoView>(
-        factory = {
-            VideoView()
-        },
+        factory = { VideoView() },
         modifier = modifier,
         viewInit = {
             getViewAttr().run {
-                playControl(VideoPlayControl.PLAY)
                 src(src)
+                playControl(playControl)
+            }
+            onPlayStateChanged?.let { getViewEvent().playStateDidChanged(it) }
+            onPlayTimeChanged?.let { cb ->
+                getViewEvent().playTimeDidChanged { cur, total ->
+                    cb(cur, total)
+                }
             }
         },
-        viewUpdate = {
-            it.getViewAttr().run {
+        viewUpdate = { view ->
+            view.getViewAttr().run {
                 src(src)
                 playControl(playControl)
             }


### PR DESCRIPTION
## Summary

- **ViewContainer**: Add `removeChildForMove`, `removeChildrenForMoveAll`, `reinsertChild`, `removeDomSubViewForMove` — lightweight remove path that preserves native render view for reuse (grouped under `// region Compose movableContent support`)
- **KNode**: Add `isInitialized` flag; `insertTopDown` distinguishes first-insert (full init) from reinsert (skip init, reuse existing renderView); `removeAt`/`removeAll` use the lightweight path; `onRelease` performs final native view cleanup; `detach` clears pager viewMap without destroying resources
- **ViewContainerMovableContentExt.kt** (new): `removeChildrenForMove(index, count)` compose-side helper
- **SemanticsNode**: Guard `!child.isDeactivated` in children traversal to prevent crash during movableContent deactivation
- **MovableContentDemo.kt** (new): 9 demos — basic move, state preservation, multi-item reorder, parameterized content, cross-container, VideoView playback continuity, LazyColumn recycling, rapid-move stress test, conditional visibility
- **VideoView.kt**: Clean `Video` composable wrapping `VideoView` with `onPlayStateChanged`/`onPlayTimeChanged` callbacks

## How it works

`movableContentOf` requires that native view resources survive a container move. The core insight: Compose Runtime guarantees `onRelease` is **not** called for movableContent moves (slot is moved, not released), but **is** called for normal node destruction. So:

- `removeAt` → lightweight remove (flex node only, renderView stays alive)
- `onRelease` → full cleanup (called same-frame for normal nodes → equivalent behavior; never called for movableContent moves → native view preserved)

Tested on Android emulator + iOS simulator + iOS real device (iPhone 13 Pro Max). VideoView demo confirms AVPlayer instance survives move — playback position continues without reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)