### PR TITLE
fix(pager): stabilize native snap alignment and pager content size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ proto/**/*.kt
 /logs/
 /iosApp/logs/
 /.claude-internal
+/.cursor/

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/Pager.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/Pager.kt
@@ -398,4 +398,11 @@ internal object PagerDebugConfig {
     const val ScrollPosition = false
     const val PagerSnapDistance = false
     const val PagerSnapLayoutInfoProvider = false
+    const val Snap = false
+}
+
+internal inline fun pagerSnapDebugLog(generateMsg: () -> String) {
+    if (PagerDebugConfig.Snap) {
+        println("[PagerSnap] ${generateMsg()}")
+    }
 }

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
@@ -65,6 +65,7 @@ import com.tencent.kuikly.core.collection.fastMutableMapOf
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.math.abs
 import kotlin.math.absoluteValue
+import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 import kotlin.math.sign
 import kotlin.ranges.IntRange
@@ -131,36 +132,22 @@ private class DefaultPagerState(
 
     companion object {
         /**
-         * To keep current page and current page offset saved.
-         * Also saves bridge-layer state (composeOffset, currentContentSize, contentOffset, offsetDirty)
-         * to support ScrollerView reuse in nested Pager scenarios.
+         * To keep current page and current page offset saved
          */
         val Saver: Saver<DefaultPagerState, *> = listSaver(
             save = {
-                val saved = listOf(
-                    it.currentPage,                             // [0] Int
-                    (it.currentPageOffsetFraction).coerceIn(MinPageOffset, MaxPageOffset), // [1] Float
-                    it.pageCount,                               // [2] Int
-                    it.kuiklyInfo.composeOffset.toInt(),        // [3] bridge: Compose scroll offset
-                    it.kuiklyInfo.currentContentSize,           // [4] bridge: virtual content size
-                    it.kuiklyInfo.contentOffset,                // [5] bridge: native scrollView offset
-                    if (it.kuiklyInfo.offsetDirty) 1 else 0,   // [6] bridge: offset dirty flag
+                listOf(
+                    it.currentPage,
+                    (it.currentPageOffsetFraction).coerceIn(MinPageOffset, MaxPageOffset),
+                    it.pageCount
                 )
-                saved
             },
             restore = {
                 DefaultPagerState(
                     currentPage = it[0] as Int,
                     currentPageOffsetFraction = it[1] as Float,
                     updatedPageCount = { it[2] as Int }
-                ).also { state ->
-                    if (it.size > 3) { // backward compatibility with old saved data
-                        state.kuiklyInfo.composeOffset = (it[3] as Int).toFloat()
-                        state.kuiklyInfo.currentContentSize = it[4] as Int
-                        state.kuiklyInfo.contentOffset = it[5] as Int
-                        state.kuiklyInfo.offsetDirty = (it[6] as Int) == 1
-                    }
-                }
+                )
             }
         )
     }
@@ -208,6 +195,8 @@ abstract class PagerState internal constructor(
     internal var upDownDifference: Offset by mutableStateOf(Offset.Zero)
     private val animatedScrollScope = PagerLazyAnimateScrollScope(this)
 
+    internal val debugPagerStateId = identityHashCode(this)
+
     private val scrollPosition = PagerScrollPosition(currentPage, currentPageOffsetFraction, this)
 
     internal var firstVisiblePage = currentPage
@@ -219,6 +208,11 @@ abstract class PagerState internal constructor(
     private var maxScrollOffset: Long = Long.MAX_VALUE
 
     private var minScrollOffset: Long = 0L
+
+    private var alignmentLayoutGeneration = 0
+    private var lastAlignmentOrientation: Orientation? = null
+    private var lastAlignmentLayoutSize = 0
+    private var lastAlignmentPageSizeWithSpacing = 0
 
     private var accumulator: Float = 0.0f
 
@@ -397,6 +391,272 @@ abstract class PagerState internal constructor(
      */
     val currentPage: Int get() = scrollPosition.currentPage
 
+    /** Native setContentOffset(animated=true) snap is in progress. */
+    internal var isSnapAnimating = false
+
+    /** Native content offset that the snap animation is settling to. */
+    internal var snapTargetContentOffset = 0
+
+    private var snapTargetReachedAlignmentRequested = false
+
+    /** Called before native setContentOffset(animated=true). */
+    internal fun markSnapAnimationStarted(targetContentOffset: Int) {
+        isSnapAnimating = true
+        snapTargetContentOffset = targetContentOffset
+        snapTargetReachedAlignmentRequested = false
+        pagerSnapDebugLog {
+            "snapStarted: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
+                "targetOffset=$targetContentOffset contentOffset=${kuiklyInfo.contentOffset} " +
+                "composeOffset=${currentAbsoluteScrollOffset().toInt()} currentPage=$currentPage"
+        }
+    }
+
+    internal fun hasSnapReachedTarget(contentOffset: Int): Boolean {
+        return abs(contentOffset - snapTargetContentOffset) <= SNAP_TARGET_OFFSET_TOLERANCE
+    }
+
+    internal fun onNativeContentOffsetChanged(contentOffset: Int) {
+        if (!isSnapAnimating ||
+            snapTargetReachedAlignmentRequested ||
+            !hasSnapReachedTarget(contentOffset)
+        ) {
+            return
+        }
+
+        snapTargetReachedAlignmentRequested = true
+        pagerSnapDebugLog {
+            "snapTargetReached: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
+                "contentOffset=$contentOffset target=$snapTargetContentOffset " +
+                "currentPage=$currentPage"
+        }
+        scheduleScrollViewOffsetAlignment(SNAP_MEASURE_JOB_INITIAL_DELAY_MS)
+    }
+
+    /** Clears drag/animated snap tracking. Call before instant programmatic scroll. */
+    internal fun clearSnapAnimationState() {
+        if (isSnapAnimating) {
+            pagerSnapDebugLog {
+                "clearSnapState: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
+                    "target=$snapTargetContentOffset contentOffset=${kuiklyInfo.contentOffset} " +
+                    "currentPage=$currentPage"
+            }
+        }
+        isSnapAnimating = false
+        snapTargetContentOffset = 0
+        snapTargetReachedAlignmentRequested = false
+        kuiklyInfo.appleScrollViewOffsetJob?.cancel()
+    }
+
+    private fun scheduleScrollViewOffsetAlignment(
+        delayMs: Long,
+        layoutSize: Int = currentLayoutMainAxisSize()
+    ) {
+        val scheduledOrientation = layoutInfo.orientation
+        val scheduledPageSizeWithSpacing = pageSizeWithSpacing
+        val scheduledContentOffset = kuiklyInfo.contentOffset
+        val scheduledComposeOffset = currentAbsoluteScrollOffset().toInt()
+        val scheduledLayoutGeneration = alignmentLayoutGeneration
+        pagerSnapDebugLog {
+            "scheduleAlign: stateId=$debugPagerStateId orientation=$scheduledOrientation " +
+                "layoutGeneration=$scheduledLayoutGeneration " +
+                "layoutSize=$layoutSize pageSizeWithSpacing=$scheduledPageSizeWithSpacing " +
+                "contentOffset=$scheduledContentOffset composeOffset=$scheduledComposeOffset " +
+                "isSnapAnimating=$isSnapAnimating isScrollInProgress=$isScrollInProgress"
+        }
+        kuiklyInfo.run {
+            appleScrollViewOffsetJob?.cancel()
+            appleScrollViewOffsetJob = scope?.launch {
+                delay(delayMs)
+                alignScrollViewOffset(
+                    layoutSize,
+                    scheduledOrientation,
+                    scheduledPageSizeWithSpacing,
+                    scheduledContentOffset,
+                    scheduledComposeOffset,
+                    scheduledLayoutGeneration
+                )
+            }
+        }
+    }
+
+    private fun currentLayoutMainAxisSize(): Int {
+        val layoutInfo = layoutInfo
+        return if (layoutInfo.orientation == Orientation.Horizontal) {
+            layoutInfo.viewportSize.width
+        } else {
+            layoutInfo.viewportSize.height
+        }
+    }
+
+    private fun nearestPageForOffset(offset: Int): Int {
+        val pageSize = pageSizeWithSpacing
+        if (pageSize == 0) {
+            return currentPage.coerceInPageRange()
+        }
+        return (offset / pageSize.toFloat()).roundToInt().coerceInPageRange()
+    }
+
+    private fun pageBoundaryOffset(page: Int): Int {
+        return page.coerceInPageRange() * pageSizeWithSpacing
+    }
+
+    private fun isPageBoundaryOffset(offset: Int): Boolean {
+        val boundaryOffset = pageBoundaryOffset(nearestPageForOffset(offset))
+        return abs(boundaryOffset - offset) <= SNAP_TARGET_OFFSET_TOLERANCE
+    }
+
+    private suspend fun alignScrollViewOffset(
+        layoutSize: Int,
+        scheduledOrientation: Orientation,
+        scheduledPageSizeWithSpacing: Int,
+        scheduledContentOffset: Int,
+        scheduledComposeOffset: Int,
+        scheduledLayoutGeneration: Int
+    ) {
+        val contentOffsetInt = scrollableState.kuiklyInfo.contentOffset
+
+        if (scheduledLayoutGeneration != alignmentLayoutGeneration) {
+            pagerSnapDebugLog {
+                "staleAlignDetected: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
+                    "scheduledOrientation=$scheduledOrientation " +
+                    "scheduledGeneration=$scheduledLayoutGeneration " +
+                    "currentGeneration=$alignmentLayoutGeneration " +
+                    "scheduledPageSizeWithSpacing=$scheduledPageSizeWithSpacing " +
+                    "currentPageSizeWithSpacing=$pageSizeWithSpacing " +
+                    "scheduledLayoutSize=$layoutSize currentLayoutSize=${currentLayoutMainAxisSize()} " +
+                    "scheduledContentOffset=$scheduledContentOffset contentOffset=$contentOffsetInt " +
+                    "scheduledComposeOffset=$scheduledComposeOffset " +
+                    "composeOffset=${currentAbsoluteScrollOffset().toInt()}"
+            }
+        }
+
+        if (isSnapAnimating && !hasSnapReachedTarget(contentOffsetInt)) {
+            pagerSnapDebugLog {
+                "skipAlignDuringSnap: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
+                    "contentOffset=$contentOffsetInt target=$snapTargetContentOffset " +
+                    "currentPage=$currentPage"
+            }
+            return
+        }
+
+        val normalComposeOffset = currentAbsoluteScrollOffset().toInt()
+        val positionCorrupted = isSnapAnimating && normalComposeOffset != contentOffsetInt
+        val correctTargetPage = nearestPageForOffset(contentOffsetInt)
+        val correctTargetOffset = pageBoundaryOffset(correctTargetPage)
+        val composeOffsetInt = if (positionCorrupted) {
+            correctTargetOffset
+        } else {
+            normalComposeOffset
+        }
+
+        val needFix = !isScrollInProgress && contentOffsetInt != composeOffsetInt
+        val composeOffsetOnBoundary = isPageBoundaryOffset(composeOffsetInt)
+        val contentOffsetOnBoundary = isPageBoundaryOffset(contentOffsetInt)
+
+        updateScrollViewContentSize(layoutSize)
+
+        if (alignComposePositionToNativeBoundaryIfNeeded(composeOffsetInt, contentOffsetInt)) {
+            return
+        }
+
+        if (needFix || positionCorrupted || isSnapAnimating) {
+            pagerSnapDebugLog {
+                "alignJob: needFix=$needFix positionCorrupted=$positionCorrupted " +
+                    "stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
+                    "scheduledOrientation=$scheduledOrientation " +
+                    "layoutGeneration=$alignmentLayoutGeneration " +
+                    "composeOffset=$composeOffsetInt contentOffset=$contentOffsetInt " +
+                    "scheduledComposeOffset=$scheduledComposeOffset " +
+                    "scheduledContentOffset=$scheduledContentOffset " +
+                    "normalComposeOffset=$normalComposeOffset currentPage=$currentPage " +
+                    "currentPageOffsetFraction=$currentPageOffsetFraction " +
+                    "firstVisiblePage=$firstVisiblePage firstVisiblePageOffset=$firstVisiblePageOffset " +
+                    "correctTargetPage=$correctTargetPage correctTargetOffset=$correctTargetOffset " +
+                    "pageSizeWithSpacing=$pageSizeWithSpacing " +
+                    "scheduledPageSizeWithSpacing=$scheduledPageSizeWithSpacing " +
+                    "layoutSize=$layoutSize currentLayoutSize=${currentLayoutMainAxisSize()} " +
+                    "isScrollInProgress=$isScrollInProgress isSnapAnimating=$isSnapAnimating " +
+                    "composeOffsetOnBoundary=$composeOffsetOnBoundary " +
+                    "contentOffsetOnBoundary=$contentOffsetOnBoundary target=$snapTargetContentOffset"
+            }
+        }
+
+        if (needFix) {
+            val delta = composeOffsetInt - contentOffsetInt
+            pagerSnapDebugLog {
+                "fixNativeOffset: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} delta=$delta"
+            }
+            applyScrollViewOffsetDelta(delta)
+        }
+
+        if (positionCorrupted) {
+            pagerSnapDebugLog {
+                "fixScrollPosition: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
+                    "correctTargetPage=$correctTargetPage " +
+                    "composeOffset=$composeOffsetInt contentOffset=$contentOffsetInt"
+            }
+            scrollPosition.requestPositionAndForgetLastKnownKey(correctTargetPage, 0f)
+        }
+
+        if (isSnapAnimating) {
+            clearSnapTrackingAfterAlignment()
+        }
+    }
+
+    private fun updateScrollViewContentSize(layoutSize: Int) {
+        val requiredContentSize = (maxScrollOffset + layoutSize).toInt()
+        if (kuiklyInfo.currentContentSize != requiredContentSize) {
+            kuiklyInfo.currentContentSize = requiredContentSize
+            kuiklyInfo.updateContentSizeToRender()
+        }
+    }
+
+    private fun alignComposePositionToNativeBoundaryIfNeeded(
+        composeOffset: Int,
+        contentOffset: Int
+    ): Boolean {
+        val composeOffsetOnBoundary = isPageBoundaryOffset(composeOffset)
+        val shouldSkipComposeOffset = pageSizeWithSpacing != 0 &&
+            !isScrollInProgress &&
+            !isSnapAnimating &&
+            !composeOffsetOnBoundary
+        pagerSnapDebugLog {
+            "alignBoundaryCheck: shouldSkip=$shouldSkipComposeOffset " +
+                "stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
+                "composeOffset=$composeOffset contentOffset=$contentOffset " +
+                "pageSizeWithSpacing=$pageSizeWithSpacing isScrollInProgress=$isScrollInProgress " +
+                "isSnapAnimating=$isSnapAnimating composeOffsetOnBoundary=$composeOffsetOnBoundary " +
+                "contentOffsetOnBoundary=${isPageBoundaryOffset(contentOffset)} currentPage=$currentPage"
+        }
+        if (!shouldSkipComposeOffset) {
+            return false
+        }
+
+        val nativePage = nearestPageForOffset(contentOffset)
+        val nativeBoundaryOffset = pageBoundaryOffset(nativePage)
+        pagerSnapDebugLog {
+            "skipNonBoundaryAlign: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
+                "composeOffset=$composeOffset contentOffset=$contentOffset " +
+                "nativePage=$nativePage nativeBoundaryOffset=$nativeBoundaryOffset currentPage=$currentPage"
+        }
+        if (!isPageBoundaryOffset(contentOffset)) {
+            val delta = nativeBoundaryOffset - contentOffset
+            pagerSnapDebugLog {
+                "fixNativeOffsetToBoundary: stateId=$debugPagerStateId " +
+                    "orientation=${layoutInfo.orientation} delta=$delta"
+            }
+            applyScrollViewOffsetDelta(delta)
+        }
+        scrollPosition.requestPositionAndForgetLastKnownKey(nativePage, 0f)
+        return true
+    }
+
+    private fun clearSnapTrackingAfterAlignment() {
+        isSnapAnimating = false
+        snapTargetContentOffset = 0
+        snapTargetReachedAlignmentRequested = false
+    }
+
     private var programmaticScrollTargetPage by mutableIntStateOf(-1)
 
     private var settledPageState by mutableIntStateOf(currentPage)
@@ -516,6 +776,7 @@ abstract class PagerState internal constructor(
         page: Int,
         @FloatRange(from = -0.5, to = 0.5) pageOffsetFraction: Float = 0f
     ) = scroll {
+        clearSnapAnimationState()
         debugLog { "Scroll from page=$currentPage to page=$page" }
         awaitScrollDependencies()
         require(pageOffsetFraction in -0.5..0.5) {
@@ -586,6 +847,7 @@ abstract class PagerState internal constructor(
         @AndroidXIntRange(from = 0) page: Int,
         @FloatRange(from = -0.5, to = 0.5) pageOffsetFraction: Float = 0.0f
     ) {
+        clearSnapAnimationState()
         // Cancel any scroll in progress.
         if (isScrollInProgress) {
             pagerLayoutInfoState.value.coroutineScope.launch {
@@ -629,20 +891,22 @@ abstract class PagerState internal constructor(
         if (targetOffset < 0) {
             targetOffset = minScrollOffset.toFloat()
         } else if (targetOffset + kuiklyInfo.viewportSize > kuiklyInfo.currentContentSize) {
-            targetOffset = maxScrollOffset.toFloat()
+            targetOffset = kuiklyInfo.currentContentSize.toFloat() - kuiklyInfo.viewportSize
         }
-        
+
         // Calculate initial and target offsets (for SpringSpec duration calculation)
         val initialOffset = kuiklyInfo.contentOffset.toFloat()
         val finalTargetOffset = targetOffset
-        
+
         // Convert AnimationSpec to SpringAnimation
         val springAnimation = convertAnimationSpecToSpringAnimation(
             animationSpec = animationSpec,
             initialValue = initialOffset,
             targetValue = finalTargetOffset
         )
-        
+
+        markSnapAnimationStarted(finalTargetOffset.toInt())
+
         kuiklyInfo.run {
             val targetOffsetDp = if (isVertical()) {
                 Offset(scrollView?.curOffsetX ?: 0f, max(0f, targetOffset / getDensity() - 0.01f))
@@ -708,7 +972,6 @@ abstract class PagerState internal constructor(
         visibleItemsStayedTheSame: Boolean = false
     ) {
         debugLog { "Applying Measure Result" }
-        // Hook: record page scroll context event for Recomposition Profiler
         val oldPage = scrollPosition.currentPage
         if (visibleItemsStayedTheSame) {
             scrollPosition.updateCurrentPageOffsetFraction(result.currentPageOffsetFraction)
@@ -742,29 +1005,29 @@ abstract class PagerState internal constructor(
 
         val layoutSize = if (result.orientation == Orientation.Horizontal)
             result.viewportSize.width else result.viewportSize.height
+        updateAlignmentLayoutGeneration(result.orientation, layoutSize)
 
-        // 非滚动状态，当前的offset和scrolview的不对齐； 调整下；
-        kuiklyInfo.run {
-            appleScrollViewOffsetJob?.cancel()
-            appleScrollViewOffsetJob = scope?.launch {
-                delay(50)
-                val latestComposeOffset = currentAbsoluteScrollOffset()
-                val contentOffsetInt = scrollableState.kuiklyInfo.contentOffset
-                val composeOffsetInt = latestComposeOffset.toInt()
-                val needFix = !isScrollInProgress && contentOffsetInt != composeOffsetInt
+        scheduleScrollViewOffsetAlignment(SNAP_MEASURE_JOB_INITIAL_DELAY_MS, layoutSize)
+    }
 
-                val requiredContentSize = (maxScrollOffset + layoutSize).toInt()
-                if (currentContentSize < requiredContentSize) {
-                    currentContentSize = requiredContentSize
-                    updateContentSizeToRender()
-                }
-
-                if (needFix) {
-                    val delta = composeOffsetInt - contentOffsetInt
-                    // 调整pager的offset
-                    applyScrollViewOffsetDelta(delta)
-                }
+    private fun updateAlignmentLayoutGeneration(orientation: Orientation, layoutSize: Int) {
+        val currentPageSizeWithSpacing = pageSizeWithSpacing
+        val changed = lastAlignmentOrientation != orientation ||
+            lastAlignmentLayoutSize != layoutSize ||
+            lastAlignmentPageSizeWithSpacing != currentPageSizeWithSpacing
+        if (changed) {
+            alignmentLayoutGeneration += 1
+            pagerSnapDebugLog {
+                "layoutGenerationChanged: stateId=$debugPagerStateId " +
+                    "generation=$alignmentLayoutGeneration " +
+                    "oldOrientation=$lastAlignmentOrientation newOrientation=$orientation " +
+                    "oldLayoutSize=$lastAlignmentLayoutSize newLayoutSize=$layoutSize " +
+                    "oldPageSizeWithSpacing=$lastAlignmentPageSizeWithSpacing " +
+                    "newPageSizeWithSpacing=$currentPageSizeWithSpacing"
             }
+            lastAlignmentOrientation = orientation
+            lastAlignmentLayoutSize = layoutSize
+            lastAlignmentPageSizeWithSpacing = currentPageSizeWithSpacing
         }
     }
 
@@ -897,6 +1160,7 @@ abstract class PagerState internal constructor(
         itemProvider: PagerLazyLayoutItemProvider,
         currentPage: Int = Snapshot.withoutReadObservation { scrollPosition.currentPage }
     ): Int = scrollPosition.matchPageWithKey(itemProvider, currentPage)
+
 }
 
 internal suspend fun PagerState.animateToNextPage() {
@@ -946,6 +1210,12 @@ private val UnitDensity = object : Density {
     override val density: Float = 1f
     override val fontScale: Float = 1f
 }
+
+/** Tolerance (px) when comparing native offset to [PagerState.snapTargetContentOffset]. */
+private const val SNAP_TARGET_OFFSET_TOLERANCE = 1
+
+/** Initial delay before checking native/compose offset alignment after measure. */
+private const val SNAP_MEASURE_JOB_INITIAL_DELAY_MS = 50L
 
 private inline fun debugLog(generateMsg: () -> String) {
     if (PagerDebugConfig.PagerState) {

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
@@ -132,22 +132,36 @@ private class DefaultPagerState(
 
     companion object {
         /**
-         * To keep current page and current page offset saved
+         * To keep current page and current page offset saved.
+         * Also saves bridge-layer state (composeOffset, currentContentSize, contentOffset, offsetDirty)
+         * to support ScrollerView reuse in nested Pager scenarios.
          */
         val Saver: Saver<DefaultPagerState, *> = listSaver(
             save = {
-                listOf(
-                    it.currentPage,
-                    (it.currentPageOffsetFraction).coerceIn(MinPageOffset, MaxPageOffset),
-                    it.pageCount
+                val saved = listOf(
+                    it.currentPage,                             // [0] Int
+                    (it.currentPageOffsetFraction).coerceIn(MinPageOffset, MaxPageOffset), // [1] Float
+                    it.pageCount,                               // [2] Int
+                    it.kuiklyInfo.composeOffset.toInt(),        // [3] bridge: Compose scroll offset
+                    it.kuiklyInfo.currentContentSize,           // [4] bridge: virtual content size
+                    it.kuiklyInfo.contentOffset,                // [5] bridge: native scrollView offset
+                    if (it.kuiklyInfo.offsetDirty) 1 else 0,   // [6] bridge: offset dirty flag
                 )
+                saved
             },
             restore = {
                 DefaultPagerState(
                     currentPage = it[0] as Int,
                     currentPageOffsetFraction = it[1] as Float,
                     updatedPageCount = { it[2] as Int }
-                )
+                ).also { state ->
+                    if (it.size > 3) { // backward compatibility with old saved data
+                        state.kuiklyInfo.composeOffset = (it[3] as Int).toFloat()
+                        state.kuiklyInfo.currentContentSize = it[4] as Int
+                        state.kuiklyInfo.contentOffset = it[5] as Int
+                        state.kuiklyInfo.offsetDirty = (it[6] as Int) == 1
+                    }
+                }
             }
         )
     }
@@ -891,13 +905,13 @@ abstract class PagerState internal constructor(
         if (targetOffset < 0) {
             targetOffset = minScrollOffset.toFloat()
         } else if (targetOffset + kuiklyInfo.viewportSize > kuiklyInfo.currentContentSize) {
-            targetOffset = kuiklyInfo.currentContentSize.toFloat() - kuiklyInfo.viewportSize
+            targetOffset = maxScrollOffset.toFloat()
         }
-
+        
         // Calculate initial and target offsets (for SpringSpec duration calculation)
         val initialOffset = kuiklyInfo.contentOffset.toFloat()
         val finalTargetOffset = targetOffset
-
+        
         // Convert AnimationSpec to SpringAnimation
         val springAnimation = convertAnimationSpecToSpringAnimation(
             animationSpec = animationSpec,
@@ -972,6 +986,7 @@ abstract class PagerState internal constructor(
         visibleItemsStayedTheSame: Boolean = false
     ) {
         debugLog { "Applying Measure Result" }
+        // Hook: record page scroll context event for Recomposition Profiler
         val oldPage = scrollPosition.currentPage
         if (visibleItemsStayedTheSame) {
             scrollPosition.updateCurrentPageOffsetFraction(result.currentPageOffsetFraction)
@@ -1160,7 +1175,6 @@ abstract class PagerState internal constructor(
         itemProvider: PagerLazyLayoutItemProvider,
         currentPage: Int = Snapshot.withoutReadObservation { scrollPosition.currentPage }
     ): Int = scrollPosition.matchPageWithKey(itemProvider, currentPage)
-
 }
 
 internal suspend fun PagerState.animateToNextPage() {
@@ -1211,17 +1225,17 @@ private val UnitDensity = object : Density {
     override val fontScale: Float = 1f
 }
 
-/** Tolerance (px) when comparing native offset to [PagerState.snapTargetContentOffset]. */
-private const val SNAP_TARGET_OFFSET_TOLERANCE = 1
-
-/** Initial delay before checking native/compose offset alignment after measure. */
-private const val SNAP_MEASURE_JOB_INITIAL_DELAY_MS = 50L
-
 private inline fun debugLog(generateMsg: () -> String) {
     if (PagerDebugConfig.PagerState) {
         println("PagerState: ${generateMsg()}")
     }
 }
+
+/** Tolerance (px) when comparing native offset to [PagerState.snapTargetContentOffset]. */
+private const val SNAP_TARGET_OFFSET_TOLERANCE = 1
+
+/** Initial delay before checking native/compose offset alignment after measure. */
+private const val SNAP_MEASURE_JOB_INITIAL_DELAY_MS = 50L
 
 internal fun PagerLayoutInfo.calculateNewMaxScrollOffset(pageCount: Int): Long {
     val pageSizeWithSpacing = pageSpacing + pageSize

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/PagerStateExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/PagerStateExtensions.kt
@@ -149,7 +149,6 @@ private fun PagerState.handleTargetPageScroll(
             ScrollableStateConstants.SPRING_ANIMATION_DAMPING,
             if (orientation == Orientation.Horizontal) params.velocityX else params.velocityY
         )
-
         val targetOffsetDp = targetOffset / density
 
         if (orientation == Orientation.Horizontal) {
@@ -181,7 +180,7 @@ private const val SNAP_LAYOUT_SIZE_TOLERANCE = 1
 /**
  * Converts AnimationSpec<Float> to SpringAnimation
  * This is a temporary solution that mainly supports animation duration and basic animation curves
- *
+ * 
  * @param animationSpec The animation spec to convert
  * @param initialValue Initial value (used for calculating SpringSpec duration)
  * @param targetValue Target value (used for calculating SpringSpec duration)
@@ -208,7 +207,7 @@ internal fun convertAnimationSpecToSpringAnimation(
             // SpringSpec is physics-based, so duration needs to be calculated from spring parameters
             // Note: getDurationMillis may involve complex calculations (Newton's method, etc.),
             // but it's only called once per animateScrollToPage, not per frame
-            val vectorizedSpec: VectorizedAnimationSpec<AnimationVector1D> =
+            val vectorizedSpec: VectorizedAnimationSpec<AnimationVector1D> = 
                 animationSpec.vectorize<AnimationVector1D>(Float.VectorConverter)
             val initialVector = AnimationVector1D(initialValue)
             val targetVector = AnimationVector1D(targetValue)
@@ -229,4 +228,4 @@ internal fun convertAnimationSpecToSpringAnimation(
             null
         }
     }
-}
+} 

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/PagerStateExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/PagerStateExtensions.kt
@@ -26,15 +26,22 @@ import com.tencent.kuikly.compose.foundation.gestures.Orientation
 import com.tencent.kuikly.compose.foundation.pager.PagerMeasureResult
 import com.tencent.kuikly.compose.foundation.pager.PagerSnapDistance
 import com.tencent.kuikly.compose.foundation.pager.PagerState
+import com.tencent.kuikly.compose.foundation.pager.pagerSnapDebugLog
 import com.tencent.kuikly.compose.ui.util.fastFirstOrNull
 import com.tencent.kuikly.core.views.SpringAnimation
 import com.tencent.kuikly.core.views.WillEndDragParams
+import kotlin.math.abs
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 /**
  * Handle drag end event
  */
 internal fun PagerState.kuiklyWillDragEnd(params: WillEndDragParams, orientation: Orientation) {
+    // Clear any previous snap animation flag in case scrollEnd didn't fire
+    // (e.g., user interrupted a snap animation by starting a new drag)
+    clearSnapAnimationState()
+
     val effectivePageSizePx = pageSize + pageSpacing
     if (effectivePageSizePx == 0) return
 
@@ -70,22 +77,79 @@ private fun PagerState.handleTargetPageScroll(
     orientation: Orientation
 ) {
     val kuiklyInfo = this.kuiklyInfo
-    (layoutInfo as? PagerMeasureResult)?.run {
+    val pagerMeasureResult = layoutInfo as? PagerMeasureResult ?: return
+    pagerMeasureResult.run {
         val allResult = visiblePagesInfo + extraPagesAfter + extraPagesBefore
         val nextPage = allResult.fastFirstOrNull { it.index == targetPage }
         val density = kuiklyInfo.getDensity()
         val offset = kuiklyInfo.composeOffset.toInt()
+        val nativeOffset = if (orientation == Orientation.Horizontal) {
+            params.offsetX.toInt()
+        } else {
+            params.offsetY.toInt()
+        }
+        val nativeTargetOffset = if (orientation == Orientation.Horizontal) {
+            params.targetContentOffsetX.toInt()
+        } else {
+            params.targetContentOffsetY.toInt()
+        }
+        val measureViewportSize = if (pagerMeasureResult.orientation == Orientation.Horizontal) {
+            viewportSize.width
+        } else {
+            viewportSize.height
+        }
+        val nativeViewportSize = kuiklyInfo.viewportSize
+
+        if (isSnapLayoutSizeUnstable(measureViewportSize, nativeViewportSize)) {
+            pagerSnapDebugLog {
+                "skipWillDragEndSnapUnstableLayoutSize: " +
+                    "stateId=${this@handleTargetPageScroll.debugPagerStateId} " +
+                    "eventOrientation=$orientation measureOrientation=${pagerMeasureResult.orientation} " +
+                    "targetPage=$targetPage measureViewportSize=$measureViewportSize " +
+                    "nativeViewportSize=$nativeViewportSize pageSize=$pageSize " +
+                    "pageSpacing=$pageSpacing pageSizeWithSpacing=$pageSizeWithSpacing " +
+                    "nativeOffset=$nativeOffset nativeTargetOffset=$nativeTargetOffset " +
+                    "kuiklyContentOffset=${kuiklyInfo.contentOffset} " +
+                    "composeOffset=${kuiklyInfo.composeOffset.toInt()} " +
+                    "currentContentSize=${kuiklyInfo.currentContentSize}"
+            }
+            return
+        }
 
         val maxOffset = kuiklyInfo.currentContentSize - kuiklyInfo.viewportSize
-        var targetOffset = nextPage?.let { offset + it.offset }
+        val composeCandidateOffset = nextPage?.let { offset + it.offset }
+        val pageBoundaryOffset = pageSizeWithSpacing * targetPage
+        val nativeBoundaryOffset = if (pageSizeWithSpacing == 0) {
+            nativeTargetOffset
+        } else {
+            (nativeTargetOffset / pageSizeWithSpacing.toFloat()).roundToInt() * pageSizeWithSpacing
+        }
+        var targetOffset = composeCandidateOffset
             ?: (pageSizeWithSpacing * targetPage)
         targetOffset = min(targetOffset, maxOffset)
+
+        pagerSnapDebugLog {
+            "willDragEndSnap: stateId=${this@handleTargetPageScroll.debugPagerStateId} " +
+                "eventOrientation=$orientation measureOrientation=${pagerMeasureResult.orientation} " +
+                "targetPage=$targetPage targetOffset=$targetOffset " +
+                "composeCandidateOffset=$composeCandidateOffset pageBoundaryOffset=$pageBoundaryOffset " +
+                "nativeOffset=$nativeOffset kuiklyContentOffset=${kuiklyInfo.contentOffset} " +
+                "nativeTargetOffset=$nativeTargetOffset nativeBoundaryOffset=$nativeBoundaryOffset " +
+                "composeOffset=$offset nextPageOffset=${nextPage?.offset} " +
+                "stateCurrentPage=${this@handleTargetPageScroll.currentPage} " +
+                "stateFirstVisiblePage=${this@handleTargetPageScroll.firstVisiblePage} " +
+                "measureCurrentPage=${currentPage?.index} measureFirstVisiblePage=${firstVisiblePage?.index} " +
+                "pageSizeWithSpacing=$pageSizeWithSpacing maxOffset=$maxOffset " +
+                "nextPageFound=${nextPage != null}"
+        }
+        this@handleTargetPageScroll.markSnapAnimationStarted(targetOffset)
 
         val springAnimation = SpringAnimation(
             ScrollableStateConstants.SPRING_ANIMATION_DURATION,
             ScrollableStateConstants.SPRING_ANIMATION_DAMPING,
             if (orientation == Orientation.Horizontal) params.velocityX else params.velocityY
         )
+
         val targetOffsetDp = targetOffset / density
 
         if (orientation == Orientation.Horizontal) {
@@ -106,10 +170,18 @@ private fun PagerState.handleTargetPageScroll(
     }
 }
 
+private fun isSnapLayoutSizeUnstable(measureViewportSize: Int, nativeViewportSize: Int): Boolean {
+    return nativeViewportSize > 0 &&
+        measureViewportSize > 0 &&
+        abs(measureViewportSize - nativeViewportSize) > SNAP_LAYOUT_SIZE_TOLERANCE
+}
+
+private const val SNAP_LAYOUT_SIZE_TOLERANCE = 1
+
 /**
  * Converts AnimationSpec<Float> to SpringAnimation
  * This is a temporary solution that mainly supports animation duration and basic animation curves
- * 
+ *
  * @param animationSpec The animation spec to convert
  * @param initialValue Initial value (used for calculating SpringSpec duration)
  * @param targetValue Target value (used for calculating SpringSpec duration)
@@ -136,7 +208,7 @@ internal fun convertAnimationSpecToSpringAnimation(
             // SpringSpec is physics-based, so duration needs to be calculated from spring parameters
             // Note: getDurationMillis may involve complex calculations (Newton's method, etc.),
             // but it's only called once per animateScrollToPage, not per frame
-            val vectorizedSpec: VectorizedAnimationSpec<AnimationVector1D> = 
+            val vectorizedSpec: VectorizedAnimationSpec<AnimationVector1D> =
                 animationSpec.vectorize<AnimationVector1D>(Float.VectorConverter)
             val initialVector = AnimationVector1D(initialValue)
             val targetVector = AnimationVector1D(targetValue)
@@ -157,4 +229,4 @@ internal fun convertAnimationSpecToSpringAnimation(
             null
         }
     }
-} 
+}

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ScrollableStateExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ScrollableStateExtensions.kt
@@ -62,7 +62,13 @@ internal fun ScrollableState.kuiklyOnScroll(delta: Float): Float = when (this) {
 internal fun ScrollableState.kuiklyOnScrollEnd(params: ScrollParams) {
     when (this) {
         is LazyListState -> scrollableState.kuiklyOnScrollEnd(params)
-        is PagerState -> scrollableState.kuiklyOnScrollEnd(params)
+        is PagerState -> {
+            // NOTE: Do NOT clear isSnapAnimating here.
+            // scrollEnd fires before data-load remeasure, so clearing here
+            // leaves updateFromMeasureResult unprotected. isSnapAnimating is
+            // cleared in the applyMeasureResult_job after FIXING decision.
+            scrollableState.kuiklyOnScrollEnd(params)
+        }
         is LazyGridState -> scrollableState.kuiklyOnScrollEnd(params)
         is LazyStaggeredGridState -> scrollableState.kuiklyOnScrollEnd(params)
         is ScrollState -> scrollableState.kuiklyOnScrollEnd(params)

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
@@ -284,6 +284,7 @@ fun SubcomposeLayout(
                 val scaleParams = it.scaleWithDensity(kuiklyInfo.getDensity())
                 val offset = if (isVertical) scaleParams.offsetY.toInt() else scaleParams.offsetX.toInt()
                 kuiklyInfo.contentOffset = offset
+                (scrollableState as? PagerState)?.onNativeContentOffsetChanged(offset)
 
                 // 仅触摸滑动结束会回调，api调用和bounce回弹都不会触发
                 // / back是回滑,forward是前滑
@@ -301,6 +302,7 @@ fun SubcomposeLayout(
 
                 val prevOffset = kuiklyInfo.contentOffset
                 kuiklyInfo.contentOffset = offset
+                (scrollableState as? PagerState)?.onNativeContentOffsetChanged(offset)
                 kuiklyInfo.isDragging = kuiklyInfo.scrollView?.isDragging ?: false
 
                 if (kuiklyInfo.ignoreScrollOffset != null) {

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/HorizontalPagerDemo3.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/HorizontalPagerDemo3.kt
@@ -40,6 +40,7 @@ import com.tencent.kuikly.compose.ui.Alignment
 import com.tencent.kuikly.compose.ui.Modifier
 import com.tencent.kuikly.compose.ui.graphics.Color
 import com.tencent.kuikly.compose.ui.unit.dp
+import com.tencent.kuikly.compose.extension.bouncesEnable
 import com.tencent.kuikly.core.annotations.Page
 
 @Page("HorizontalPagerDemo3")
@@ -75,6 +76,7 @@ class HorizontalPagerDemo3 : ComposeContainer() {
                         Modifier
                             .height(100.dp)
                             .fillMaxWidth()
+                            .bouncesEnable(false)
                             .background(Color.LightGray),
                     pageSize = PageSize.Fixed(250.dp),
                     contentPadding = PaddingValues(horizontal = 32.dp),

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/MovableContentDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/MovableContentDemo.kt
@@ -54,6 +54,7 @@ import com.tencent.kuikly.compose.ui.text.font.FontWeight
 import com.tencent.kuikly.compose.ui.unit.Dp
 import com.tencent.kuikly.compose.ui.unit.dp
 import com.tencent.kuikly.compose.ui.unit.sp
+import com.tencent.kuikly.compose.ui.semantics.semantics
 import com.tencent.kuikly.compose.ui.semantics.testTag
 import com.tencent.kuikly.core.annotations.Page
 
@@ -252,18 +253,18 @@ private fun StatePreservationDemo() {
             ) {
                 Button(
                     onClick = { count++ },
-                    modifier = Modifier.testTag("demo2_btn_increment"),
+                    modifier = Modifier.semantics { testTag = "demo2_btn_increment" },
                 ) { Text("+") }
                 Text(
                     "计数: $count",
                     fontSize = 20.sp,
                     fontWeight = FontWeight.Bold,
                     color = Color(0xFF673AB7),
-                    modifier = Modifier.testTag("demo2_counter_text"),
+                    modifier = Modifier.semantics { testTag = "demo2_counter_text" },
                 )
                 Button(
                     onClick = { count-- },
-                    modifier = Modifier.testTag("demo2_btn_decrement"),
+                    modifier = Modifier.semantics { testTag = "demo2_btn_decrement" },
                 ) { Text("-") }
             }
         }
@@ -272,7 +273,7 @@ private fun StatePreservationDemo() {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Button(
             onClick = { isTop = !isTop },
-            modifier = Modifier.testTag("demo2_btn_move"),
+            modifier = Modifier.semantics { testTag = "demo2_btn_move" },
         ) {
             Text(if (isTop) "移到底部" else "移到顶部")
         }
@@ -446,12 +447,12 @@ private fun CrossContainerMoveDemo() {
                     "切换次数: $toggleCount",
                     fontSize = 14.sp,
                     color = Color(0xFF388E3C),
-                    modifier = Modifier.testTag("demo5_toggle_count_text"),
+                    modifier = Modifier.semantics { testTag = "demo5_toggle_count_text" },
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Button(
                     onClick = { toggleCount++ },
-                    modifier = Modifier.testTag("demo5_btn_increment"),
+                    modifier = Modifier.semantics { testTag = "demo5_btn_increment" },
                 ) { Text("点击+1") }
             }
         }
@@ -460,7 +461,7 @@ private fun CrossContainerMoveDemo() {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Button(
             onClick = { inLeft = !inLeft },
-            modifier = Modifier.testTag("demo5_btn_move_panel"),
+            modifier = Modifier.semantics { testTag = "demo5_btn_move_panel" },
         ) {
             Text(if (inLeft) "移到右面板" else "移到左面板")
         }
@@ -566,7 +567,7 @@ private fun VideoViewMoveDemo() {
         ) {
             Button(
                 onClick = { isTop = !isTop; moveCount++ },
-                modifier = Modifier.testTag("demo6_btn_move"),
+                modifier = Modifier.semantics { testTag = "demo6_btn_move" },
             ) {
                 Text(if (isTop) "移到下方" else "移到上方")
             }
@@ -575,19 +576,19 @@ private fun VideoViewMoveDemo() {
                     "移动次数: $moveCount",
                     fontSize = 12.sp,
                     color = Color(0xFF555555),
-                    modifier = Modifier.testTag("demo6_move_count_text"),
+                    modifier = Modifier.semantics { testTag = "demo6_move_count_text" },
                 )
                 Text(
                     "播放进度: ${playTimeMs / 1000}s",
                     fontSize = 12.sp,
                     color = Color(0xFF1565C0),
-                    modifier = Modifier.testTag("demo6_play_time_text"),
+                    modifier = Modifier.semantics { testTag = "demo6_play_time_text" },
                 )
                 Text(
                     statusText,
                     fontSize = 12.sp,
                     color = Color(0xFF388E3C),
-                    modifier = Modifier.testTag("demo6_status_text"),
+                    modifier = Modifier.semantics { testTag = "demo6_status_text" },
                 )
             }
         }


### PR DESCRIPTION
## Summary
- 统一 Pager native snap 动画跟踪与 offset 对齐，避免 remeasure 后 scrollPosition 与 native 偏移不一致
- 横竖屏切换时在 viewport 尺寸不稳定阶段跳过 native snap，修复停半页/跳回问题
- 将 native `contentSize` 同步到 measured pager 边界（扩容+收缩），修复最后一页左滑边界 overscroll

## Test plan
- [x] `:compose:compileDebugKotlinAndroid` 编译通过
- [x] ComposeOnKuikly `HorizontalPagerDemo3` Android 真机验证（横竖屏切换、边界滑动）
- [x] WeSee 业务包 mavenLocal 集成验证 Pager 行为


Made with [Cursor](https://cursor.com)