### PR TITLE
fix: pass font family to text fields

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/BasicTextField.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/BasicTextField.kt
@@ -36,6 +36,8 @@ import com.tencent.kuikly.compose.ui.graphics.Color
 import com.tencent.kuikly.compose.ui.graphics.SolidColor
 import com.tencent.kuikly.compose.ui.text.TextLayoutResult
 import com.tencent.kuikly.compose.ui.text.TextStyle
+import com.tencent.kuikly.compose.ui.text.font.FontListFontFamily
+import com.tencent.kuikly.compose.ui.text.font.GenericFontFamily
 import com.tencent.kuikly.compose.ui.text.input.ImeAction
 import com.tencent.kuikly.compose.ui.text.input.KeyboardType
 import com.tencent.kuikly.compose.ui.text.input.TextFieldValue
@@ -43,6 +45,7 @@ import com.tencent.kuikly.compose.ui.text.input.VisualTransformation
 import com.tencent.kuikly.compose.ui.text.style.TextAlign
 import com.tencent.kuikly.compose.ui.unit.Density
 import com.tencent.kuikly.compose.ui.unit.isSpecified
+import com.tencent.kuikly.compose.resources.toKuiklyFontFamily
 import com.tencent.kuikly.core.views.TextAreaAttr
 
 internal fun TextAreaAttr.setTextStyle(style: TextStyle, density: Density) {
@@ -74,6 +77,11 @@ internal fun TextAreaAttr.setTextStyle(style: TextStyle, density: Density) {
         } else {
             fontWeightNormal()
         }
+    }
+    when (val fontFamily = style.fontFamily) {
+        is GenericFontFamily -> fontFamily(fontFamily.name)
+        is FontListFontFamily -> fontFamily(fontFamily.fonts.toKuiklyFontFamily())
+        else -> Unit
     }
 
     if (style.lineHeight.isSpecified) {

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/CoreTextField.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/CoreTextField.kt
@@ -357,6 +357,12 @@ internal fun CoreTextField(
         state,
         focusRequester,
         readOnly,
+        onTapPosition = { offset ->
+            if (autoHeightTextAreaView.getPager().pageData.isIOS) {
+                val pageDensity = autoHeightTextAreaView.getPager().pagerDensity()
+                autoHeightTextAreaView.setCursorIndexByPoint(offset.x / pageDensity, offset.y / pageDensity)
+            }
+        },
 //        offsetMapping,
     )
 

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/TextFieldPointerModifier.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/TextFieldPointerModifier.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import com.tencent.kuikly.compose.foundation.interaction.MutableInteractionSource
 import com.tencent.kuikly.compose.ui.Modifier
 import com.tencent.kuikly.compose.ui.focus.FocusRequester
+import com.tencent.kuikly.compose.ui.geometry.Offset
 
 //import androidx.compose.foundation.interaction.MutableInteractionSource
 //import androidx.compose.foundation.text.selection.TextFieldSelectionManager
@@ -40,6 +41,7 @@ internal fun Modifier.textFieldPointer(
     state: LegacyTextFieldState,
     focusRequester: FocusRequester,
     readOnly: Boolean,
+    onTapPosition: ((Offset) -> Unit)? = null,
 //    offsetMapping: OffsetMapping
 ): Modifier = Modifier.defaultTextFieldPointer(
 //    manager,
@@ -48,6 +50,7 @@ internal fun Modifier.textFieldPointer(
     state,
     focusRequester,
     readOnly,
+    onTapPosition,
 //    offsetMapping,
 )
 
@@ -59,11 +62,15 @@ internal fun Modifier.defaultTextFieldPointer(
     state: LegacyTextFieldState,
     focusRequester: FocusRequester,
     readOnly: Boolean,
+    onTapPosition: ((Offset) -> Unit)? = null,
 //    offsetMapping: OffsetMapping
 ) = this
 //    .updateSelectionTouchMode { state.isInTouchMode = it }
     .tapPressTextFieldModifier(interactionSource, enabled) { offset ->
         requestFocusAndShowKeyboardIfNeeded(state, focusRequester, !readOnly)
+        if (!readOnly && (state.hasFocus || focusRequester.hasAttachedNodes())) {
+            onTapPosition?.invoke(offset)
+        }
         if (state.hasFocus && enabled) {
 //            if (state.handleState != HandleState.Selection) {
 //                state.layoutResult?.let { layoutResult ->

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRTextFieldView.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRTextFieldView.kt
@@ -120,6 +120,7 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
     private var inputReturnCallBack: KuiklyRenderCallback? = null
 
     private var fontSize = -1f
+    private var fontFamily = KRCssConst.EMPTY_STRING
     private var lineHeight = -1f
     private var lineHeightSpan: HRLineHeightSpan? = null
     private var textWatcher: TextWatcher? = null
@@ -194,6 +195,7 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
             KRTextProps.PROP_KEY_VALUES -> setValues(propValue)
             FONT_SIZE -> setFontSize(propValue)
             FONT_WEIGHT -> setFontWeight(propValue)
+            KRTextProps.PROP_KEY_FONT_FAMILY -> setFontFamily(propValue)
             COLOR -> setColor(propValue)
             TINT_COLOR -> setTintColor(propValue)
             SELECTION_COLOR -> setSelectionColor(propValue)
@@ -485,6 +487,7 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
                 InputType.TYPE_CLASS_TEXT
             }
         }
+        applyFontFamily()
         return true
     }
 
@@ -615,6 +618,18 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
         val fontWeightSpan = FontWeightSpan(propValue as String)
         fontWeightSpan.updateDrawState(paint)
         return true
+    }
+
+    private fun setFontFamily(propValue: Any): Boolean {
+        fontFamily = propValue as String
+        applyFontFamily()
+        return true
+    }
+
+    private fun applyFontFamily() {
+        if (fontFamily.isNotEmpty()) {
+            typeface = kuiklyRenderContext?.getTypeFaceLoader()?.getTypeface(fontFamily, false)
+        }
     }
 
     private fun setFocus() {

--- a/core-render-ios/Extension/Category/KRConvertUtil.m
+++ b/core-render-ios/Extension/Category/KRConvertUtil.m
@@ -36,26 +36,7 @@ const NSString *lineargradientPrefix = @"linear-gradient(";
     NSString *fontFamily = json[@"fontFamily"];
     CGFloat fontSize = [self CGFloat:json[@"fontSize"]] ?: 15;
     KuiklyContextParam* contextParam = json[@"contextParam"];
-    
-    if (fontFamily && fontFamily.length) {
-        UIFont* font = [UIFont fontWithName:fontFamily size:fontSize];      // 判断字体是否已经在info.plist中注册
-        if (font) {
-            return font;
-        }
-        
-        // 未静态注册，则调用业务方hr_loadCustomFont
-        if (contextParam && [KRFontModule hr_loadCustomFont:fontFamily contextParams:contextParam]) {
-            UIFont* font = [UIFont fontWithName:fontFamily size:fontSize];      // 以上下文参数ContextParam作为路径来源，动态加载字体
-            if (font) {
-                return font;
-            }
-        } else {
-            // 动态加载字体失败，返回系统默认字体
-            return [UIFont systemFontOfSize:fontSize];
-        }
-    }
-    
-    // 执行默认字体加载，所覆盖的场景有：fontFamily为nil或者为空、ContextParam为nil、业务方字体加载失败
+
     static dispatch_once_t onceToken;
     static NSDictionary *gFontWeightMap = nil;
     dispatch_once(&onceToken, ^{
@@ -74,11 +55,13 @@ const NSString *lineargradientPrefix = @"linear-gradient(";
         };
     });
     UIFontWeight fontWeight = [(gFontWeightMap[json[@"fontWeight"]?:@""] ?: @(UIFontWeightRegular)) doubleValue];
+    BOOL italic = json[@"fontStyle"] && [@"italic" isEqualToString:json[@"fontStyle"]];
     
     if (fontFamily.length) {
         UIFont *font = nil;
+        font = [self genericUIFontWithFamily:fontFamily fontSize:fontSize fontWeight:fontWeight italic:italic];
         if ([[KuiklyRenderBridge componentExpandHandler] respondsToSelector:@selector(hr_fontWithFontFamily:fontSize:fontWeight:)]) {
-            font = [[KuiklyRenderBridge componentExpandHandler] hr_fontWithFontFamily:fontFamily fontSize:fontSize fontWeight:fontWeight];
+            font = [[KuiklyRenderBridge componentExpandHandler] hr_fontWithFontFamily:fontFamily fontSize:fontSize fontWeight:fontWeight] ?: font;
         }
         if (font == nil && [[KuiklyRenderBridge componentExpandHandler] respondsToSelector:@selector(hr_fontWithFontFamily:fontSize:)]) {
             font = [[KuiklyRenderBridge componentExpandHandler] hr_fontWithFontFamily:fontFamily fontSize:fontSize];
@@ -86,16 +69,73 @@ const NSString *lineargradientPrefix = @"linear-gradient(";
         if (font == nil) {
             font = [UIFont fontWithName:fontFamily size:fontSize];
         }
+        if (font == nil && contextParam && [KRFontModule hr_loadCustomFont:fontFamily contextParams:contextParam]) {
+            font = [UIFont fontWithName:fontFamily size:fontSize];
+        }
         if (font) {
-            return font;
+            return [self styledFontWithFont:font fontWeight:fontWeight italic:italic] ?: font;
         }
     }
     
-    if (json[@"fontStyle"] && [@"italic" isEqualToString:json[@"fontStyle"]]) {
+    if (italic) {
         return [self italicFontWithSize:fontSize bold:fontWeight >=UIFontWeightBold itatic:YES weight:fontWeight];
     }
     
     return [UIFont systemFontOfSize:fontSize weight:fontWeight];
+}
+
++ (UIFont *)genericUIFontWithFamily:(NSString *)fontFamily
+                           fontSize:(CGFloat)fontSize
+                         fontWeight:(UIFontWeight)fontWeight
+                             italic:(BOOL)italic {
+    NSString *family = [[fontFamily lowercaseString] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    BOOL bold = fontWeight >= UIFontWeightBold;
+    NSString *fontName = nil;
+    if ([family isEqualToString:@"sans-serif"]) {
+        return italic ? [self italicFontWithSize:fontSize bold:bold itatic:YES weight:fontWeight] : [UIFont systemFontOfSize:fontSize weight:fontWeight];
+    }
+    if ([family isEqualToString:@"serif"]) {
+        if (bold && italic) {
+            fontName = @"TimesNewRomanPS-BoldItalicMT";
+        } else if (bold) {
+            fontName = @"TimesNewRomanPS-BoldMT";
+        } else if (italic) {
+            fontName = @"TimesNewRomanPS-ItalicMT";
+        } else {
+            fontName = @"TimesNewRomanPSMT";
+        }
+    } else if ([family isEqualToString:@"monospace"]) {
+        if (bold && italic) {
+            fontName = @"CourierNewPS-BoldItalicMT";
+        } else if (bold) {
+            fontName = @"CourierNewPS-BoldMT";
+        } else if (italic) {
+            fontName = @"CourierNewPS-ItalicMT";
+        } else {
+            fontName = @"CourierNewPSMT";
+        }
+    } else if ([family isEqualToString:@"cursive"]) {
+        fontName = bold ? @"SnellRoundhand-Bold" : @"SnellRoundhand";
+    }
+    return fontName.length ? [UIFont fontWithName:fontName size:fontSize] : nil;
+}
+
++ (UIFont *)styledFontWithFont:(UIFont *)font
+                    fontWeight:(UIFontWeight)fontWeight
+                        italic:(BOOL)italic {
+    BOOL bold = fontWeight >= UIFontWeightBold;
+    if (!bold && !italic) {
+        return font;
+    }
+    UIFontDescriptorSymbolicTraits symbolicTraits = 0;
+    if (italic) {
+        symbolicTraits |= UIFontDescriptorTraitItalic;
+    }
+    if (bold) {
+        symbolicTraits |= UIFontDescriptorTraitBold;
+    }
+    UIFontDescriptor *descriptor = [[font fontDescriptor] fontDescriptorWithSymbolicTraits:symbolicTraits];
+    return descriptor ? [UIFont fontWithDescriptor:descriptor size:font.pointSize] : nil;
 }
 
 + (UIFont *)italicFontWithSize:(CGFloat)fontSize

--- a/core-render-ios/Extension/Components/KRTextAreaView.m
+++ b/core-render-ios/Extension/Components/KRTextAreaView.m
@@ -356,6 +356,9 @@ NSString *const KRFontFamilyKey = @"fontFamily";
 }
 
 - (void)css_setCursorIndexByPoint:(NSDictionary *)args {
+#if TARGET_OS_OSX
+    return;
+#else
     NSString *params = args[KRC_PARAM_KEY];
     NSArray<NSString *> *components = [params componentsSeparatedByString:@" "];
     if (components.count < 2) {
@@ -383,6 +386,7 @@ NSString *const KRFontFamilyKey = @"fontFamily";
             @"compositionEnd": @(-1)
         });
     }
+#endif
 }
 
 - (void)setCss_textInputState:(NSString *)css_textInputState {

--- a/core-render-ios/Extension/Components/KRTextAreaView.m
+++ b/core-render-ios/Extension/Components/KRTextAreaView.m
@@ -23,6 +23,7 @@
 // 字典key常量
 NSString *const KRFontSizeKey = @"fontSize";
 NSString *const KRFontWeightKey = @"fontWeight";
+NSString *const KRFontFamilyKey = @"fontFamily";
 
 /*
  * @brief 暴露给Kotlin侧调用的多行输入框组件
@@ -38,6 +39,8 @@ NSString *const KRFontWeightKey = @"fontWeight";
 @property (nonatomic, strong)  NSNumber *KUIKLY_PROP(fontSize);
 /** attr is fontWeight */
 @property (nonatomic, strong)  NSString *KUIKLY_PROP(fontWeight);
+/** attr is fontFamily */
+@property (nonatomic, strong)  NSString *KUIKLY_PROP(fontFamily);
 #if TARGET_OS_OSX
 /** clipPath for macOS - 使用 KUIKLY_PROP 命名规范，仅在 macOS 声明避免覆盖 iOS 上 UIView+CSS category */
 @property (nonatomic, copy) NSString *KUIKLY_PROP(clipPath);
@@ -284,12 +287,18 @@ NSString *const KRFontWeightKey = @"fontWeight";
 - (void)setCss_fontSize:(NSNumber *)css_fontSize {
     _css_fontSize = css_fontSize;
     self.font = [KRConvertUtil UIFont:@{KRFontSizeKey: css_fontSize ?: @(16),
-                                        KRFontWeightKey: _css_fontWeight ?: @"400"}];
+                                        KRFontWeightKey: _css_fontWeight ?: @"400",
+                                        KRFontFamilyKey: _css_fontFamily ?: @""}];
     [self setNeedsLayout];
 }
 
 - (void)setCss_fontWeight:(NSString *)css_fontWeight {
     _css_fontWeight = css_fontWeight;
+    [self setCss_fontSize:_css_fontSize];
+}
+
+- (void)setCss_fontFamily:(NSString *)css_fontFamily {
+    _css_fontFamily = css_fontFamily;
     [self setCss_fontSize:_css_fontSize];
 }
 

--- a/core-render-ios/Extension/Components/KRTextAreaView.m
+++ b/core-render-ios/Extension/Components/KRTextAreaView.m
@@ -98,6 +98,10 @@ NSString *const KRFontFamilyKey = @"fontFamily";
 - (BOOL)p_shouldReapplyTextPostProcessorForIncomingRawText:(NSString *)rawText;
 - (BOOL)p_containsShortcodeToken:(NSString *)rawText;
 - (BOOL)p_shouldRejectProgrammaticShortcodeInput:(NSString *)rawText;
+- (void)p_applyValuesAttributedText;
+- (void)p_refreshAttributedTextStyleIfNeeded;
+- (void)p_updateFont;
+- (void)p_updateTypingAttributes;
 
 @end
 
@@ -226,22 +230,7 @@ NSString *const KRFontFamilyKey = @"fontFamily";
 - (void)setCss_values:(NSString *)css_values {
     if (_css_values != css_values) {
         _css_values = css_values;
-        if (_css_values.length) {
-            KRRichTextShadow *textShadow = [KRRichTextShadow new];
-            [textShadow hrv_setPropWithKey:@"textPostProcessor" propValue:NSStringFromClass([self class])];
-            for (NSString *key in _props.allKeys) {
-                [textShadow hrv_setPropWithKey:key propValue:_props[key]];
-            }
-            // 调用buildAttributedString之前，都需要设置contextParam，预防字体测量的需求
-            [textShadow hrv_setPropWithKey:@"contextParam" propValue:self.hr_rootView.contextParam];
-            UITextPosition *newPosition = [self positionFromPosition:self.beginningOfDocument offset:self.selectedRange.location];
-
-            self.attributedText =  [textShadow buildAttributedString];;
-            self.selectedTextRange = [self textRangeFromPosition:newPosition toPosition:newPosition];
-
-        } else {
-            self.attributedText = nil;
-        }
+        [self p_applyValuesAttributedText];
         [self p_updatePlaceholder];
         [self textViewDidChange:self];
     }
@@ -274,6 +263,8 @@ NSString *const KRFontFamilyKey = @"fontFamily";
 
 - (void)setCss_color:(NSNumber *)css_color {
     self.textColor = [UIView css_color:css_color];
+    [self p_updateTypingAttributes];
+    [self p_refreshAttributedTextStyleIfNeeded];
 }
 
 - (void)setCss_editable:(NSNumber *)css_editable {
@@ -286,9 +277,8 @@ NSString *const KRFontFamilyKey = @"fontFamily";
 
 - (void)setCss_fontSize:(NSNumber *)css_fontSize {
     _css_fontSize = css_fontSize;
-    self.font = [KRConvertUtil UIFont:@{KRFontSizeKey: css_fontSize ?: @(16),
-                                        KRFontWeightKey: _css_fontWeight ?: @"400",
-                                        KRFontFamilyKey: _css_fontFamily ?: @""}];
+    [self p_updateFont];
+    [self p_refreshAttributedTextStyleIfNeeded];
     [self setNeedsLayout];
 }
 
@@ -363,6 +353,36 @@ NSString *const KRFontFamilyKey = @"fontFamily";
 - (void)css_setCursorIndex:(NSDictionary *)args {
     NSUInteger index = [args[KRC_PARAM_KEY] intValue];
     [self updateCursorIndex:index];
+}
+
+- (void)css_setCursorIndexByPoint:(NSDictionary *)args {
+    NSString *params = args[KRC_PARAM_KEY];
+    NSArray<NSString *> *components = [params componentsSeparatedByString:@" "];
+    if (components.count < 2) {
+        return;
+    }
+    CGPoint point = CGPointMake([components[0] doubleValue], [components[1] doubleValue]);
+    if (![self isFirstResponder]) {
+        [self becomeFirstResponder];
+    }
+    UITextPosition *position = [self closestPositionToPoint:point];
+    if (!position) {
+        return;
+    }
+    _ignoreTextDidChanged = YES;
+    self.selectedTextRange = [self textRangeFromPosition:position toPosition:position];
+    _ignoreTextDidChanged = NO;
+    if (self.css_selectionChange) {
+        NSString *rawText = [self p_outputText];
+        NSRange outputSelectionRange = [self p_getOutputSelectionRange];
+        self.css_selectionChange(@{
+            @"text": rawText ?: @"",
+            @"selectionStart": @(outputSelectionRange.location),
+            @"selectionEnd": @(NSMaxRange(outputSelectionRange)),
+            @"compositionStart": @(-1),
+            @"compositionEnd": @(-1)
+        });
+    }
 }
 
 - (void)setCss_textInputState:(NSString *)css_textInputState {
@@ -1032,6 +1052,78 @@ NSString *const KRFontFamilyKey = @"fontFamily";
     _placeholderTextView.hidden = self.text.length > 0 || self.attributedText.length > 0;
     if (self.markedTextRange) { // 输入中
         _placeholderTextView.hidden = YES;
+    }
+}
+
+- (NSMutableDictionary *)p_fontProps {
+    NSMutableDictionary *fontProps = [@{KRFontSizeKey: _css_fontSize ?: @(16),
+                                        KRFontWeightKey: _css_fontWeight ?: @"400",
+                                        KRFontFamilyKey: _css_fontFamily ?: @""} mutableCopy];
+    id contextParam = self.hr_rootView.contextParam;
+    if (contextParam) {
+        fontProps[@"contextParam"] = contextParam;
+    }
+    return fontProps;
+}
+
+- (void)p_updateTypingAttributes {
+    NSMutableDictionary *typingAttrs = [self.typingAttributes mutableCopy] ?: [NSMutableDictionary dictionary];
+    if (self.font) {
+        typingAttrs[NSFontAttributeName] = self.font;
+    }
+    if (self.textColor) {
+        typingAttrs[NSForegroundColorAttributeName] = self.textColor;
+    }
+    self.typingAttributes = typingAttrs;
+}
+
+- (void)p_updateFont {
+    self.font = [KRConvertUtil UIFont:[self p_fontProps]];
+    [self p_updateTypingAttributes];
+}
+
+- (void)p_refreshAttributedTextStyleIfNeeded {
+    if (_css_values.length) {
+        [self p_applyValuesAttributedText];
+        return;
+    }
+    if (!self.attributedText.length) {
+        return;
+    }
+    NSMutableAttributedString *attrString = [self.attributedText mutableCopy];
+    NSRange fullRange = NSMakeRange(0, attrString.length);
+    if (self.font) {
+        [attrString addAttribute:NSFontAttributeName value:self.font range:fullRange];
+    }
+    if (self.textColor) {
+        [attrString addAttribute:NSForegroundColorAttributeName value:self.textColor range:fullRange];
+    }
+    NSRange selectedRange = self.selectedRange;
+    _ignoreTextDidChanged = YES;
+    self.attributedText = attrString;
+    if (selectedRange.location <= attrString.length) {
+        selectedRange.length = MIN(selectedRange.length, attrString.length - selectedRange.location);
+        self.selectedRange = selectedRange;
+    }
+    _ignoreTextDidChanged = NO;
+}
+
+- (void)p_applyValuesAttributedText {
+    if (_css_values.length) {
+        KRRichTextShadow *textShadow = [KRRichTextShadow new];
+        [textShadow hrv_setPropWithKey:@"textPostProcessor" propValue:NSStringFromClass([self class])];
+        for (NSString *key in _props.allKeys) {
+            [textShadow hrv_setPropWithKey:key propValue:_props[key]];
+        }
+        id contextParam = self.hr_rootView.contextParam;
+        if (contextParam) {
+            [textShadow hrv_setPropWithKey:@"contextParam" propValue:contextParam];
+        }
+        UITextPosition *newPosition = [self positionFromPosition:self.beginningOfDocument offset:self.selectedRange.location];
+        self.attributedText = [textShadow buildAttributedString];
+        self.selectedTextRange = [self textRangeFromPosition:newPosition toPosition:newPosition];
+    } else {
+        self.attributedText = nil;
     }
 }
 

--- a/core-render-ios/Extension/Components/KRTextFieldView.m
+++ b/core-render-ios/Extension/Components/KRTextFieldView.m
@@ -304,6 +304,9 @@ NSString *const KRVFontFamilyKey = @"fontFamily";
 }
 
 - (void)css_setCursorIndexByPoint:(NSDictionary *)args {
+#if TARGET_OS_OSX
+    return;
+#else
     NSString *params = args[KRC_PARAM_KEY];
     NSArray<NSString *> *components = [params componentsSeparatedByString:@" "];
     if (components.count < 2) {
@@ -323,6 +326,7 @@ NSString *const KRVFontFamilyKey = @"fontFamily";
     if (self.css_selectionChange) {
         self.css_selectionChange([self p_currentTextInputStatePayload]);
     }
+#endif
 }
 
 - (void)css_setTextInputState:(NSDictionary *)args {

--- a/core-render-ios/Extension/Components/KRTextFieldView.m
+++ b/core-render-ios/Extension/Components/KRTextFieldView.m
@@ -21,6 +21,7 @@
 // 字典key常量
 NSString *const KRVFontSizeKey = @"fontSize";
 NSString *const KRVFontWeightKey = @"fontWeight";
+NSString *const KRVFontFamilyKey = @"fontFamily";
 
 /*
  * @brief 暴露给Kotlin侧调用的多行输入框组件
@@ -34,6 +35,8 @@ NSString *const KRVFontWeightKey = @"fontWeight";
 @property (nonatomic, strong)  NSNumber *KUIKLY_PROP(fontSize);
 /** attr is fontWeight */
 @property (nonatomic, strong)  NSString *KUIKLY_PROP(fontWeight);
+/** attr is fontFamily */
+@property (nonatomic, strong)  NSString *KUIKLY_PROP(fontFamily);
 /** attr is placeholder */
 @property (nonatomic, strong)  NSString *KUIKLY_PROP(placeholder);
 /** attr is textAign */
@@ -228,12 +231,19 @@ NSString *const KRVFontWeightKey = @"fontWeight";
 - (void)setCss_fontSize:(NSNumber *)css_fontSize {
     _css_fontSize = css_fontSize;
     self.font = [KRConvertUtil UIFont:@{KRVFontSizeKey: css_fontSize ?: @(16),
-                                        KRVFontWeightKey: _css_fontWeight ?: @"400"}];
+                                        KRVFontWeightKey: _css_fontWeight ?: @"400",
+                                        KRVFontFamilyKey: _css_fontFamily ?: @""}];
 }
 
 - (void)setCss_fontWeight:(NSString *)css_fontWeight {
     _css_fontWeight = css_fontWeight;
     [self setCss_fontSize:_css_fontSize];
+}
+
+- (void)setCss_fontFamily:(NSString *)css_fontFamily {
+    _css_fontFamily = css_fontFamily;
+    [self setCss_fontSize:_css_fontSize];
+    [self p_setNeedUpdatePlaceholder];
 }
 
 - (void)setCss_placeholder:(NSString *)css_placeholder {

--- a/core-render-ios/Extension/Components/KRTextFieldView.m
+++ b/core-render-ios/Extension/Components/KRTextFieldView.m
@@ -82,6 +82,9 @@ NSString *const KRVFontFamilyKey = @"fontFamily";
 
 - (BOOL)p_containsShortcodeToken:(NSString *)rawText;
 - (BOOL)p_shouldRejectProgrammaticShortcodeInput:(NSString *)rawText;
+- (void)p_applyValuesAttributedText;
+- (void)p_refreshAttributedTextIfNeeded;
+- (void)p_updateFont;
 
 @end
 
@@ -163,36 +166,14 @@ NSString *const KRVFontFamilyKey = @"fontFamily";
 - (void)setCss_values:(NSString *)css_values {
     if (_css_values != css_values) {
         _css_values = css_values;
-        if (_css_values.length) {
-            KRRichTextShadow *textShadow = [KRRichTextShadow new];
-            for (NSString *key in _props.allKeys) {
-                [textShadow hrv_setPropWithKey:key propValue:_props[key]];
-            }
-            [textShadow hrv_setPropWithKey:@"contextParam" propValue:self.hr_rootView.contextParam];
-            // 保存原光标位置
-            UITextRange *originalSelectedTextRange = self.selectedTextRange;
-            // 设置新的 attributedText
-            NSAttributedString *resAttr = [textShadow buildAttributedString];
-            // NOTE: UITextField does not render NSTextAttachment images (only UITextView does).
-            // Therefore textPostProcessor with emoji/image attachment rendering is NOT supported
-            // in single-line mode (KRTextFieldView). Use KRTextAreaView for custom emoji support.
-            // The textPostProcessor call here is kept for any non-image text transformations
-            // (e.g., text masking, formatting) that do not rely on NSTextAttachment rendering.
-            if ([[KuiklyRenderBridge componentExpandHandler] respondsToSelector:@selector(hr_customTextWithAttributedString:textPostProcessor:)]) {
-                resAttr = [[KuiklyRenderBridge componentExpandHandler] hr_customTextWithAttributedString:resAttr textPostProcessor:NSStringFromClass([self class])];
-            }
-            self.attributedText = resAttr;
-            // 恢复原光标位置
-            self.selectedTextRange = originalSelectedTextRange;
-        } else {
-            self.attributedText = nil;
-        }
+        [self p_applyValuesAttributedText];
         [self onTextFeildTextChanged:self];
     }
 }
 
 - (void)setCss_color:(NSNumber *)css_color {
     self.textColor = [UIView css_color:css_color];
+    [self p_refreshAttributedTextIfNeeded];
 }
 
 - (void)setCss_tintColor:(NSNumber *)css_tintColor {
@@ -230,9 +211,8 @@ NSString *const KRVFontFamilyKey = @"fontFamily";
 
 - (void)setCss_fontSize:(NSNumber *)css_fontSize {
     _css_fontSize = css_fontSize;
-    self.font = [KRConvertUtil UIFont:@{KRVFontSizeKey: css_fontSize ?: @(16),
-                                        KRVFontWeightKey: _css_fontWeight ?: @"400",
-                                        KRVFontFamilyKey: _css_fontFamily ?: @""}];
+    [self p_updateFont];
+    [self p_refreshAttributedTextIfNeeded];
 }
 
 - (void)setCss_fontWeight:(NSString *)css_fontWeight {
@@ -321,6 +301,28 @@ NSString *const KRVFontFamilyKey = @"fontFamily";
     _ignoreSelectionChange = YES;
     self.selectedTextRange = [self textRangeFromPosition:newPosition toPosition:newPosition];
     _ignoreSelectionChange = NO;
+}
+
+- (void)css_setCursorIndexByPoint:(NSDictionary *)args {
+    NSString *params = args[KRC_PARAM_KEY];
+    NSArray<NSString *> *components = [params componentsSeparatedByString:@" "];
+    if (components.count < 2) {
+        return;
+    }
+    CGPoint point = CGPointMake([components[0] doubleValue], [components[1] doubleValue]);
+    if (![self isFirstResponder]) {
+        [self becomeFirstResponder];
+    }
+    UITextPosition *position = [self closestPositionToPoint:point];
+    if (!position) {
+        return;
+    }
+    _ignoreSelectionChange = YES;
+    self.selectedTextRange = [self textRangeFromPosition:position toPosition:position];
+    _ignoreSelectionChange = NO;
+    if (self.css_selectionChange) {
+        self.css_selectionChange([self p_currentTextInputStatePayload]);
+    }
 }
 
 - (void)css_setTextInputState:(NSDictionary *)args {
@@ -600,6 +602,50 @@ NSString *const KRVFontFamilyKey = @"fontFamily";
 - (void)p_setNeedUpdatePlaceholder {
     _setNeedUpdatePlaceholder = YES;
     [self setNeedsLayout];
+}
+
+- (NSMutableDictionary *)p_fontProps {
+    NSMutableDictionary *fontProps = [@{KRVFontSizeKey: _css_fontSize ?: @(16),
+                                        KRVFontWeightKey: _css_fontWeight ?: @"400",
+                                        KRVFontFamilyKey: _css_fontFamily ?: @""} mutableCopy];
+    id contextParam = self.hr_rootView.contextParam;
+    if (contextParam) {
+        fontProps[@"contextParam"] = contextParam;
+    }
+    return fontProps;
+}
+
+- (void)p_updateFont {
+    self.font = [KRConvertUtil UIFont:[self p_fontProps]];
+}
+
+- (void)p_refreshAttributedTextIfNeeded {
+    if (_css_values.length) {
+        [self p_applyValuesAttributedText];
+    }
+}
+
+- (void)p_applyValuesAttributedText {
+    if (_css_values.length) {
+        KRRichTextShadow *textShadow = [KRRichTextShadow new];
+        for (NSString *key in _props.allKeys) {
+            [textShadow hrv_setPropWithKey:key propValue:_props[key]];
+        }
+        id contextParam = self.hr_rootView.contextParam;
+        if (contextParam) {
+            [textShadow hrv_setPropWithKey:@"contextParam" propValue:contextParam];
+        }
+        UITextRange *originalSelectedTextRange = self.selectedTextRange;
+        NSAttributedString *resAttr = [textShadow buildAttributedString];
+        // UITextField does not render NSTextAttachment images. Use KRTextAreaView for custom emoji.
+        if ([[KuiklyRenderBridge componentExpandHandler] respondsToSelector:@selector(hr_customTextWithAttributedString:textPostProcessor:)]) {
+            resAttr = [[KuiklyRenderBridge componentExpandHandler] hr_customTextWithAttributedString:resAttr textPostProcessor:NSStringFromClass([self class])];
+        }
+        self.attributedText = resAttr;
+        self.selectedTextRange = originalSelectedTextRange;
+    } else {
+        self.attributedText = nil;
+    }
 }
 
 - (NSDictionary *)p_currentTextInputStatePayload {
@@ -924,5 +970,3 @@ NSString *const KRVFontFamilyKey = @"fontFamily";
 }
 
 @end
-
-

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextAreaView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextAreaView.cpp
@@ -97,7 +97,8 @@ std::pair<uint32_t, uint32_t> KRTextAreaView::GetInputNodeTextSelectionRange() {
     }
     return {0, 0};
 }
-void KRTextAreaView::UpdateInputNodePlaceholderFont(uint32_t font_size, ArkUI_FontWeight font_weight) {
+void KRTextAreaView::UpdateInputNodePlaceholderFont(uint32_t font_size, ArkUI_FontWeight font_weight,
+                                                    const std::string &font_family) {
     ArkUI_NumberValue fontWeight = {.i32 = font_weight};
     ArkUI_NumberValue tempStyle = {.i32 = ARKUI_FONT_STYLE_NORMAL};
     const auto &rootView = GetRootView().lock();
@@ -115,7 +116,9 @@ void KRTextAreaView::UpdateInputNodePlaceholderFont(uint32_t font_size, ArkUI_Fo
         font_size_temp = font_size_px;
     }
     std::array<ArkUI_NumberValue, 3> value = {{{.f32 = font_size_temp}, tempStyle, fontWeight}};
-    ArkUI_AttributeItem item = {value.data(), value.size()};
+    ArkUI_AttributeItem item = {
+        value.data(), static_cast<int32_t>(value.size()),
+        font_family.empty() ? nullptr : font_family.c_str(), nullptr};
     kuikly::util::GetNodeApi()->setAttribute(node, NODE_TEXT_AREA_PLACEHOLDER_FONT, &item);
     if (!fontSizeScaleFollowSystem) {
         kuikly::util::GetNodeApi()->setLengthMetricUnit(node, ARKUI_LENGTH_METRIC_UNIT_DEFAULT);

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextAreaView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextAreaView.h
@@ -60,7 +60,8 @@ class KRTextAreaView : public KRTextFieldView {
     uint32_t GetInputNodeSelectionStartPosition() override;
     void UpdateInputNodeSelectionStartPosition(uint32_t index) override;
     std::pair<uint32_t, uint32_t> GetInputNodeTextSelectionRange() override;
-    void UpdateInputNodePlaceholderFont(uint32_t font_size, ArkUI_FontWeight font_weight) override;
+    void UpdateInputNodePlaceholderFont(uint32_t font_size, ArkUI_FontWeight font_weight,
+                                        const std::string &font_family) override;
     void UpdateInputNodeContentText(const std::string &text) override;
 
 };

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextEditorAreaView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextEditorAreaView.cpp
@@ -198,6 +198,14 @@ bool KRTextEditorAreaView::HandleValuesModeStyleProp(const std::string &prop_key
         kuikly::text_editor::ApplyPlaceholder(node, state_);
         return true;
     }
+    if (kuikly::util::isEqual(prop_key, kuikly::text_editor::kFontFamily)) {
+        state_.font_family_ = prop_value->toString();
+        UpdateFontFamilyNode(state_.font_family_);
+        kuikly::text_editor::ApplyTypingStyle(state_);
+        kuikly::text_editor::ApplyPlaceholder(node, state_);
+        RewriteValuesStyledStringFromCache();
+        return true;
+    }
     if (kuikly::util::isEqual(prop_key, kuikly::text_editor::kColor)) {
         state_.font_color_ = kuikly::util::ConvertToHexColor(prop_value->toString());
         return true;

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextEditorCommon.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextEditorCommon.h
@@ -263,6 +263,7 @@ static constexpr const char *kPlaceholder = "placeholder";
 static constexpr const char *kPlaceholderColor = "placeholderColor";
 static constexpr const char *kFontSize = "fontSize";
 static constexpr const char *kFontWeight = "fontWeight";
+static constexpr const char *kFontFamily = "fontFamily";
 static constexpr const char *kColor = "color";
 static constexpr const char *kEditable = "editable";
 static constexpr const char *kTintColor = "tintColor";
@@ -315,6 +316,7 @@ static constexpr int32_t kNoComposition = -1;
 struct KRTextEditorState {
     float font_size_ = 15;  // fp，默认与老实现一致
     ArkUI_FontWeight font_weight_ = ARKUI_FONT_WEIGHT_NORMAL;
+    std::string font_family_;
     uint32_t font_color_ = 0xFF000000;  // 默认黑色（老实现未显式设，这里落一个稳定默认）
     ArkUI_TextAlignment text_align_ = ARKUI_TEXT_ALIGNMENT_START;
     std::string placeholder_text_;

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextEditorFieldView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextEditorFieldView.cpp
@@ -15,6 +15,7 @@
 
 #include "libohos_render/expand/components/input/KRTextEditorFieldView.h"
 
+#include "libohos_render/expand/components/richtext/KRRichTextShadow.h"
 #include "libohos_render/manager/KRKeyboardManager.h"
 #include "libohos_render/utils/KRConvertUtil.h"
 #include "libohos_render/utils/KRStringUtil.h"
@@ -209,6 +210,10 @@ bool KRTextEditorFieldView::SetProp(const std::string &prop_key, const KRAnyValu
         state_.font_weight_ = kuikly::util::ConvertArkUIFontWeight(prop_value->toInt(), scale);
         ApplyTypingStyle(state_);
         ApplyPlaceholder(node, state_);
+        return true;
+    }
+    if (kuikly::util::isEqual(prop_key, kFontFamily)) {
+        ApplyFontFamily(prop_value->toString());
         return true;
     }
     if (kuikly::util::isEqual(prop_key, kColor)) {
@@ -1064,6 +1069,34 @@ void KRTextEditorFieldView::ApplyReturnKeyType(const std::string &type) {
     ArkUI_EnterKeyType ek = kuikly::util::ConvertToEnterKeyType(type);
     state_.enter_key_type_ = ek;
     kuikly::text_editor::UpdateEnterKeyType(GetNode(), ek);
+}
+
+void KRTextEditorFieldView::ApplyFontFamily(const std::string &font_family) {
+    state_.font_family_ = font_family;
+    UpdateFontFamilyNode(font_family);
+    kuikly::text_editor::ApplyTypingStyle(state_);
+    kuikly::text_editor::ApplyPlaceholder(GetNode(), state_);
+    if (!state_.cached_text_.empty()) {
+        kuikly::text_editor::SetStyledText(state_, state_.cached_text_);
+    }
+}
+
+void KRTextEditorFieldView::UpdateFontFamilyNode(const std::string &font_family) {
+    auto node = GetNode();
+    if (!node) {
+        return;
+    }
+    if (font_family.empty()) {
+        kuikly::util::GetNodeApi()->resetAttribute(node, NODE_FONT_FAMILY);
+    } else {
+        if (auto root = GetRootView().lock()) {
+            KRFontCollectionWrapper::GetInstance().RegisterCustomFont(
+                root->GetNativeResourceManager(), font_family);
+        }
+        ArkUI_AttributeItem item = {};
+        item.string = font_family.c_str();
+        kuikly::util::GetNodeApi()->setAttribute(node, NODE_FONT_FAMILY, &item);
+    }
 }
 
 #endif  // KUIKLY_TEXT_EDITOR_AVAILABLE

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextEditorFieldView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextEditorFieldView.h
@@ -115,6 +115,10 @@ class KRTextEditorFieldView : public IKRRenderViewExport {
 
     // returnKeyType 映射
     void ApplyReturnKeyType(const std::string &type);
+
+    // Keep rendered editor text aligned with shadow measurement when fontFamily changes.
+    void ApplyFontFamily(const std::string &font_family);
+    void UpdateFontFamilyNode(const std::string &font_family);
 };
 
 #endif  // KUIKLY_TEXT_EDITOR_AVAILABLE

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextFieldView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextFieldView.cpp
@@ -15,6 +15,7 @@
 
 #include "libohos_render/expand/components/input/KRTextFieldView.h"
 
+#include "libohos_render/expand/components/richtext/KRRichTextShadow.h"
 #include "libohos_render/manager/KRKeyboardManager.h"
 #include <algorithm>
 #include <arkui/drag_and_drop.h>
@@ -37,6 +38,7 @@ constexpr char *kPlaceholder = "placeholder";
 constexpr char *kPlaceholderColor = "placeholderColor";
 constexpr char *kFontSize = "fontSize";
 constexpr char *kFontWeight = "fontWeight";
+constexpr char *kFontFamily = "fontFamily";
 constexpr char *kColor = "color";
 constexpr char *kEditable = "editable";
 constexpr char *kTintColor = "tintColor";
@@ -83,7 +85,7 @@ void KRTextFieldView::DidInit() {
     kuikly::util::UpdateNodeBackgroundColor(GetNode(), 0);                          // 默认背景色为透明
     kuikly::util::UpdateNodeBorderRadius(GetNode(), KRBorderRadiuses(0, 0, 0, 0));  // 系统默认有圆角，此处应默认无圆角
     kuikly::util::SetArkUIPadding(GetNode(), 0, 0, 0, 0);                           // 系统默认有padding，此处应默认无padding
-    SetFont(font_size_, font_weight_);
+    SetFont(font_size_, font_weight_, font_family_);
     RegisterEvent(GetOnChangeEventType());
     
     // 默认软键盘不关闭
@@ -148,7 +150,8 @@ void KRTextFieldView::UpdateInputNodeSelectionStartPosition(uint32_t index){
     kuikly::util::UpdateInputNodeSelectionStartPosition(GetNode(), index);
 }
 
-void KRTextFieldView::UpdateInputNodePlaceholderFont(uint32_t font_size, ArkUI_FontWeight font_weight){
+void KRTextFieldView::UpdateInputNodePlaceholderFont(uint32_t font_size, ArkUI_FontWeight font_weight,
+                                                     const std::string &font_family){
     const auto &rootView = GetRootView().lock();
     bool fontSizeScaleFollowSystem = true;
     float font_size_px = 0;
@@ -156,7 +159,8 @@ void KRTextFieldView::UpdateInputNodePlaceholderFont(uint32_t font_size, ArkUI_F
         fontSizeScaleFollowSystem = rootView->GetContext()->Config()->GetFontSizeScaleFollowSystem();
         font_size_px = rootView->GetContext()->Config()->fp2px(font_size);
     }
-    kuikly::util::UpdateInputNodePlaceholderFont(GetNode(), font_size, font_weight, fontSizeScaleFollowSystem, font_size_px);
+    kuikly::util::UpdateInputNodePlaceholderFont(
+        GetNode(), font_size, font_weight, fontSizeScaleFollowSystem, font_size_px, font_family);
 }
 
 void KRTextFieldView::UpdateInputNodeContentText(const std::string &text){
@@ -181,7 +185,7 @@ bool KRTextFieldView::SetProp(const std::string &prop_key, const KRAnyValue &pro
     }
     if (kuikly::util::isEqual(prop_key, kFontSize)) {  // 字体大小
         font_size_ = prop_value->toFloat();
-        SetFont(font_size_, font_weight_);
+        SetFont(font_size_, font_weight_, font_family_);
         return true;
     }
     if (kuikly::util::isEqual(prop_key, kFontWeight)) {  // 字重
@@ -190,7 +194,12 @@ bool KRTextFieldView::SetProp(const std::string &prop_key, const KRAnyValue &pro
             scale = root->GetContext()->Config()->GetFontWeightScale();
         }
         font_weight_ = kuikly::util::ConvertArkUIFontWeight(prop_value->toInt(), scale);
-        SetFont(font_size_, font_weight_);
+        SetFont(font_size_, font_weight_, font_family_);
+        return true;
+    }
+    if (kuikly::util::isEqual(prop_key, kFontFamily)) {
+        font_family_ = prop_value->toString();
+        SetFont(font_size_, font_weight_, font_family_);
         return true;
     }
     if (kuikly::util::isEqual(prop_key, kColor)) {  // 字体颜色
@@ -568,8 +577,28 @@ void KRTextFieldView::OnTextSelectionChange(ArkUI_NodeEvent *event) {
  * @param font_size
  * @param font_weight
  */
-void KRTextFieldView::SetFont(uint32_t font_size, ArkUI_FontWeight font_weight) {
-    UpdateInputNodePlaceholderFont(font_size, font_weight);
+void KRTextFieldView::SetFont(uint32_t font_size, ArkUI_FontWeight font_weight,
+                              const std::string &font_family) {
+    UpdateInputNodeFontFamily(font_family);
+    UpdateInputNodePlaceholderFont(font_size, font_weight, font_family);
+}
+
+void KRTextFieldView::UpdateInputNodeFontFamily(const std::string &font_family) {
+    auto node = GetNode();
+    if (!node) {
+        return;
+    }
+    if (font_family.empty()) {
+        kuikly::util::GetNodeApi()->resetAttribute(node, NODE_FONT_FAMILY);
+        return;
+    }
+    if (auto root = GetRootView().lock()) {
+        KRFontCollectionWrapper::GetInstance().RegisterCustomFont(
+            root->GetNativeResourceManager(), font_family);
+    }
+    ArkUI_AttributeItem item = {};
+    item.string = font_family.c_str();
+    kuikly::util::GetNodeApi()->setAttribute(node, NODE_FONT_FAMILY, &item);
 }
 
 /******* 事件回调 ******/

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextFieldView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextFieldView.h
@@ -19,6 +19,7 @@
 #include "libohos_render/export/IKRRenderViewExport.h"
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <utility>
 
 class KRTextFieldView : public IKRRenderViewExport {
@@ -88,13 +89,15 @@ class KRTextFieldView : public IKRRenderViewExport {
      * 子类（如 KRTextAreaView）可 override 以适配不同的 ArkUI 节点类型。
      */
     virtual std::pair<uint32_t, uint32_t> GetInputNodeTextSelectionRange();
-    virtual void UpdateInputNodePlaceholderFont(uint32_t font_size, ArkUI_FontWeight font_weight);
+    virtual void UpdateInputNodePlaceholderFont(uint32_t font_size, ArkUI_FontWeight font_weight,
+                                                const std::string &font_family);
     virtual void UpdateInputNodeContentText(const std::string &text);
     virtual std::string GetInputNodeContentText();
 
  private:
     float font_size_ = 15;  // default 15
     ArkUI_FontWeight font_weight_ = ARKUI_FONT_WEIGHT_NORMAL;
+    std::string font_family_;
     bool focusable_ = true;
     int32_t max_length_ = -1;
     int length_limit_type_ = -1;  // -1: unset, 0: BYTE, 1: CHARACTER, 2: VISUAL_WIDTH
@@ -184,7 +187,8 @@ class KRTextFieldView : public IKRRenderViewExport {
      * @param font_size
      * @param font_weight
      */
-    void SetFont(uint32_t font_size, ArkUI_FontWeight font_weight);
+    void SetFont(uint32_t font_size, ArkUI_FontWeight font_weight, const std::string &font_family);
+    void UpdateInputNodeFontFamily(const std::string &font_family);
 
     /**
      * 文本变化回调

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.cpp
@@ -1017,12 +1017,17 @@ void UpdateInputNodeTextAlign(ArkUI_NodeHandle node, const std::string &text_ali
     GetNodeApi()->setAttribute(node, NODE_TEXT_ALIGN, &item);
 }
 
-void UpdateInputNodePlaceholderFont(ArkUI_NodeHandle node, uint32_t font_size, ArkUI_FontWeight font_weight, bool fontSizeScaleFollowSystem, float font_size_px) {
+void UpdateInputNodePlaceholderFont(ArkUI_NodeHandle node, uint32_t font_size, ArkUI_FontWeight font_weight,
+                                    bool fontSizeScaleFollowSystem, float font_size_px,
+                                    const std::string &font_family) {
     ArkUI_NumberValue fontWeight = {.i32 = font_weight};
     ArkUI_NumberValue tempStyle = {.i32 = ARKUI_FONT_STYLE_NORMAL};
     std::array<ArkUI_NumberValue, 3> value = {{{.f32 = static_cast<float>(font_size)}, tempStyle, fontWeight}};
-    ArkUI_AttributeItem item = {value.data(), value.size()};
-    GetNodeApi()->setAttribute(node, NODE_TEXT_INPUT_PLACEHOLDER_FONT, &item);
+    ArkUI_AttributeItem placeholderItem = {
+        value.data(), static_cast<int32_t>(value.size()),
+        font_family.empty() ? nullptr : font_family.c_str(), nullptr};
+    GetNodeApi()->setAttribute(node, NODE_TEXT_INPUT_PLACEHOLDER_FONT, &placeholderItem);
+    ArkUI_AttributeItem item = {value.data(), static_cast<int32_t>(value.size())};
     GetNodeApi()->setAttribute(node, NODE_FONT_SIZE, &item);
     {
         // 如果禁用输入框内字体缩放需要设置为px

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.h
@@ -27,6 +27,7 @@
 #include <native_drawing/drawing_text_declaration.h>
 #include <native_drawing/drawing_text_typography.h>
 #include <sys/stat.h>
+#include <string>
 #include <unordered_set>
 #include <vector>
 #include "libohos_render/expand/components/base/KRBasePropsHandler.h"
@@ -240,7 +241,9 @@ void UpdateTextAreaNodeSelectionColor(ArkUI_NodeHandle node, uint32_t color);
 // 文本对齐
 void UpdateInputNodeTextAlign(ArkUI_NodeHandle node, const std::string &text_align);
 
-void UpdateInputNodePlaceholderFont(ArkUI_NodeHandle node, uint32_t font_size, ArkUI_FontWeight font_weight, bool fontSizeScaleFollowSystem, float font_size_px);
+void UpdateInputNodePlaceholderFont(ArkUI_NodeHandle node, uint32_t font_size, ArkUI_FontWeight font_weight,
+                                    bool fontSizeScaleFollowSystem, float font_size_px,
+                                    const std::string &font_family = "");
 
 void UpdateInputNodeColor(ArkUI_NodeHandle node, uint32_t color);
 

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/AutoHeightTextAreaView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/AutoHeightTextAreaView.kt
@@ -127,6 +127,12 @@ class AutoHeightTextAreaView(val singleLine: Boolean = false) :
         }
     }
 
+    fun setCursorIndexByPoint(x: Float, y: Float) {
+        performTaskWhenRenderViewDidLoad {
+            renderView?.callMethod("setCursorIndexByPoint", "$x $y")
+        }
+    }
+
     /**
      * Atomically set raw text, selection, and composition state.
      */

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextAreaView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextAreaView.kt
@@ -332,6 +332,11 @@ open class TextAreaAttr : Attr() {
         return this
     }
 
+    fun fontFamily(fontFamily: String): TextAreaAttr {
+        TextConst.FONT_FAMILY with fontFamily
+        return this
+    }
+
     fun lines(lines: Int): TextAreaAttr {
         TextConst.LINES with lines
         return this

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/ComposeAllSample.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/ComposeAllSample.kt
@@ -108,7 +108,7 @@ internal class ComposeAllSample : ComposeContainer() {
             DemoItem("HorizontalPager", "HorizontalPager基本用法示例", "HorizontalPagerDemo1"),
             DemoItem("LazyHorizontalGrid", "LazyHorizontalGrid基本用法示例", "LazyHorizontalGridDemo1"),
             DemoItem("焦点处理", "Focus焦点处理示例", "focusDemo"),
-            DemoItem("TextField", "TextField 组件示例", "TextFieldDemo"),
+            DemoItem("TextField", "TextField 组件示例，含已输入文本字体样式对比", "TextFieldDemo"),
             DemoItem("PullToRefresh", "PullToRefresh 组件示例", "PullToRefreshDemo"),
             // 其他
             DemoItem("封装KuiklyView", "封装Kuikly的VideoView为一个Composeable组件示例", "ComposeVideoDemo"),

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/TextFieldDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/TextFieldDemo.kt
@@ -65,6 +65,8 @@ import com.tencent.kuikly.compose.ui.layout.ContentScale
 import com.tencent.kuikly.compose.ui.platform.LocalFocusManager
 import com.tencent.kuikly.compose.ui.platform.LocalSoftwareKeyboardController
 import com.tencent.kuikly.compose.ui.text.TextStyle
+import com.tencent.kuikly.compose.ui.text.font.FontFamily
+import com.tencent.kuikly.compose.ui.text.font.FontWeight
 import com.tencent.kuikly.compose.ui.text.input.ImeAction
 import com.tencent.kuikly.compose.ui.text.input.KeyboardType
 import com.tencent.kuikly.compose.ui.unit.dp
@@ -148,7 +150,51 @@ class TextFieldDemo : ComposeContainer() {
                     }
 
                     Spacer(modifier = Modifier.height(16.dp))
-                    Text(text = "1 BasicTextField Box居中 红色游标")
+                    Text(text = "1 BasicTextField 已输入文本 fontFamily/style 对比")
+                    var defaultValueText by remember { mutableStateOf("Default input value") }
+                    Text(text = "默认输入框：")
+                    Box(
+                        modifier = Modifier.fillMaxWidth().height(50.dp)
+                            .border(1.dp, color = Color.Black)
+                            .padding(horizontal = 12.dp),
+                        contentAlignment = Alignment.CenterStart,
+                    ) {
+                        BasicTextField(
+                            value = defaultValueText,
+                            onValueChange = { defaultValueText = it },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    var styledValueText by remember { mutableStateOf("Styled value text") }
+                    Text(text = "显式 textStyle：Serif + Bold + 26sp + Red，keyboardType=Email")
+                    Box(
+                        modifier = Modifier.fillMaxWidth().height(58.dp)
+                            .border(1.dp, color = Color.Black)
+                            .padding(horizontal = 12.dp),
+                        contentAlignment = Alignment.CenterStart,
+                    ) {
+                        BasicTextField(
+                            value = styledValueText,
+                            onValueChange = { styledValueText = it },
+                            textStyle = TextStyle(
+                                fontFamily = FontFamily.Serif,
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 26.sp,
+                                color = Color.Red,
+                            ),
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                    Text(
+                        text = "说明：本用例验证已输入 value 的 textStyle/fontFamily；placeholder 样式不在本次范围。",
+                        fontSize = 12.sp,
+                        color = Color.Gray,
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(text = "2 BasicTextField Box居中 红色游标")
                     Box(
                         modifier = Modifier.fillMaxWidth().height(50.dp)
                             .border(1.dp, color = Color.Black),
@@ -175,7 +221,7 @@ class TextFieldDemo : ComposeContainer() {
                     // 1. 基础输入框
                     Spacer(modifier = Modifier.height(16.dp))
                     var text0 by remember { mutableStateOf("") }
-                    Text(text = "2 右侧图标 输入框带：$text0")
+                    Text(text = "3 右侧图标 输入框带：$text0")
                     TextField(
                         modifier = Modifier.fillMaxWidth().nativeRef(ref = {
                             println("nativeRef " + it.nativeRef)
@@ -205,7 +251,7 @@ class TextFieldDemo : ComposeContainer() {
 
                     Spacer(modifier = Modifier.height(16.dp))
                     var text1 by remember { mutableStateOf("") }
-                    Text(text = "3 单行输入不换行：$text1")
+                    Text(text = "4 单行输入不换行：$text1")
                     TextField(
                         singleLine = true,
                         value = text1,

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/InputMeasureDemoPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/InputMeasureDemoPage.kt
@@ -580,6 +580,11 @@ private fun ViewContainer<*, *>.LineHeightDemo() {
         }
     }
     // 字体族 + 颜色
+    val fontFamilySampleText = """
+        |Serif Bold Red
+        |WWWWWWWWWW
+        |狐狸跳过懒狗
+    """.trimMargin()
     View {
         attr {
             flexDirectionRow()
@@ -593,15 +598,8 @@ private fun ViewContainer<*, *>.LineHeightDemo() {
                 fontWeightBold()
                 color(Color.RED)
                 lineHeight(34f)
-                height(102f)
                 flex(1f)
-                text(
-                    """
-                    |Serif + Bold + 26 + Red
-                    |WWWWWW serif wrap test
-                    |狐狸跳过了懒狗
-                    """.trimMargin()
-                )
+                text(fontFamilySampleText)
             }
         }
         Text {
@@ -612,15 +610,8 @@ private fun ViewContainer<*, *>.LineHeightDemo() {
                 fontWeightBold()
                 color(Color.RED)
                 lineHeight(34f)
-                height(102f)
                 flex(1f)
-                text(
-                    """
-                    |Serif + Bold + 26 + Red
-                    |WWWWWW serif wrap test
-                    |狐狸跳过了懒狗
-                    """.trimMargin()
-                )
+                text(fontFamilySampleText)
             }
         }
     }

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/InputMeasureDemoPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/InputMeasureDemoPage.kt
@@ -579,6 +579,51 @@ private fun ViewContainer<*, *>.LineHeightDemo() {
             }
         }
     }
+    // 字体族 + 颜色
+    View {
+        attr {
+            flexDirectionRow()
+        }
+        TextArea {
+            attr {
+                editable(false)
+                border(Border(1f, BorderStyle.SOLID, Color.GRAY))
+                fontSize(26f)
+                fontFamily("serif")
+                fontWeightBold()
+                color(Color.RED)
+                lineHeight(34f)
+                height(102f)
+                flex(1f)
+                text(
+                    """
+                    |Serif + Bold + 26 + Red
+                    |WWWWWW serif wrap test
+                    |狐狸跳过了懒狗
+                    """.trimMargin()
+                )
+            }
+        }
+        Text {
+            attr {
+                border(Border(1f, BorderStyle.SOLID, Color.GRAY))
+                fontSize(26f)
+                fontFamily("serif")
+                fontWeightBold()
+                color(Color.RED)
+                lineHeight(34f)
+                height(102f)
+                flex(1f)
+                text(
+                    """
+                    |Serif + Bold + 26 + Red
+                    |WWWWWW serif wrap test
+                    |狐狸跳过了懒狗
+                    """.trimMargin()
+                )
+            }
+        }
+    }
 }
 
 private fun ViewContainer<*, *>.ViewLayoutDemo() {

--- a/docs/API/components/input.md
+++ b/docs/API/components/input.md
@@ -24,6 +24,10 @@
 
 作用和``Text``组件的[fontWeightBold属性方法一致](text.md#fontWeightBold方法)
 
+### fontFamily方法
+
+作用和``Text``组件的[fontFamily属性方法一致](text.md#fontFamily方法)
+
 ### color方法
 
 指定输入框输入文本的颜色, 作用和``Text``组件的[color属性方法一致](text.md#color方法)
@@ -1350,7 +1354,6 @@ private fun insertEmoji(shortcode: String) {
     }
 }
 ```
-
 
 
 


### PR DESCRIPTION
之前输入框中输入的文字无法设置字体

## Summary
- pass Compose BasicTextField TextStyle.fontFamily through TextAreaAttr
- add TextAreaAttr.fontFamily API matching Text
- apply fontFamily in Android KRTextFieldView via existing TypeFaceLoader
- re-apply TextField typeface after keyboardType/inputType changes so Android EditText does not reset custom fonts
- document Input fontFamily support

## Validation
- ./gradlew --no-daemon --console=plain :core:compileKotlinMetadata :compose:compileKotlinMetadata :core-render-android:compileDebugKotlin

Draft PR for review before marking ready.