### PR TITLE
fix(compose): keep snap target key during pager align corrections

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerScrollPosition.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerScrollPosition.kt
@@ -62,6 +62,21 @@ internal class PagerScrollPosition(
      * Updates the current scroll position based on the results of the last measurement.
      */
     fun updateFromMeasureResult(measureResult: PagerMeasureResult) {
+        val oldPage = currentPage
+        val oldOffsetFraction = currentPageOffsetFraction
+        val oldKey = lastKnownCurrentPageKey
+        val measuredPage = measureResult.currentPage
+        if (state.isSnapAnimating || oldPage != measuredPage?.index || oldKey != measuredPage?.key) {
+            pagerSnapDebugLog {
+                "scrollPositionUpdateFromMeasure: stateId=${state.debugPagerStateId} " +
+                    "oldPage=$oldPage oldOffsetFraction=$oldOffsetFraction oldKey=$oldKey " +
+                    "measuredPage=${measuredPage?.index} measuredKey=${measuredPage?.key} " +
+                    "measuredOffsetFraction=${measureResult.currentPageOffsetFraction} " +
+                    "visibleCount=${measureResult.visiblePagesInfo.size} " +
+                    "hadFirstNotEmptyLayout=$hadFirstNotEmptyLayout " +
+                    "isSnapAnimating=${state.isSnapAnimating} pageCount=${state.pageCount}"
+            }
+        }
         lastKnownCurrentPageKey = measureResult.currentPage?.key
         // we ignore the index and offset from measureResult until we get at least one
         // measurement with real pages. otherwise the initial index and scroll passed to the
@@ -88,17 +103,46 @@ internal class PagerScrollPosition(
      * would have to compose few elements before the asked index, changing the first visible page.
      */
     fun requestPositionAndForgetLastKnownKey(index: Int, offsetFraction: Float) {
+        pagerSnapDebugLog {
+            "scrollPositionForgetKey: stateId=${state.debugPagerStateId} " +
+                "fromPage=$currentPage fromOffsetFraction=$currentPageOffsetFraction " +
+                "fromKey=$lastKnownCurrentPageKey requestPage=$index " +
+                "requestOffsetFraction=$offsetFraction isSnapAnimating=${state.isSnapAnimating} " +
+                "pageCount=${state.pageCount}"
+        }
         update(index, offsetFraction)
         // clear the stored key as we have a direct request to scroll to [index] position and the
         // next [checkIfFirstVisibleItemWasMoved] shouldn't override this.
         lastKnownCurrentPageKey = null
     }
 
+    fun requestPositionAndKeepKnownKey(index: Int, offsetFraction: Float, key: Any?) {
+        pagerSnapDebugLog {
+            "scrollPositionKeepKey: stateId=${state.debugPagerStateId} " +
+                "fromPage=$currentPage fromOffsetFraction=$currentPageOffsetFraction " +
+                "fromKey=$lastKnownCurrentPageKey requestPage=$index " +
+                "requestOffsetFraction=$offsetFraction keepKey=$key " +
+                "isSnapAnimating=${state.isSnapAnimating} pageCount=${state.pageCount}"
+        }
+        update(index, offsetFraction)
+        lastKnownCurrentPageKey = key
+    }
+
     fun matchPageWithKey(
         itemProvider: PagerLazyLayoutItemProvider,
         index: Int
     ): Int {
-        val newIndex = itemProvider.findIndexByKey(lastKnownCurrentPageKey, index)
+        val key = lastKnownCurrentPageKey
+        val indexKey = if (index in 0 until itemProvider.itemCount) itemProvider.getKey(index) else null
+        val newIndex = itemProvider.findIndexByKey(key, index)
+        if (state.isSnapAnimating || index != newIndex || key != indexKey) {
+            pagerSnapDebugLog {
+                "scrollPositionMatchKey: stateId=${state.debugPagerStateId} " +
+                    "lastKnownKey=$key oldIndex=$index oldIndexKey=$indexKey " +
+                    "newIndex=$newIndex itemCount=${itemProvider.itemCount} " +
+                    "isSnapAnimating=${state.isSnapAnimating} pageCount=${state.pageCount}"
+            }
+        }
         if (index != newIndex) {
             currentPage = newIndex
             nearestRangeState.update(index)

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
@@ -462,7 +462,8 @@ abstract class PagerState internal constructor(
             "snapStarted: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
                 "targetOffset=$targetContentOffset contentOffset=${kuiklyInfo.contentOffset} " +
                 "composeOffset=${currentAbsoluteScrollOffset().toInt()} currentPage=$currentPage " +
-                "anchorCorrection=${kuiklyInfo.snapAnchorOffsetCorrection}"
+                "targetPage=$targetPage targetKey=$targetKey pageCount=$pageCount " +
+                "desyncPages=$desyncPages anchorCorrection=${kuiklyInfo.snapAnchorOffsetCorrection}"
         }
     }
 
@@ -494,7 +495,9 @@ abstract class PagerState internal constructor(
             pagerSnapDebugLog {
                 "clearSnapState: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
                     "target=$snapTargetContentOffset contentOffset=${kuiklyInfo.contentOffset} " +
-                    "currentPage=$currentPage"
+                    "currentPage=$currentPage snapStartPageCount=$snapStartPageCount " +
+                    "pageCount=$pageCount snapTargetPage=$snapTargetRelocatedPage " +
+                    "snapTargetKey=$snapTargetItemKey snapStartDesyncPages=$snapStartDesyncPages"
             }
         }
         isSnapAnimating = false
@@ -616,8 +619,28 @@ abstract class PagerState internal constructor(
                 currentPage.coerceInPageRange()
             }
             val relocatedTargetOffset = pageBoundaryOffset(relocatedTarget)
+            pagerSnapDebugLog {
+                "alignRelocatedSnapTarget: stateId=$debugPagerStateId " +
+                    "orientation=${layoutInfo.orientation} relocatedTarget=$relocatedTarget " +
+                    "relocatedTargetOffset=$relocatedTargetOffset " +
+                    "snapTargetKey=$snapTargetItemKey snapStartPageCount=$snapStartPageCount " +
+                    "pageCount=$pageCount snapStartedDesynced=$snapStartedDesynced " +
+                    "contentOffset=$contentOffsetInt composeOffset=${currentAbsoluteScrollOffset().toInt()} " +
+                    "currentPage=$currentPage"
+            }
             updateScrollViewContentSize(layoutSize)
-            scrollPosition.requestPositionAndForgetLastKnownKey(relocatedTarget, 0f)
+            val relocatedKey = snapTargetItemKey
+            if (relocatedKey != null) {
+                pagerSnapDebugLog {
+                    "alignRelocatedSnapTargetKeepKey: stateId=$debugPagerStateId " +
+                        "orientation=${layoutInfo.orientation} relocatedTarget=$relocatedTarget " +
+                        "relocatedKey=$relocatedKey pageCount=$pageCount " +
+                        "snapStartPageCount=$snapStartPageCount snapStartedDesynced=$snapStartedDesynced"
+                }
+                scrollPosition.requestPositionAndKeepKnownKey(relocatedTarget, 0f, relocatedKey)
+            } else {
+                scrollPosition.requestPositionAndForgetLastKnownKey(relocatedTarget, 0f)
+            }
             val delta = relocatedTargetOffset - contentOffsetInt
             if (delta != 0) {
                 applyScrollViewOffsetDelta(delta)
@@ -688,7 +711,17 @@ abstract class PagerState internal constructor(
                     "correctTargetPage=$correctTargetPage " +
                     "composeOffset=$composeOffsetInt contentOffset=$contentOffsetInt"
             }
-            scrollPosition.requestPositionAndForgetLastKnownKey(correctTargetPage, 0f)
+            val targetKey = snapTargetItemKey
+            if (targetKey != null) {
+                pagerSnapDebugLog {
+                    "fixScrollPositionKeepTargetKey: stateId=$debugPagerStateId " +
+                        "orientation=${layoutInfo.orientation} correctTargetPage=$correctTargetPage " +
+                        "targetKey=$targetKey composeOffset=$composeOffsetInt contentOffset=$contentOffsetInt"
+                }
+                scrollPosition.requestPositionAndKeepKnownKey(correctTargetPage, 0f, targetKey)
+            } else {
+                scrollPosition.requestPositionAndForgetLastKnownKey(correctTargetPage, 0f)
+            }
             kuiklyInfo.composeOffset = correctTargetOffset.toFloat()
         }
 
@@ -746,6 +779,15 @@ abstract class PagerState internal constructor(
     }
 
     private fun clearSnapTrackingAfterAlignment() {
+        pagerSnapDebugLog {
+            "clearSnapTrackingAfterAlignment: stateId=$debugPagerStateId " +
+                "orientation=${layoutInfo.orientation} currentPage=$currentPage " +
+                "contentOffset=${kuiklyInfo.contentOffset} " +
+                "composeOffset=${currentAbsoluteScrollOffset().toInt()} " +
+                "snapTarget=$snapTargetContentOffset snapStartPageCount=$snapStartPageCount " +
+                "pageCount=$pageCount snapTargetPage=$snapTargetRelocatedPage " +
+                "snapTargetKey=$snapTargetItemKey snapStartDesyncPages=$snapStartDesyncPages"
+        }
         isSnapAnimating = false
         snapTargetContentOffset = 0
         snapStartPageCount = 0
@@ -802,7 +844,18 @@ abstract class PagerState internal constructor(
                 "currentPage=$currentPage firstVisiblePage=$firstVisiblePage"
         }
         updateScrollViewContentSize(layoutSize)
-        scrollPosition.requestPositionAndForgetLastKnownKey(fallbackPage, 0f)
+        val fallbackKey = snapTargetItemKey
+        if (fallbackKey != null) {
+            pagerSnapDebugLog {
+                "fixInterruptedSnapKeepTargetKey: stateId=$debugPagerStateId " +
+                    "orientation=${layoutInfo.orientation} fallbackPage=$fallbackPage " +
+                    "fallbackKey=$fallbackKey pageCount=$pageCount " +
+                    "snapStartPageCount=$snapStartPageCount snapStartDesyncPages=$snapStartDesyncPages"
+            }
+            scrollPosition.requestPositionAndKeepKnownKey(fallbackPage, 0f, fallbackKey)
+        } else {
+            scrollPosition.requestPositionAndForgetLastKnownKey(fallbackPage, 0f)
+        }
         val delta = fallbackOffset - contentOffset
         if (delta != 0) {
             applyScrollViewOffsetDelta(delta)
@@ -820,10 +873,36 @@ abstract class PagerState internal constructor(
      */
     @OptIn(ExperimentalFoundationApi::class)
     internal fun relocateSnapTargetByKey(itemProvider: PagerLazyLayoutItemProvider) {
-        if (!isSnapAnimating) return
-        val key = snapTargetItemKey ?: return
-        if (snapTargetRelocatedPage < 0) return
+        if (!isSnapAnimating) {
+            return
+        }
+        val key = snapTargetItemKey
+        if (key == null) {
+            pagerSnapDebugLog {
+                "relocateSnapTargetByKeySkipped: stateId=$debugPagerStateId reason=noTargetKey " +
+                    "currentPage=$currentPage pageCount=$pageCount itemCount=${itemProvider.itemCount} " +
+                    "snapTargetPage=$snapTargetRelocatedPage"
+            }
+            return
+        }
+        if (snapTargetRelocatedPage < 0) {
+            pagerSnapDebugLog {
+                "relocateSnapTargetByKeySkipped: stateId=$debugPagerStateId reason=noTargetPage " +
+                    "targetKey=$key currentPage=$currentPage pageCount=$pageCount " +
+                    "itemCount=${itemProvider.itemCount}"
+            }
+            return
+        }
+        val oldIndex = snapTargetRelocatedPage
         val newIndex = itemProvider.findIndexByKey(key, snapTargetRelocatedPage)
+        val oldIndexKey = if (oldIndex in 0 until itemProvider.itemCount) itemProvider.getKey(oldIndex) else null
+        val newIndexKey = if (newIndex in 0 until itemProvider.itemCount) itemProvider.getKey(newIndex) else null
+        pagerSnapDebugLog {
+            "relocateSnapTargetByKey: stateId=$debugPagerStateId targetKey=$key " +
+                "oldIndex=$oldIndex oldIndexKey=$oldIndexKey newIndex=$newIndex " +
+                "newIndexKey=$newIndexKey pageCount=$pageCount itemCount=${itemProvider.itemCount} " +
+                "currentPage=$currentPage"
+        }
         if (newIndex != snapTargetRelocatedPage) {
             snapTargetRelocatedPage = newIndex
         }

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/PagerStateExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/PagerStateExtensions.kt
@@ -69,6 +69,14 @@ internal fun PagerState.kuiklyWillDragEnd(params: WillEndDragParams, orientation
     }.coerceIn(0, pageCount)
 
     val correctedTargetPage = calculateTargetPage(snapBasePage, targetPage, velocity)
+    pagerSnapDebugLog {
+        "willDragEndDecision: stateId=$debugPagerStateId orientation=$orientation " +
+            "velocity=$velocity pageDirection=$pageDirection snapBasePage=$snapBasePage " +
+            "targetPage=$targetPage correctedTargetPage=$correctedTargetPage " +
+            "currentPage=$currentPage firstVisiblePage=$firstVisiblePage " +
+            "nativeContentOffset=$nativeContentOffset nativePageFromOffset=$nativePageFromOffset " +
+            "desyncPages=$desyncPages pageCount=$pageCount"
+    }
     handleTargetPageScroll(correctedTargetPage, params, orientation, desyncPages)
 }
 


### PR DESCRIPTION
## Summary

Cherry-picks the two internal ComposeOnKuikly pager fixes (1.3.141 / 1.3.142) that were missing on the public repo after #1409:

- **`alignRelocatedSnapTarget` / `fixInterruptedSnap`**: when snap settle runs during list prepend, keep `snapTargetItemKey` via `requestPositionAndKeepKnownKey` instead of clearing `lastKnownCurrentPageKey`.
- **`fixScrollPosition` (`positionCorrupted`)**: same keep-key behavior so prepend does not drop the anchored item.

Also adds targeted `[PagerSnap]` debug logs (`scrollPositionKeepKey`, `fixInterruptedSnapKeepTargetKey`, `willDragEndDecision`, etc.) to diagnose key relocation — gated by existing `PagerDebugConfig.Snap`.

**Scope**: only 3 pager files; no unrelated internal/business code.

## Background

WeSee vertical drama pager: fast backward scroll + concurrent `topMore` prepend caused large jumps (e.g. 24→16) when align paths called `requestPositionAndForgetLastKnownKey`, leaving `matchPageWithKey` with `lastKnownKey=null` at index 0 after prepend.

See internal harness docs: `pager-compose-native-architecture.md` §4.5.

## Test plan

- [ ] `HorizontalPagerDemo3` / `VerticalPagerDemo`: fast backward fling still settles on adjacent page
- [ ] List prepend during snap: current item key preserved (no jump to prepend batch head)
- [ ] `PagerDebugConfig.Snap = false` in release — no extra log noise
- [ ] WeSee short-drama vertical pager: fast下滑 + topMore no longer大跳 (business integration)


Made with [Cursor](https://cursor.com)