### PR TITLE
fix(compose): stabilize pager snap settling

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerMeasurePolicy.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerMeasurePolicy.kt
@@ -151,6 +151,9 @@ internal fun rememberPagerMeasurePolicy(
         val currentPageOffset: Int
 
         Snapshot.withoutReadObservation {
+            // Keep the snap target aligned to its item key when items are inserted/removed
+            // before it during the snap settle window (itemProvider is only available here).
+            state.relocateSnapTargetByKey(itemProvider)
             currentPage = state.matchScrollPositionWithKey(itemProvider, state.currentPage)
             currentPageOffset = snapPosition.currentPageOffset(
                 mainAxisAvailableSize,

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
@@ -411,17 +411,57 @@ abstract class PagerState internal constructor(
     /** Native content offset that the snap animation is settling to. */
     internal var snapTargetContentOffset = 0
 
+    /**
+     * pageCount captured when the snap animation started. Used to detect that the item set
+     * changed (e.g. head/middle insertion) during the snap settle window, in which case the
+     * native pixel offset becomes stale and must not be used to re-derive the target page.
+     */
+    internal var snapStartPageCount = 0
+
+    /**
+     * Key of the target page item captured when the snap animation started. When items are
+     * inserted/removed during the settle window, the target page index shifts; we re-resolve
+     * the target index from this key (see [relocateSnapTargetByKey]) instead of trusting the
+     * stale native pixel offset.
+     */
+    internal var snapTargetItemKey: Any? = null
+
+    /** Target page index, kept up to date by key when the item set changes during snap. */
+    internal var snapTargetRelocatedPage = -1
+
+    /**
+     * Compose<->native desync (in pages) captured when the snap started. When non-zero the native
+     * pixel offset cannot be trusted to re-derive the target page at settle (the coordinate systems
+     * are shifted), so the settle must drive compose from the key-tracked target page and re-base
+     * native onto compose's boundary, exactly like the item-set-changed path.
+     */
+    internal var snapStartDesyncPages = 0
+
     private var snapTargetReachedAlignmentRequested = false
 
+    private var snapStallAlignmentRetryRequested = false
+
     /** Called before native setContentOffset(animated=true). */
-    internal fun markSnapAnimationStarted(targetContentOffset: Int) {
+    internal fun markSnapAnimationStarted(
+        targetContentOffset: Int,
+        targetPage: Int = -1,
+        targetKey: Any? = null,
+        desyncPages: Int = 0
+    ) {
         isSnapAnimating = true
         snapTargetContentOffset = targetContentOffset
+        snapStartPageCount = pageCount
+        snapTargetRelocatedPage = targetPage
+        snapTargetItemKey = targetKey
+        snapStartDesyncPages = desyncPages
+        kuiklyInfo.snapAnchorOffsetCorrection = 0
         snapTargetReachedAlignmentRequested = false
+        snapStallAlignmentRetryRequested = false
         pagerSnapDebugLog {
             "snapStarted: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
                 "targetOffset=$targetContentOffset contentOffset=${kuiklyInfo.contentOffset} " +
-                "composeOffset=${currentAbsoluteScrollOffset().toInt()} currentPage=$currentPage"
+                "composeOffset=${currentAbsoluteScrollOffset().toInt()} currentPage=$currentPage " +
+                "anchorCorrection=${kuiklyInfo.snapAnchorOffsetCorrection}"
         }
     }
 
@@ -430,10 +470,11 @@ abstract class PagerState internal constructor(
     }
 
     internal fun onNativeContentOffsetChanged(contentOffset: Int) {
-        if (!isSnapAnimating ||
-            snapTargetReachedAlignmentRequested ||
-            !hasSnapReachedTarget(contentOffset)
-        ) {
+        if (!isSnapAnimating || snapTargetReachedAlignmentRequested) {
+            return
+        }
+
+        if (!hasSnapReachedTarget(contentOffset)) {
             return
         }
 
@@ -441,7 +482,7 @@ abstract class PagerState internal constructor(
         pagerSnapDebugLog {
             "snapTargetReached: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
                 "contentOffset=$contentOffset target=$snapTargetContentOffset " +
-                "currentPage=$currentPage"
+                "currentPage=$currentPage anchorCorrection=${kuiklyInfo.snapAnchorOffsetCorrection}"
         }
         scheduleScrollViewOffsetAlignment(SNAP_MEASURE_JOB_INITIAL_DELAY_MS)
     }
@@ -457,7 +498,13 @@ abstract class PagerState internal constructor(
         }
         isSnapAnimating = false
         snapTargetContentOffset = 0
+        snapStartPageCount = 0
+        snapTargetItemKey = null
+        snapTargetRelocatedPage = -1
+        snapStartDesyncPages = 0
         snapTargetReachedAlignmentRequested = false
+        snapStallAlignmentRetryRequested = false
+        kuiklyInfo.snapAnchorOffsetCorrection = 0
         kuiklyInfo.appleScrollViewOffsetJob?.cancel()
     }
 
@@ -544,12 +591,43 @@ abstract class PagerState internal constructor(
             }
         }
 
-        if (isSnapAnimating && !hasSnapReachedTarget(contentOffsetInt)) {
-            pagerSnapDebugLog {
-                "skipAlignDuringSnap: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
-                    "contentOffset=$contentOffsetInt target=$snapTargetContentOffset " +
-                    "currentPage=$currentPage"
+        if (handleUnreachedSnapTarget(
+                contentOffsetInt,
+                scheduledContentOffset,
+                layoutSize
+            )
+        ) {
+            return
+        }
+
+        // While snapping, the target item is pinned to snapTargetContentOffset by
+        // snapAnchorOffsetCorrection. Once the native animation reaches that original target,
+        // settle the compose position to the key-tracked page and clear the correction by moving
+        // native offset and child frames together. This keeps the visual position unchanged while
+        // restoring the normal compose/native coordinate system.
+        val itemsChangedDuringSnap =
+            isSnapAnimating && snapStartPageCount != 0 && pageCount != snapStartPageCount
+        val snapStartedDesynced = isSnapAnimating && snapStartDesyncPages != 0
+        if (itemsChangedDuringSnap || snapStartedDesynced) {
+            val relocatedTarget = if (snapTargetRelocatedPage in 0 until pageCount) {
+                snapTargetRelocatedPage
+            } else {
+                currentPage.coerceInPageRange()
             }
+            val relocatedTargetOffset = pageBoundaryOffset(relocatedTarget)
+            updateScrollViewContentSize(layoutSize)
+            scrollPosition.requestPositionAndForgetLastKnownKey(relocatedTarget, 0f)
+            val delta = relocatedTargetOffset - contentOffsetInt
+            if (delta != 0) {
+                applyScrollViewOffsetDelta(delta)
+            } else {
+                // requestPosition changes the Compose page raw coordinates. Keep the frame offset
+                // on the relocated target boundary; otherwise the viewport can stay in the stale
+                // native coordinate system after items are inserted before the snap target.
+                kuiklyInfo.composeOffset = relocatedTargetOffset.toFloat()
+            }
+            kuiklyInfo.snapAnchorOffsetCorrection = 0
+            clearSnapTrackingAfterAlignment()
             return
         }
 
@@ -610,6 +688,7 @@ abstract class PagerState internal constructor(
                     "composeOffset=$composeOffsetInt contentOffset=$contentOffsetInt"
             }
             scrollPosition.requestPositionAndForgetLastKnownKey(correctTargetPage, 0f)
+            kuiklyInfo.composeOffset = correctTargetOffset.toFloat()
         }
 
         if (isSnapAnimating) {
@@ -668,7 +747,85 @@ abstract class PagerState internal constructor(
     private fun clearSnapTrackingAfterAlignment() {
         isSnapAnimating = false
         snapTargetContentOffset = 0
+        snapStartPageCount = 0
+        snapTargetItemKey = null
+        snapTargetRelocatedPage = -1
+        snapStartDesyncPages = 0
         snapTargetReachedAlignmentRequested = false
+        snapStallAlignmentRetryRequested = false
+        kuiklyInfo.snapAnchorOffsetCorrection = 0
+    }
+
+    private fun handleUnreachedSnapTarget(
+        contentOffset: Int,
+        scheduledContentOffset: Int,
+        layoutSize: Int
+    ): Boolean {
+        if (!isSnapAnimating || hasSnapReachedTarget(contentOffset)) {
+            snapStallAlignmentRetryRequested = false
+            return false
+        }
+
+        if (contentOffset != scheduledContentOffset) {
+            snapStallAlignmentRetryRequested = false
+            pagerSnapDebugLog {
+                "waitAlignDuringSnap: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
+                    "scheduledContentOffset=$scheduledContentOffset contentOffset=$contentOffset " +
+                    "target=$snapTargetContentOffset currentPage=$currentPage"
+            }
+            scheduleScrollViewOffsetAlignment(SNAP_MEASURE_JOB_INITIAL_DELAY_MS, layoutSize)
+            return true
+        }
+
+        if (!snapStallAlignmentRetryRequested) {
+            snapStallAlignmentRetryRequested = true
+            pagerSnapDebugLog {
+                "confirmSnapStall: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
+                    "contentOffset=$contentOffset target=$snapTargetContentOffset " +
+                    "currentPage=$currentPage"
+            }
+            scheduleScrollViewOffsetAlignment(SNAP_MEASURE_JOB_INITIAL_DELAY_MS, layoutSize)
+            return true
+        }
+
+        val fallbackPage = if (snapTargetRelocatedPage in 0 until pageCount) {
+            snapTargetRelocatedPage
+        } else {
+            nearestPageForOffset(snapTargetContentOffset)
+        }
+        val fallbackOffset = pageBoundaryOffset(fallbackPage)
+        pagerSnapDebugLog {
+            "fixInterruptedSnap: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
+                "fallbackPage=$fallbackPage fallbackOffset=$fallbackOffset " +
+                "contentOffset=$contentOffset target=$snapTargetContentOffset " +
+                "currentPage=$currentPage firstVisiblePage=$firstVisiblePage"
+        }
+        updateScrollViewContentSize(layoutSize)
+        scrollPosition.requestPositionAndForgetLastKnownKey(fallbackPage, 0f)
+        val delta = fallbackOffset - contentOffset
+        if (delta != 0) {
+            applyScrollViewOffsetDelta(delta)
+        } else {
+            kuiklyInfo.composeOffset = fallbackOffset.toFloat()
+        }
+        clearSnapTrackingAfterAlignment()
+        return true
+    }
+
+    /**
+     * Re-resolve the snap target index from its captured key. Must be called during measure
+     * (where [itemProvider] is available) so that insertions/removals before the target during
+     * the snap settle window shift the target to its new index instead of leaving it stale.
+     */
+    @OptIn(ExperimentalFoundationApi::class)
+    internal fun relocateSnapTargetByKey(itemProvider: PagerLazyLayoutItemProvider) {
+        if (!isSnapAnimating) return
+        val key = snapTargetItemKey ?: return
+        if (snapTargetRelocatedPage < 0) return
+        val newIndex = itemProvider.findIndexByKey(key, snapTargetRelocatedPage)
+        if (newIndex != snapTargetRelocatedPage) {
+            snapTargetRelocatedPage = newIndex
+        }
     }
 
     private var programmaticScrollTargetPage by mutableIntStateOf(-1)

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
@@ -33,6 +33,7 @@ import com.tencent.kuikly.compose.foundation.lazy.layout.AwaitFirstLayoutModifie
 import com.tencent.kuikly.compose.foundation.lazy.layout.LazyLayoutBeyondBoundsInfo
 import com.tencent.kuikly.compose.foundation.lazy.layout.LazyLayoutPinnedItemList
 import com.tencent.kuikly.compose.foundation.lazy.layout.ObservableScopeInvalidator
+import com.tencent.kuikly.compose.foundation.lazy.layout.findIndexByKey
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
@@ -66,6 +66,13 @@ class KuiklyScrollInfo {
     var composeOffset = 0f
 
     /**
+     * Temporary native-coordinate correction used while a Pager snap animation is running.
+     * When items are inserted before the snap target, this keeps the target item's native frame
+     * anchored to the original snap target offset until the snap settles.
+     */
+    var snapAnchorOffsetCorrection = 0
+
+    /**
      * Current contentView size, used to expand the bottom boundary
      */
     var currentContentSize by mutableStateOf((DEFAULT_CONTENT_SIZE * getDensity()).toInt())

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/PagerStateExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/PagerStateExtensions.kt
@@ -43,14 +43,33 @@ internal fun PagerState.kuiklyWillDragEnd(params: WillEndDragParams, orientation
     clearSnapAnimationState()
 
     val effectivePageSizePx = pageSize + pageSpacing
-    if (effectivePageSizePx == 0) return
+    if (effectivePageSizePx == 0) {
+        return
+    }
+
+    // Capture compose<->native desync at gesture end. The snap target is still derived from the
+    // logical current page and gesture direction, but settle must avoid re-deriving the page from a
+    // shifted native pixel offset.
+    val nativeContentOffset = kuiklyInfo.contentOffset
+    val nativePageFromOffset =
+        (nativeContentOffset.toFloat() / effectivePageSizePx).roundToInt()
+    val desyncPages = firstVisiblePage - nativePageFromOffset
 
     val velocity = if (orientation == Orientation.Horizontal) -params.velocityX else -params.velocityY
-    val startPage = if (velocity < 0) firstVisiblePage + 1 else firstVisiblePage
-    val targetPage = startPage.coerceIn(0, pageCount)
+    val pageDirection = when {
+        velocity < 0 -> 1
+        velocity > 0 -> -1
+        else -> 0
+    }
+    val snapBasePage = currentPage
+    val targetPage = if (pageDirection == 0) {
+        currentPage
+    } else {
+        snapBasePage + pageDirection
+    }.coerceIn(0, pageCount)
 
-    val correctedTargetPage = calculateTargetPage(startPage, targetPage, velocity)
-    handleTargetPageScroll(correctedTargetPage, params, orientation)
+    val correctedTargetPage = calculateTargetPage(snapBasePage, targetPage, velocity)
+    handleTargetPageScroll(correctedTargetPage, params, orientation, desyncPages)
 }
 
 private fun PagerState.calculateTargetPage(
@@ -74,7 +93,8 @@ private fun PagerState.calculateTargetPage(
 private fun PagerState.handleTargetPageScroll(
     targetPage: Int,
     params: WillEndDragParams,
-    orientation: Orientation
+    orientation: Orientation,
+    desyncPages: Int = 0
 ) {
     val kuiklyInfo = this.kuiklyInfo
     val pagerMeasureResult = layoutInfo as? PagerMeasureResult ?: return
@@ -119,14 +139,15 @@ private fun PagerState.handleTargetPageScroll(
         val maxOffset = kuiklyInfo.currentContentSize - kuiklyInfo.viewportSize
         val composeCandidateOffset = nextPage?.let { offset + it.offset }
         val pageBoundaryOffset = pageSizeWithSpacing * targetPage
-        val nativeBoundaryOffset = if (pageSizeWithSpacing == 0) {
-            nativeTargetOffset
-        } else {
-            (nativeTargetOffset / pageSizeWithSpacing.toFloat()).roundToInt() * pageSizeWithSpacing
-        }
-        var targetOffset = composeCandidateOffset
-            ?: (pageSizeWithSpacing * targetPage)
-        targetOffset = min(targetOffset, maxOffset)
+        // Snap target selection:
+        //  - Aligned (no desync): use the compose-coordinate candidate. Native and compose share the
+        //    same coordinate, so this lands exactly on the next page.
+        //  - Pre-existing compose<->native desync: the event offset can be stale, but Android
+        //    setContentOffset is applied against the contentView's current top/left, which already
+        //    includes composeOffset. Use the compose-coordinate target so the native animation moves
+        //    in the same direction as the visible item frames.
+        var targetOffset = composeCandidateOffset ?: pageBoundaryOffset
+        targetOffset = min(targetOffset, maxOffset).coerceAtLeast(0)
 
         pagerSnapDebugLog {
             "willDragEndSnap: stateId=${this@handleTargetPageScroll.debugPagerStateId} " +
@@ -134,7 +155,7 @@ private fun PagerState.handleTargetPageScroll(
                 "targetPage=$targetPage targetOffset=$targetOffset " +
                 "composeCandidateOffset=$composeCandidateOffset pageBoundaryOffset=$pageBoundaryOffset " +
                 "nativeOffset=$nativeOffset kuiklyContentOffset=${kuiklyInfo.contentOffset} " +
-                "nativeTargetOffset=$nativeTargetOffset nativeBoundaryOffset=$nativeBoundaryOffset " +
+                "nativeTargetOffset=$nativeTargetOffset " +
                 "composeOffset=$offset nextPageOffset=${nextPage?.offset} " +
                 "stateCurrentPage=${this@handleTargetPageScroll.currentPage} " +
                 "stateFirstVisiblePage=${this@handleTargetPageScroll.firstVisiblePage} " +
@@ -142,7 +163,12 @@ private fun PagerState.handleTargetPageScroll(
                 "pageSizeWithSpacing=$pageSizeWithSpacing maxOffset=$maxOffset " +
                 "nextPageFound=${nextPage != null}"
         }
-        this@handleTargetPageScroll.markSnapAnimationStarted(targetOffset)
+        this@handleTargetPageScroll.markSnapAnimationStarted(
+            targetOffset,
+            targetPage,
+            nextPage?.key,
+            desyncPages
+        )
 
         val springAnimation = SpringAnimation(
             ScrollableStateConstants.SPRING_ANIMATION_DURATION,
@@ -180,7 +206,7 @@ private const val SNAP_LAYOUT_SIZE_TOLERANCE = 1
 /**
  * Converts AnimationSpec<Float> to SpringAnimation
  * This is a temporary solution that mainly supports animation duration and basic animation curves
- * 
+ *
  * @param animationSpec The animation spec to convert
  * @param initialValue Initial value (used for calculating SpringSpec duration)
  * @param targetValue Target value (used for calculating SpringSpec duration)
@@ -207,7 +233,7 @@ internal fun convertAnimationSpecToSpringAnimation(
             // SpringSpec is physics-based, so duration needs to be calculated from spring parameters
             // Note: getDurationMillis may involve complex calculations (Newton's method, etc.),
             // but it's only called once per animateScrollToPage, not per frame
-            val vectorizedSpec: VectorizedAnimationSpec<AnimationVector1D> = 
+            val vectorizedSpec: VectorizedAnimationSpec<AnimationVector1D> =
                 animationSpec.vectorize<AnimationVector1D>(Float.VectorConverter)
             val initialVector = AnimationVector1D(initialValue)
             val targetVector = AnimationVector1D(targetValue)
@@ -228,4 +254,4 @@ internal fun convertAnimationSpecToSpringAnimation(
             null
         }
     }
-} 
+}

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/KNode.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/KNode.kt
@@ -264,7 +264,7 @@ internal class KNode<T : DeclarativeBaseView<*, *>>(
         if (ksScrollSubView && needFixScrollOffset) {
             val scrollerView = (parent as KNode<*>).view
             ((scrollerView.renderProperties as? RenderProperties)?.kuiklyScrollInfo)?.apply {
-                val deltaOffset = composeOffset
+                val deltaOffset = composeOffset + snapAnchorOffsetCorrection
                 pos = if (orientation == Orientation.Vertical) {
                     Offset(pos.x, pos.y + deltaOffset)
                 } else {


### PR DESCRIPTION
## Summary
- Port Pager snap settle stability fix from ComposeOnKuikly `1.3.140-compose-beta` (`c572bde5da`)
- Track snap targets by item key during prepend/remove; settle from logical `currentPage` + swipe direction instead of stale native pixel offset
- Add interrupted snap fallback when native animation stalls mid-page; sync `composeOffset` on `positionCorrupted`
- Add `snapAnchorOffsetCorrection` for native frame anchoring during snap with data changes

## KuiklyUI-specific adaptations
- Kept `DefaultPagerState.Saver` bridge state untouched (no whole-file overwrite)
- `KuiklyScrollInfo.snapAnchorOffsetCorrection` added under `compose/gestures/`
- `KNode` uses `RenderProperties.kuiklyScrollInfo` path (not `extProps`)

## Files
- `PagerState.kt` — snap state machine, `alignScrollViewOffset`, `relocateSnapTargetByKey`, `handleUnreachedSnapTarget`
- `PagerStateExtensions.kt` — `kuiklyWillDragEnd` uses `currentPage + pageDirection`
- `PagerMeasurePolicy.kt` — call `relocateSnapTargetByKey` during measure
- `KuiklyScrollInfo.kt` / `KNode.kt` — anchor correction

## Test plan
- [ ] `HorizontalPagerDemo3` — rotation / boundary snap
- [ ] `VerticalPagerDemo` — basic vertical paging
- [ ] WeSee short-drama vertical pager: fast back-swipe, prepend during snap, desync settle (upgrade integration)

## References
- ComposeOnKuikly: `fix/pager-snap-stability-fix7` → `1.3.140-compose-beta`
- Harness docs: `pager-compose-native-architecture.md`, `pager-wesee-business-cases.md`


Made with [Cursor](https://cursor.com)