### PR TITLE
fix(ohos): center single-line text with lineHeight via SetTypographyVerticalAlignment

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRParagraph.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRParagraph.cpp
@@ -32,6 +32,9 @@ extern "C" {
 #endif
 // Remove this declaration if compatable api is raised to 14 and above
 extern OH_Drawing_FontCollection *OH_Drawing_GetFontCollectionGlobalInstance(void) __attribute__((weak));
+// 垂直对齐接口的弱符号声明（系统 API 20+ 提供，低版本系统该符号为 nullptr）
+extern void OH_Drawing_SetTypographyVerticalAlignment(OH_Drawing_TypographyStyle* style,
+                                                      OH_Drawing_TextVerticalAlignment alignment) __attribute__((weak));
 #ifdef __cplusplus
 };
 #endif
@@ -210,6 +213,11 @@ ArkUI_StyledString *KRParagraph::GetStyledString() {
 
 OH_Drawing_TypographyStyle *KRParagraph::CreateTypographyStyle() {
     OH_Drawing_TypographyStyle *typography_style = OH_Drawing_CreateTypographyStyle();
+
+    // 垂直居中：系统 API 20+ 支持时使用新接口，后续基线策略会相应调整
+    if (&OH_Drawing_SetTypographyVerticalAlignment != nullptr) {
+        OH_Drawing_SetTypographyVerticalAlignment(typography_style, TEXT_VERTICAL_ALIGNMENT_CENTER);
+    }
 
     auto numberOfLines = GetKTValue("numberOfLines", props_, props_)->toInt();
     if (numberOfLines == 0) {

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
@@ -40,6 +40,9 @@ extern "C" {
 extern OH_Drawing_FontCollection* OH_Drawing_GetFontCollectionGlobalInstance(void) __attribute__((weak));
 extern OH_Drawing_Array* OH_Drawing_TypographyGetTextLines(OH_Drawing_Typography* typography) __attribute__((weak));
 extern void OH_Drawing_DestroyTextLines(OH_Drawing_Array* lines) __attribute__((weak));
+// 垂直对齐接口的弱符号声明（系统 API 20+ 提供，低版本系统该符号为 nullptr）
+extern void OH_Drawing_SetTypographyVerticalAlignment(OH_Drawing_TypographyStyle* style,
+                                                      OH_Drawing_TextVerticalAlignment alignment) __attribute__((weak));
 
 void KREnableTextRenderV2(){
     KR_TEXT_RENDER_V2_ENABLED = true;
@@ -443,7 +446,7 @@ OH_Drawing_Typography *KRRichTextShadow::BuildTextTypography(double constraint_w
         }
         OH_Drawing_SetTextStyleFontSize(txtStyle, fontSize);
         OH_Drawing_SetTextStyleFontWeight(txtStyle, fontWeight);
-        OH_Drawing_SetTextStyleBaseLine(txtStyle, TEXT_BASELINE_IDEOGRAPHIC);
+        OH_Drawing_SetTextStyleBaseLine(txtStyle, TEXT_BASELINE_ALPHABETIC);
         OH_Drawing_SetTextStyleDecoration(txtStyle, textDecoration);
         OH_Drawing_SetTextStyleFontStyle(txtStyle, fontStyle);
         if (letterSpacing > 0) {
@@ -454,6 +457,12 @@ OH_Drawing_Typography *KRRichTextShadow::BuildTextTypography(double constraint_w
         } else if (lineHeight > 0) {
             lineHeight = std::max(lineHeight, 1.0);
             OH_Drawing_SetTextStyleFontHeight(txtStyle, lineHeight);
+            // 低版本系统（不支持 OH_Drawing_SetTypographyVerticalAlignment）的 work around：
+            // cai 系统绘制存在偏移问题，手动校准 drawOffsetY_ 实现垂直居中
+            // 高版本系统通过 OH_Drawing_SetTypographyVerticalAlignment 设置垂直居中，无需此校准
+            if (&OH_Drawing_SetTypographyVerticalAlignment == nullptr) {
+                context_thread_drawOffsetY_ = (fontSize * lineHeight - fontSize) / 4;
+            }
         }
         // fontFamily
         if (!fontFamily.empty()) {
@@ -494,6 +503,11 @@ OH_Drawing_Typography *KRRichTextShadow::BuildTextTypography(double constraint_w
                  * 等待修复，目前使用设置行高+禁用首尾行间距实现，注意同时设置lineHeight和lineSpacing首尾间距也会失效
                  */
                 OH_Drawing_TypographyTextSetHeightBehavior(typoStyle, TEXT_HEIGHT_DISABLE_ALL);
+            }
+            // 设置文本垂直居中：API 20+ 系统支持 OH_Drawing_SetTypographyVerticalAlignment
+            // 弱符号检查：地址为 nullptr 表示当前系统不提供该接口，将回退到基线 work around
+            if (&OH_Drawing_SetTypographyVerticalAlignment != nullptr) {
+                OH_Drawing_SetTypographyVerticalAlignment(typoStyle, TEXT_VERTICAL_ALIGNMENT_CENTER);
             }
             handler = CreateTypographyHandler(typoStyle);
         } else {

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/kit_demo/DeclarativeDemo/TextExamplePage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/kit_demo/DeclarativeDemo/TextExamplePage.kt
@@ -908,6 +908,162 @@ internal fun ViewContainer<*, *>.TextExampleLineHeight(init: TextExampleLineHeig
     addChild(TextExampleLineHeight(), init)
 }
 
+internal class TextExampleLineHeightVerticalAlignment: ComposeView<ComposeAttr, ComposeEvent>() {
+    override fun body(): ViewBuilder {
+        return {
+            attr {
+                flexDirectionColumn()
+                justifyContentFlexStart()
+                padding(all = 16f)
+            }
+            
+            // 标题说明
+            Text {
+                attr {
+                    text("单行文本lineHeight垂直居中问题测试")
+                    fontSize(16f)
+                    fontWeightBold()
+                    color(Color.BLACK)
+                    marginBottom(10f)
+                }
+            }
+            
+            // 测试用例1: 小字体 + 大lineHeight
+            Text {
+                attr {
+                    text("小字体(12px) + 大lineHeight(30px)")
+                    fontSize(12f)
+                    lineHeight(30f)
+                    backgroundColor(0xFFF0E68C) // 浅黄色背景
+                    height(30f)
+                    textAlignCenter()
+                    marginBottom(5f)
+                }
+            }
+            
+            // 测试用例2: 中等字体 + 大lineHeight
+            Text {
+                attr {
+                    text("中等字体(16px) + 大lineHeight(40px)")
+                    fontSize(16f)
+                    lineHeight(40f)
+                    backgroundColor(0xFFADD8E6) // 浅蓝色背景
+                    height(40f)
+                    textAlignCenter()
+                    marginBottom(5f)
+                }
+            }
+            
+            // 测试用例3: 大字体 + 大lineHeight
+            Text {
+                attr {
+                    text("大字体(24px) + 大lineHeight(50px)")
+                    fontSize(24f)
+                    lineHeight(50f)
+                    backgroundColor(0xFFFFA07A) // 浅橙色背景
+                    height(50f)
+                    textAlignCenter()
+                    marginBottom(5f)
+                }
+            }
+            
+            // 测试用例4: 正常字体 + 正常lineHeight（作为对比）
+            Text {
+                attr {
+                    text("正常字体(16px) + 正常lineHeight(20px)")
+                    fontSize(16f)
+                    lineHeight(20f)
+                    backgroundColor(0xFFEEEEEE) // 灰色背景
+                    height(20f)
+                    textAlignCenter()
+                    marginBottom(5f)
+                }
+            }
+            
+            // 测试用例5: 极端情况 - 字体很小，lineHeight很大
+            Text {
+                attr {
+                    text("极小字体(8px) + 极大lineHeight(60px)")
+                    fontSize(8f)
+                    lineHeight(60f)
+                    backgroundColor(0xFFD8BFD8) // 浅紫色背景
+                    height(60f)
+                    textAlignCenter()
+                    marginBottom(5f)
+                }
+            }
+            
+            // 测试用例6: 英文文本测试
+            Text {
+                attr {
+                    text("English Text (16px) + lineHeight(35px)")
+                    fontSize(16f)
+                    lineHeight(35f)
+                    backgroundColor(0xFF98FB98) // 浅绿色背景
+                    height(35f)
+                    textAlignCenter()
+                    marginBottom(5f)
+                }
+            }
+            
+            // 测试用例7: 混合文本测试
+            Text {
+                attr {
+                    text("中英文混合ABC中文 (18px) + lineHeight(45px)")
+                    fontSize(18f)
+                    lineHeight(45f)
+                    backgroundColor(0xFFFFD700) // 金色背景
+                    height(45f)
+                    textAlignCenter()
+                    marginBottom(5f)
+                }
+            }
+            
+            // 测试用例8: 无lineHeight设置（基准对比）
+            Text {
+                attr {
+                    text("无lineHeight设置 (16px) - 基准对比")
+                    fontSize(16f)
+                    backgroundColor(0xFFF5F5DC) // 米色背景
+                    height(20f)
+                    textAlignCenter()
+                    marginBottom(5f)
+                }
+            }
+            
+            // 说明文字
+            Text {
+                attr {
+                    text("问题描述：单行文本设置lineHeight时，文字在鸿蒙上可能显示不居中")
+                    fontSize(12f)
+                    color(Color.GRAY)
+                    marginTop(10f)
+                }
+            }
+            Text {
+                attr {
+                    text("预期效果：文字应该在背景色区域内垂直居中显示")
+                    fontSize(12f)
+                    color(Color.GRAY)
+                    marginBottom(10f)
+                }
+            }
+        }
+    }
+
+    override fun createAttr(): ComposeAttr {
+        return ComposeAttr()
+    }
+
+    override fun createEvent(): ComposeEvent {
+        return ComposeEvent()
+    }
+}
+
+internal fun ViewContainer<*, *>.TextExampleLineHeightVerticalAlignment(init: TextExampleLineHeightVerticalAlignment.() -> Unit) {
+    addChild(TextExampleLineHeightVerticalAlignment(), init)
+}
+
 internal class TextExampleLetterSpacing: ComposeView<ComposeAttr, ComposeEvent>() {
     override fun body(): ViewBuilder {
         return {
@@ -1336,6 +1492,8 @@ internal class TextExamplePage: BasePager() {
                 TextExampleEmoji {  }
                 ViewExampleSectionHeader { attr { title = "LineBreakMargin & onLineBreakMargin" } }
                 TextExampleLineBreakMargin {  }
+                ViewExampleSectionHeader { attr { title = "单行文本lineHeight垂直居中问题测试" } }
+                TextExampleLineHeightVerticalAlignment {  }
             }
         }
     }


### PR DESCRIPTION
…erticalAlignment

When a single-line text has lineHeight set, the rendered glyph is not vertically centered in the line box on HarmonyOS. Browser team reported this regression after upgrading. The previous trick used in commit c45543b9 was either incomplete or undone in subsequent refactors.

HarmonyOS API 20+ now provides the proper API:
  OH_Drawing_SetTypographyVerticalAlignment(style, alignment)

This change introduces it as a weak symbol so the binary still loads on older systems where the symbol resolves to nullptr, then:

  * On systems that provide the API, sets TEXT_VERTICAL_ALIGNMENT_CENTER on the typography style. - In KRRichTextShadow, the call is placed right after typoStyle is fully populated and before CreateTypographyHandler(typoStyle). - In KRParagraph, the call is placed right after OH_Drawing_CreateTypographyStyle() in CreateTypographyStyle().

  * On older systems (weak symbol == nullptr), KRRichTextShadow falls back to the legacy work around inside the lineHeight branch: context_thread_drawOffsetY_ = (fontSize * lineHeight - fontSize) / 4; which manually compensates the cai-system rendering offset that was originally introduced and later removed by c45543b9.

  * Adds a reproduction case in TextExamplePage covering single-line text with lineHeight, used to visually verify the fix on HarmonyOS.