### PR TITLE
refactor(ohos): clean up entry CMake linking and public Kuikly include

### DIFF
--- a/ohosApp/entry/src/main/cpp/CMakeLists.txt
+++ b/ohosApp/entry/src/main/cpp/CMakeLists.txt
@@ -2,10 +2,14 @@
 cmake_minimum_required(VERSION 3.4.1)
 project(kuikly_entry)
 
-set(KUIKLY_ENTRY_ROOT_PATH .)
+set(KUIKLY_ENTRY_ROOT_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 set(CMAKE_CXX_STANDARD 17)
-if(DEFINED PACKAGE_FIND_FILE)
+
+if(EXISTS ${PACKAGE_FIND_FILE})
     include(${PACKAGE_FIND_FILE})
+    find_package(render REQUIRED CONFIG)
+else()
+    message(FATAL_ERROR "PACKAGE_FIND_FILE not found. 请检查CMake构建环境")
 endif()
 
 set(SOURCE_SET
@@ -15,17 +19,18 @@ set(SOURCE_SET
 add_library(kuikly_entry SHARED ${SOURCE_SET})
 include_directories(${KUIKLY_ENTRY_ROOT_PATH} ${KUIKLY_ENTRY_ROOT_PATH}/include)
 
-# include render头文件
-target_include_directories(kuikly_entry PRIVATE "${KUIKLY_ENTRY_ROOT_PATH}/../../../../../core-render-ohos/src/main/cpp")
-# 链接render库
-message(${KUIKLY_ENTRY_ROOT_PATH})
-set(OHOS_RENDER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../oh_modules/@kuikly-open/render/build/default/intermediates/libs/default/${OHOS_ARCH})
-add_library(kuikly_render SHARED IMPORTED)
-set_target_properties(kuikly_render PROPERTIES IMPORTED_LOCATION ${OHOS_RENDER_DIR}/libkuikly.so)
-target_link_libraries(kuikly_entry PUBLIC kuikly_render)
+# Kuikly SDK
+add_library(kuikly_render ALIAS render::kuikly)
 
-# 链接系统库
-target_link_libraries(kuikly_entry PUBLIC
+# 业务 so
+add_library(kuikly_shared SHARED IMPORTED)
+set_target_properties(kuikly_shared
+    PROPERTIES
+    IMPORTED_LOCATION ${KUIKLY_ENTRY_ROOT_PATH}/../../../libs/${OHOS_ARCH}/libshared.so)
+
+# 链接系统库、Kuikly SDK 和业务 so
+target_link_libraries(kuikly_entry
+    PUBLIC
     libace_napi.z.so
     libace_ndk.z.so
     hilog_ndk.z.so
@@ -33,6 +38,6 @@ target_link_libraries(kuikly_entry PUBLIC
     libpixelmap.so
     libimage_source.so
     librawfile.z.so
-    # biz库
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../libs/arm64-v8a/libshared.so
+    kuikly_render
+    kuikly_shared
 )

--- a/ohosApp/entry/src/main/cpp/napi_init.cpp
+++ b/ohosApp/entry/src/main/cpp/napi_init.cpp
@@ -26,8 +26,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
-#include "libohos_render/api/include/Kuikly/Kuikly.h"
-#include "libohos_render/utils/KRRenderLoger.h"
+#include <Kuikly/Kuikly.h>
 #include "napi/native_api.h"
 #include "thirdparty/biz_entry/libshared_api.h"
 
@@ -192,7 +191,7 @@ int32_t MyImageAdapterV3(const void *context,
     // 业务逻辑...
     if (paramsMap.count("test") > 0) {
         auto value = paramsMap["test"];
-        KR_LOG_INFO << "imageParams testxxx value: " << value;
+        OH_LOG_Print(LOG_APP, LOG_INFO, 0x1234, "KuiklyEntry", "imageParams testxxx value: %{public}s", value.c_str());
     }
     
     // 方式2：获取特定的参数值（如果只需要某个字段）
@@ -201,7 +200,7 @@ int32_t MyImageAdapterV3(const void *context,
         if (KRAnyDataGetMapValue(imageParams, "test", &testValue) == KRANYDATA_SUCCESS && testValue != nullptr) {
             if (KRAnyDataIsString(testValue)) {
                 const char *str = KRAnyDataGetString(testValue);
-                KR_LOG_INFO << "imageParams test value: " << str;
+                OH_LOG_Print(LOG_APP, LOG_INFO, 0x1234, "KuiklyEntry", "imageParams test value: %{public}s", str);
             }
         }
     }


### PR DESCRIPTION
- resolve the render dependency through find_package and render::kuikly
- import libshared.so as a dedicated target instead of linking by raw path
- switch to the public Kuikly header include and remove the internal KRRenderLoger dependency