### PR TITLE
fix: tolerate cancelled compose flush tasks

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/platform/FlushCoroutineDispatcher.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/platform/FlushCoroutineDispatcher.kt
@@ -91,7 +91,7 @@ internal class FlushCoroutineDispatcher(
                 immediateTasks = tmp
             }
 
-            immediateTasksSwap.forEach(Runnable::run)
+            immediateTasksSwap.forEach(::runTaskSafely)
             immediateTasksSwap.clear()
         }
     }
@@ -116,13 +116,7 @@ internal class FlushCoroutineDispatcher(
                 immediateTasks = tmp
             }
 
-            immediateTasksSwap.forEach { task ->
-                try {
-                    task.run()
-                } catch (_: CancellationException) {
-                    // Expected during shutdown — the task's coroutine was already cancelled.
-                }
-            }
+            immediateTasksSwap.forEach(::runTaskSafely)
             immediateTasksSwap.clear()
         }
     }
@@ -134,6 +128,14 @@ internal class FlushCoroutineDispatcher(
             body()
         } finally {
             isPerformingRun = false
+        }
+    }
+
+    private fun runTaskSafely(task: Runnable) {
+        try {
+            task.run()
+        } catch (_: CancellationException) {
+            // Expected when a queued coroutine task has already been cancelled.
         }
     }
 


### PR DESCRIPTION
## Summary

This PR extends the existing `drainSafely()` cancelled-task protection to normal `flush()` execution in `FlushCoroutineDispatcher`.

`drainSafely()` already catches `CancellationException` for queued coroutine tasks that have been cancelled before their dispatched `Runnable` is drained. The same task can also be reached through `flush()` during a normal frame/effect dispatch path, so this change moves the per-task execution guard into a shared helper and uses it from both paths.

## Behavior

- `flush()` now runs queued tasks through `runTaskSafely`.
- `drainSafely()` reuses the same helper.
- Only direct `CancellationException` from a queued task is ignored.
- Other exceptions still propagate.

## Validation

- `git diff --check` passed.
- Local OHOS compose compile was attempted, but configuration fails before source compilation on the current upstream `main` build script with `core/build.2.0.ohos.gradle.kts:58:47: Unresolved reference: lowercase`; this is pre-existing on this branch and unrelated to this one-file dispatcher change.
