### PR TITLE
fix(compose): add pullToRefreshItem topInset for overlay header (#1325)

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
@@ -139,6 +139,12 @@ class KuiklyScrollInfo {
         }
 
     /**
+     * Extra top inset on the pull-to-refresh lazy item in pixels,
+     * from [com.tencent.kuikly.compose.material3.pullToRefreshItem.topInset].
+     */
+    var pullToRefreshTopInsetPx: Int = 0
+
+    /**
      * Cached total number of items, used to detect changes in item count
      */
     var cachedTotalItems: Int = 0
@@ -187,6 +193,7 @@ class KuiklyScrollInfo {
         itemMainSpaceCache.clear()
         stickyItemKey = null
         cachedTotalItems = 0
+        pullToRefreshTopInsetPx = 0
     }
 
     /**

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/material3/PullToRefresh.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/material3/PullToRefresh.kt
@@ -42,6 +42,7 @@ import com.tencent.kuikly.compose.ui.text.style.TextAlign
 import com.tencent.kuikly.compose.ui.unit.Dp
 import com.tencent.kuikly.compose.ui.unit.dp
 import com.tencent.kuikly.compose.ui.unit.sp
+import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlin.math.abs
@@ -171,6 +172,8 @@ class PullToRefreshState(
  * @param onRefresh Refresh callback
  * @param scrollState LazyListState for monitoring scroll state
  * @param modifier Modifier
+ * @param topInset Extra top inset for overlay header (e.g. collapsing HeaderBar).
+ *   Pass the header's maximum height, not its animated height.
  * @param refreshThreshold Threshold to trigger refresh
  * @param content Custom refresh indicator content
  */
@@ -179,6 +182,7 @@ fun LazyListScope.pullToRefreshItem(
     onRefresh: () -> Unit,
     scrollState: LazyListState,
     modifier: Modifier = Modifier,
+    topInset: Dp = 0.dp,
     refreshThreshold: Dp = 80.dp,
     content: @Composable (
         pullProgress: Float,
@@ -197,6 +201,7 @@ fun LazyListScope.pullToRefreshItem(
             onRefresh = onRefresh,
             scrollState = scrollState,
             modifier = modifier,
+            topInset = topInset,
             refreshThreshold = refreshThreshold,
             content = content
         )
@@ -213,6 +218,7 @@ internal fun PullToRefreshItem(
     onRefresh: () -> Unit,
     scrollState: LazyListState,
     modifier: Modifier = Modifier,
+    topInset: Dp = 0.dp,
     refreshThreshold: Dp = 80.dp,
     content: @Composable (
         pullProgress: Float,
@@ -226,6 +232,8 @@ internal fun PullToRefreshItem(
     val refreshThresholdPx = with(density) { refreshThreshold.toPx() }
     val refreshThresholdLogical = refreshThresholdPx / density.density
     val updatedOnRefresh by rememberUpdatedState(onRefresh)
+
+    scrollState.kuiklyInfo.pullToRefreshTopInsetPx = with(density) { topInset.roundToPx() }
 
     // Monitor scroll state changes inspired by RefreshView logic
     LaunchedEffect(scrollState) {
@@ -371,6 +379,7 @@ internal fun PullToRefreshItem(
     // Refresh indicator UI
     Box(
         modifier = modifier
+            .then(if (topInset > 0.dp) Modifier.padding(top = topInset) else Modifier)
             .offsetWithParentAdjustment(y = -refreshThreshold)
             .fillMaxWidth()
             .height(refreshThreshold),

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ContentSizeExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ContentSizeExtensions.kt
@@ -181,6 +181,45 @@ private fun ScrollState.calculateScrollStateContentSize(): Int? {
     } else null
 }
 
+private const val PULL_TO_REFRESH_ITEM_KEY = "pull_to_refresh"
+
+/**
+ * Whether Compose is at top for scroll-sync correction.
+ * Only differs from [isAtTop] when PTR [KuiklyScrollInfo.pullToRefreshTopInsetPx] > 0.
+ */
+private fun ScrollableState.isComposeAtTopForScrollSync(): Boolean {
+    if (this is LazyListState && kuiklyInfo.pullToRefreshTopInsetPx > 0) {
+        return firstVisibleItemIndex == 0 && firstVisibleItemScrollOffset == 0
+    }
+    return isAtTop()
+}
+
+/**
+ * Estimate Compose scroll offset when PTR item is taller than average (topInset case).
+ */
+private fun LazyListState.estimateComposeScrollOffset(avgItemSize: Int): Int {
+    val index = firstVisibleItemIndex
+    if (index <= 0) return firstVisibleItemScrollOffset
+
+    val spacing = layoutInfo.mainAxisItemSpacing
+    var sum = 0
+    for (i in 0 until index) {
+        sum += itemMainAxisSizeAt(i, avgItemSize)
+        if (i < index - 1) {
+            sum += spacing
+        }
+    }
+    return sum + firstVisibleItemScrollOffset
+}
+
+private fun LazyListState.itemMainAxisSizeAt(index: Int, avgItemSize: Int): Int {
+    layoutInfo.visibleItemsInfo.find { it.index == index }?.size?.let { return it }
+    if (kuiklyInfo.pullToRefreshTopInsetPx > 0 && index == 0) {
+        kuiklyInfo.itemMainSpaceCache[PULL_TO_REFRESH_ITEM_KEY]?.let { return it }
+    }
+    return avgItemSize
+}
+
 /**
  * Calculate back expansion size
  */
@@ -190,16 +229,19 @@ internal fun ScrollableState.calculateBackExpandSize(offset: Int): Int? {
     val visibleItems = layoutInfo.visibleItemsInfo
     if (visibleItems.isEmpty()) return null
 
-    val itemsSum = visibleItems.fastSumBy { it.size }
-    val avgSize = itemsSum / visibleItems.size + layoutInfo.mainAxisItemSpacing
-    val firstItem = visibleItems.firstOrNull() ?: return null
-
-    // Adjust for PullToRefresh offset if it exists
-    val pullToRefreshOffset = if (kuiklyInfo.hasPullToRefresh) 1 else 0
-    val adjustedFirstItemIndex = maxOf(0, firstItem.index - pullToRefreshOffset)
-
-    val estimateOffset = adjustedFirstItemIndex * avgSize - firstItem.offset
-    val density = this.kuiklyInfo.getDensity()
+    val density = kuiklyInfo.getDensity()
+    val estimateOffset = if (kuiklyInfo.pullToRefreshTopInsetPx > 0) {
+        val itemsSum = visibleItems.fastSumBy { it.size }
+        val avgItemSize = itemsSum / visibleItems.size
+        estimateComposeScrollOffset(avgItemSize)
+    } else {
+        val itemsSum = visibleItems.fastSumBy { it.size }
+        val avgSize = itemsSum / visibleItems.size + layoutInfo.mainAxisItemSpacing
+        val firstItem = visibleItems.firstOrNull() ?: return null
+        val pullToRefreshOffset = if (kuiklyInfo.hasPullToRefresh) 1 else 0
+        val adjustedFirstItemIndex = maxOf(0, firstItem.index - pullToRefreshOffset)
+        adjustedFirstItemIndex * avgSize - firstItem.offset
+    }
 
     return if (estimateOffset - offset > ScrollableStateConstants.SCROLL_THRESHOLD * density) {
         estimateOffset - offset + (ScrollableStateConstants.MIN_EXPAND_SIZE * density).toInt()
@@ -214,7 +256,7 @@ internal fun ScrollableState.tryExpandStartSize(offset: Int, isScrolling: Boolea
 
     val density = kuiklyInfo.getDensity()
     // scrollview 到顶了，但是compose没到顶
-    if (offset <= 0 && !isAtTop() && kuiklyInfo.offsetDirty) {
+    if (offset <= 0 && !isComposeAtTopForScrollSync() && kuiklyInfo.offsetDirty) {
         var delta = calculateBackExpandSize(offset)
         val minDelta = (ScrollableStateConstants.DEFAULT_CONTENT_SIZE * density).toInt()
         delta = max(delta ?: minDelta, minDelta)
@@ -234,7 +276,7 @@ internal fun ScrollableState.tryExpandStartSize(offset: Int, isScrolling: Boolea
         }
         kuiklyInfo.offsetDirty = true
         applyScrollViewOffsetDelta(delta)
-    } else if (offset > 0 && isAtTop()) {
+    } else if (offset > 0 && isComposeAtTopForScrollSync()) {
         // compose 到顶了，但是scrollview没到顶
         applyScrollViewOffsetDelta(-offset)
         kuiklyInfo.offsetDirty = false
@@ -251,7 +293,7 @@ internal fun ScrollableState.tryExpandStartSizeNoScroll(forceExpand: Boolean = f
             val epsilon = 0.5 * getDensity()  // 使用 0.5dp 作为误差值
             val reachBtm = contentOffset + viewportSize - currentContentSize >= -epsilon
 
-            if (contentOffset <= 0 && !isAtTop() && (forceExpand || scrollView?.isDragging != true)) {
+            if (contentOffset <= 0 && !isComposeAtTopForScrollSync() && (forceExpand || scrollView?.isDragging != true)) {
                 // 整体把offset 加一下
                 var delta = calculateBackExpandSize(contentOffset)
                 delta = max(delta ?: minDelta, minDelta)
@@ -266,7 +308,7 @@ internal fun ScrollableState.tryExpandStartSizeNoScroll(forceExpand: Boolean = f
                 }
                 applyScrollViewOffsetDelta(delta)
                 offsetDirty = true
-            } else if (contentOffset > 0 && isAtTop()) {
+            } else if (contentOffset > 0 && isComposeAtTopForScrollSync()) {
                 // compose 到顶了，但是scrollview没到顶
                 applyScrollViewOffsetDelta(-contentOffset)
                 offsetDirty = false

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ScrollableStateExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ScrollableStateExtensions.kt
@@ -87,8 +87,13 @@ internal fun ScrollableState.kuiklyOnScrollEnd(params: ScrollParams) {
  */
 internal fun ScrollableState.isAtTop(): Boolean = when(this) {
     is LazyListState -> {
-        val pullToRefreshOffset = if (kuiklyInfo.hasPullToRefresh) 1 else 0
-        firstVisibleItemIndex <= pullToRefreshOffset && firstVisibleItemScrollOffset == 0
+        if (kuiklyInfo.hasPullToRefresh && kuiklyInfo.pullToRefreshTopInsetPx > 0) {
+            // With top inset, index=1 offset=0 means PTR padding scrolled away — not at top.
+            firstVisibleItemIndex == 0
+        } else {
+            val pullToRefreshOffset = if (kuiklyInfo.hasPullToRefresh) 1 else 0
+            firstVisibleItemIndex <= pullToRefreshOffset && firstVisibleItemScrollOffset == 0
+        }
     }
     is PagerState -> firstVisiblePage == 0 && firstVisiblePageOffset == 0
     is LazyGridState -> {

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/ComposeAllSample.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/ComposeAllSample.kt
@@ -110,6 +110,7 @@ internal class ComposeAllSample : ComposeContainer() {
             DemoItem("焦点处理", "Focus焦点处理示例", "focusDemo"),
             DemoItem("TextField", "TextField 组件示例", "TextFieldDemo"),
             DemoItem("PullToRefresh", "PullToRefresh 组件示例", "PullToRefreshDemo"),
+            DemoItem("PTR Padding Bug", "Issue #1325 HeaderBar+PTR padding", "BugReproPullRefreshPaddingPage"),
             // 其他
             DemoItem("封装KuiklyView", "封装Kuikly的VideoView为一个Composeable组件示例", "ComposeVideoDemo"),
             DemoItem("iOS LiquidGlass", "iOS LiquidGlass 组件示例", "LiquidGlassComposeDemo"),

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/debug/BugReproPullRefreshPaddingPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/debug/BugReproPullRefreshPaddingPage.kt
@@ -1,0 +1,222 @@
+/*
+ * Issue #1325 repro: HeaderBar overlay + pullToRefreshItem padding(top=84.dp)
+ */
+package com.tencent.kuikly.demo.pages.debug
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import com.tencent.kuikly.compose.ComposeContainer
+import com.tencent.kuikly.compose.foundation.background
+import com.tencent.kuikly.compose.foundation.layout.Arrangement
+import com.tencent.kuikly.compose.foundation.layout.Box
+import com.tencent.kuikly.compose.foundation.layout.Column
+import com.tencent.kuikly.compose.foundation.layout.Row
+import com.tencent.kuikly.compose.foundation.layout.fillMaxHeight
+import com.tencent.kuikly.compose.foundation.layout.fillMaxSize
+import com.tencent.kuikly.compose.foundation.layout.fillMaxWidth
+import com.tencent.kuikly.compose.foundation.layout.height
+import com.tencent.kuikly.compose.foundation.layout.padding
+import com.tencent.kuikly.compose.foundation.lazy.LazyColumn
+import com.tencent.kuikly.compose.foundation.lazy.LazyListState
+import com.tencent.kuikly.compose.foundation.lazy.items
+import com.tencent.kuikly.compose.foundation.lazy.rememberLazyListState
+import com.tencent.kuikly.compose.material3.Text
+import com.tencent.kuikly.compose.material3.pullToRefreshItem
+import com.tencent.kuikly.compose.material3.rememberPullToRefreshState
+import com.tencent.kuikly.compose.setContent
+import com.tencent.kuikly.compose.ui.Alignment
+import com.tencent.kuikly.compose.ui.Modifier
+import com.tencent.kuikly.compose.ui.draw.alpha
+import com.tencent.kuikly.compose.ui.graphics.Color
+import com.tencent.kuikly.compose.ui.platform.LocalDensity
+import com.tencent.kuikly.compose.ui.text.style.TextAlign
+import com.tencent.kuikly.compose.ui.unit.Dp
+import com.tencent.kuikly.compose.ui.unit.dp
+import com.tencent.kuikly.compose.ui.unit.sp
+import com.tencent.kuikly.core.annotations.Page
+import com.tencent.kuikly.core.log.KLog
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@Page("BugReproPullRefreshPaddingPage")
+internal class BugReproPullRefreshPaddingPage : ComposeContainer() {
+
+    override fun willInit() {
+        super.willInit()
+        setContent {
+            BugReproContent()
+        }
+    }
+}
+
+@Composable
+private fun BugReproContent() {
+    val listState = rememberLazyListState()
+    var isRefreshing by remember { mutableStateOf(false) }
+    var itemCount by remember { mutableStateOf(30) }
+    val pullToRefreshState = rememberPullToRefreshState(isRefreshing)
+    val scope = rememberCoroutineScope()
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text(
+            text = "Issue #1325: 慢滑列表观察顶部留白与 index",
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            fontSize = 12.sp,
+            color = Color.Gray,
+        )
+
+        Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight()
+                    .background(Color.White),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                pullToRefreshItem(
+                    state = pullToRefreshState,
+                    onRefresh = {
+                        scope.launch {
+                            isRefreshing = true
+                            delay(2000)
+                            itemCount += 5
+                            isRefreshing = false
+                        }
+                    },
+                    scrollState = listState,
+                    topInset = 84.dp,
+                    content = { progress, refreshing, threshold ->
+                        SimpleRefreshIndicator(progress, refreshing, threshold)
+                    },
+                )
+
+                items(itemCount) { index ->
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(56.dp)
+                            .background(Color(0xFFECEFF1))
+                            .padding(horizontal = 16.dp),
+                        contentAlignment = Alignment.CenterStart,
+                    ) {
+                        Text("Item ${index + 1}", fontSize = 15.sp)
+                    }
+                }
+            }
+
+            DemoHeaderBar(listState = listState)
+        }
+    }
+}
+
+@Composable
+private fun DemoHeaderBar(listState: LazyListState) {
+    val topBarHeightDp = 48.dp
+    val topBarHeightPx = with(LocalDensity.current) { topBarHeightDp.toPx() }
+
+    val scrollProgress by remember(listState, topBarHeightPx) {
+        derivedStateOf {
+            val index = listState.firstVisibleItemIndex
+            val offset = listState.firstVisibleItemScrollOffset
+            KLog.i("scrollProgress", "index=$index offset=$offset")
+            when {
+                topBarHeightPx <= 0f -> 0f
+                index <= 0 -> (offset.toFloat() / topBarHeightPx).coerceIn(0f, 1f)
+                else -> 1f
+            }
+        }
+    }
+
+    val currentTopBarHeightDp = with(LocalDensity.current) {
+        (topBarHeightPx * (1f - scrollProgress)).toDp()
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color(0xFF1A1A2E)),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(currentTopBarHeightDp)
+                .alpha(1f - scrollProgress),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text("DEMO LOGO", color = Color.White, fontSize = 18.sp)
+                Text("按钮", color = Color.White, fontSize = 14.sp)
+            }
+        }
+
+        val customerWidthDp = 60.dp
+        val searchEndPadding = customerWidthDp * scrollProgress
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(36.dp)
+                .padding(start = 12.dp, end = 12.dp, bottom = 4.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth()
+                    .padding(end = searchEndPadding)
+                    .background(Color.White.copy(alpha = 0.15f)),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                Text(
+                    "不压缩部分...",
+                    color = Color.White.copy(alpha = 0.5f),
+                    fontSize = 13.sp,
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .alpha(scrollProgress)
+                    .padding(end = 4.dp),
+            ) {
+                Text("按钮", color = Color.White, fontSize = 13.sp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SimpleRefreshIndicator(
+    pullProgress: Float,
+    isRefreshing: Boolean,
+    refreshThreshold: Dp,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(refreshThreshold),
+        contentAlignment = Alignment.Center,
+    ) {
+        val text = when {
+            isRefreshing -> "Refreshing..."
+            pullProgress >= 1f -> "Release to refresh"
+            pullProgress > 0f -> "Pull to refresh"
+            else -> ""
+        }
+        if (text.isNotEmpty()) {
+            Text(text, fontSize = 14.sp, color = Color.Gray, textAlign = TextAlign.Center)
+        }
+    }
+}

--- a/docs/Compose/list-and-scroll.md
+++ b/docs/Compose/list-and-scroll.md
@@ -168,6 +168,36 @@ fun PullToRefreshList(data: List<String>) {
 }
 ```
 
+#### 参数说明
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `topInset` | `0.dp` | overlay HeaderBar 等场景下，PTR item 顶部的额外留白。传 **header 展开时的最大高度**，不是动画中的实时高度。框架会在 PTR item 内部自动应用等效 `padding(top)`，**请勿**再在 `modifier` 上重复设置 `padding(top = ...)`。未设置时行为与原来一致。 |
+| `refreshThreshold` | `80.dp` | 触发刷新的下拉距离 |
+
+#### overlay HeaderBar（`topInset`）
+
+常见结构：HeaderBar 浮在列表上方，列表需要顶部留白避免内容被遮挡。
+
+```kotlin
+Box(modifier = Modifier.fillMaxSize()) {
+    LazyColumn(state = listState) {
+        pullToRefreshItem(
+            state = pullToRefreshState,
+            scrollState = listState,
+            topInset = 84.dp,  // header 展开时的最大高度（如 48.dp + 36.dp）
+            onRefresh = { /* ... */ },
+        )
+        items(data) { /* ... */ }
+    }
+    HeaderBar(listState)  // overlay，折叠动画根据 listState 驱动
+}
+```
+
+`topInset` 是固定最大值；header 收起动画由 overlay 层根据 `listState` 驱动，列表里的留白会随滚动被滚走，无需让 `topInset` 跟着 header 实时变化。
+
+参考 demo：`BugReproPullRefreshPaddingPage.kt`（Issue #1325 回归页）。
+
 ## 示例：基础纵向列表（LazyColumn）
 
 ```kotlin


### PR DESCRIPTION
## Summary
- Add `pullToRefreshItem(topInset: Dp = 0.dp)` for overlay header layouts; writes `kuiklyInfo.pullToRefreshTopInsetPx` and applies top padding on the PTR lazy item.
- When `topInset > 0`, tighten top detection (`isAtTop` / scroll-sync) so `index=1, offset=0` is no longer treated as fully at top, and use PTR item size cache for back-expand offset estimation.
- No behavior change when `topInset` is not set (existing PTR `index <= 1` logic preserved).
- Add `BugReproPullRefreshPaddingPage` demo for regression.

Fixes #1325

## Test plan
- [x] `BugReproPullRefreshPaddingPage` on Android device: slow-scroll no longer loses top padding / stuck at `index=1 offset=0`
- [ ] `PullToRefreshDemo` without `topInset` still works
- [ ] `./gradlew :compose:compileDebugKotlinAndroid :androidApp:assembleDebug`


Made with [Cursor](https://cursor.com)