### PR TITLE
fix(compose): 修正 JS 端 IdentityHashCode 源文件目录路径

### DIFF
--- a/compose/src/jsMain/kotlin/com/tencent/kuikly/compose/material3/internal/IdentityHashCode.js.kt
+++ b/compose/src/jsMain/kotlin/com/tencent/kuikly/compose/material3/internal/IdentityHashCode.js.kt
@@ -2,7 +2,7 @@ package com.tencent.kuikly.compose.material3.internal
 
 import androidx.compose.runtime.NoLiveLiterals
 
-actual fun identityHashCode(instance: Any?): Int {
+internal actual fun identityHashCode(instance: Any?): Int {
     if (instance == null) {
         return 0
     }


### PR DESCRIPTION
## Summary
- 将 `IdentityHashCode.js.kt` 从错误路径 `material3/material3/internal/` 移至 `material3/internal/`，与包名及 androidMain/nativeMain 目录结构一致
- 将 `actual fun identityHashCode` 改为 `internal actual fun identityHashCode`，与 android/native 端保持一致
- 删除空的 `material3/material3/internal` 目录

## Test plan
- [x] `./gradlew -c settings.2.1.21.gradle.kts :compose:compileKotlinJs` 编译通过


Made with [Cursor](https://cursor.com)