### PR TITLE
fix(compose): LazyGrid contentSize shrink and pager contentPadding boundary

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/lazy/grid/LazyGrid.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/lazy/grid/LazyGrid.kt
@@ -232,8 +232,13 @@ private fun rememberLazyGridMeasurePolicy(
         val spaceBetweenLines = spaceBetweenLinesDp.roundToPx()
         val itemsCount = itemProvider.itemCount
 
-        if (state.kuiklyInfo.cachedTotalItems > 0 && itemsCount < state.kuiklyInfo.cachedTotalItems) {
-            state.kuiklyInfo.offsetDirty = true
+        if (state.kuiklyInfo.cachedTotalItems > 0) {
+            if (itemsCount < state.kuiklyInfo.cachedTotalItems) {
+                state.kuiklyInfo.offsetDirty = true
+            } else if (itemsCount > state.kuiklyInfo.cachedTotalItems) {
+                state.kuiklyInfo.realContentSize = null
+                state.tryExpandStartSizeNoScroll()
+            }
         }
         state.kuiklyInfo.cachedTotalItems = itemsCount
 

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/lazy/grid/LazyGridState.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/lazy/grid/LazyGridState.kt
@@ -50,7 +50,6 @@ import com.tencent.kuikly.compose.ui.layout.RemeasurementModifier
 import com.tencent.kuikly.compose.ui.unit.Density
 import com.tencent.kuikly.compose.ui.unit.dp
 import com.tencent.kuikly.compose.ui.util.fastForEach
-import com.tencent.kuikly.compose.scroller.calculateContentSize
 import com.tencent.kuikly.compose.scroller.kuiklyInfo
 import com.tencent.kuikly.compose.scroller.tryExpandStartSizeNoScroll
 import com.tencent.kuikly.compose.profiler.RecompositionProfiler
@@ -556,14 +555,6 @@ class LazyGridState @ExperimentalFoundationApi constructor(
                     to = newFirstVisible,
                     visibleItemCount = result.visibleItemsInfo.size
                 )
-            }
-        }
-
-        kuiklyInfo.run {
-            val requiredContentSize = calculateContentSize()
-            if (currentContentSize < requiredContentSize) {
-                currentContentSize = requiredContentSize
-                updateContentSizeToRender()
             }
         }
 

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/lazy/staggeredgrid/LazyStaggeredGridMeasure.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/lazy/staggeredgrid/LazyStaggeredGridMeasure.kt
@@ -279,8 +279,14 @@ private fun LazyStaggeredGridMeasureContext.measure(
     withDebugLogging(measureScope) {
         val itemCount = itemProvider.itemCount
 
-        if (state.kuiklyInfo.cachedTotalItems > 0 && itemCount < state.kuiklyInfo.cachedTotalItems) {
-            state.kuiklyInfo.offsetDirty = true
+        // 检测 item 数量变化
+        if (state.kuiklyInfo.cachedTotalItems > 0) {
+            if (itemCount < state.kuiklyInfo.cachedTotalItems) {
+                state.kuiklyInfo.offsetDirty = true
+            } else if (itemCount > state.kuiklyInfo.cachedTotalItems) {
+                state.kuiklyInfo.realContentSize = null
+                state.tryExpandStartSizeNoScroll()
+            }
         }
         state.kuiklyInfo.cachedTotalItems = itemCount
 

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
@@ -74,6 +74,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.max
+import kotlin.math.min
 
 /**
  * Creates and remember a [PagerState] to be used with a [Pager]
@@ -566,9 +567,36 @@ abstract class PagerState internal constructor(
         return (offset / pageSize.toFloat()).roundToInt().coerceInPageRange()
     }
 
+    /**
+     * Scroll offset where [page] sits on its snap boundary.
+     * Last/first page must use [maxScrollOffset]/[minScrollOffset] so after/before contentPadding
+     * is not clipped when native is already at the scroll limit.
+     */
     private fun pageBoundaryOffset(page: Int): Int {
-        return page.coerceInPageRange() * pageSizeWithSpacing
+        if (pageCount == 0 || pageSizeWithSpacing == 0) {
+            return 0
+        }
+        val coercedPage = page.coerceInPageRange()
+        var offset = coercedPage * pageSizeWithSpacing
+        if (coercedPage == 0) {
+            offset = max(offset, minScrollOffset.toInt())
+        }
+        if (coercedPage == pageCount - 1) {
+            offset = min(offset, maxScrollOffset.toInt())
+        }
+        return offset
     }
+
+    private fun pageBoundaryOffsetFraction(page: Int): Float {
+        if (pageSizeWithSpacing == 0) {
+            return 0f
+        }
+        val coercedPage = page.coerceInPageRange()
+        return (pageBoundaryOffset(coercedPage) - coercedPage * pageSizeWithSpacing)
+            .toFloat() / pageSizeWithSpacing
+    }
+
+    internal fun snapScrollOffsetForPage(page: Int): Int = pageBoundaryOffset(page)
 
     private fun isPageBoundaryOffset(offset: Int): Boolean {
         val boundaryOffset = pageBoundaryOffset(nearestPageForOffset(offset))
@@ -824,7 +852,11 @@ abstract class PagerState internal constructor(
                     "nativePage=$nativePage currentPage=$trustedPage targetPage=$targetPage " +
                     "pageGap=$pageGap anchorKey=$anchorKey"
             }
-            scrollPosition.requestPositionAndKeepKnownKey(targetPage, 0f, anchorKey)
+            scrollPosition.requestPositionAndKeepKnownKey(
+                targetPage,
+                pageBoundaryOffsetFraction(targetPage),
+                anchorKey
+            )
         } else {
             val reason = if (anchorKey != null) {
                 "alignBoundaryForgetKeyTrustNative"
@@ -836,8 +868,12 @@ abstract class PagerState internal constructor(
                     "nativePage=$nativePage currentPage=$trustedPage targetPage=$targetPage " +
                     "pageGap=$pageGap anchorKey=$anchorKey"
             }
-            scrollPosition.requestPositionAndForgetLastKnownKey(targetPage, 0f)
+            scrollPosition.requestPositionAndForgetLastKnownKey(
+                targetPage,
+                pageBoundaryOffsetFraction(targetPage)
+            )
         }
+        kuiklyInfo.composeOffset = targetBoundaryOffset.toFloat()
         return true
     }
 
@@ -1313,13 +1349,13 @@ abstract class PagerState internal constructor(
         tryRunPrefetch(result)
         maxScrollOffset = result.calculateNewMaxScrollOffset(pageCount)
         minScrollOffset = result.calculateNewMinScrollOffset(pageCount)
+        val layoutSize = if (result.orientation == Orientation.Horizontal)
+            result.viewportSize.width else result.viewportSize.height
         debugLog {
             "Finished Applying Measure Result" +
                 "\nNew maxScrollOffset=$maxScrollOffset"
         }
 
-        val layoutSize = if (result.orientation == Orientation.Horizontal)
-            result.viewportSize.width else result.viewportSize.height
         updateAlignmentLayoutGeneration(result.orientation, layoutSize)
 
         scheduleScrollViewOffsetAlignment(SNAP_MEASURE_JOB_INITIAL_DELAY_MS, layoutSize)

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/PagerStateExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/PagerStateExtensions.kt
@@ -161,7 +161,7 @@ private fun PagerState.handleTargetPageScroll(
 
         val maxOffset = kuiklyInfo.currentContentSize - kuiklyInfo.viewportSize
         val composeCandidateOffset = nextPage?.let { offset + it.offset }
-        val pageBoundaryOffset = pageSizeWithSpacing * targetPage
+        val pageBoundaryOffset = snapScrollOffsetForPage(targetPage)
         // Snap target selection:
         //  - Aligned (no desync): use the compose-coordinate candidate. Native and compose share the
         //    same coordinate, so this lands exactly on the next page.


### PR DESCRIPTION
## Summary

Migrate two ComposeOnKuikly fixes to upstream KuiklyUI:

- **fix(compose): align LazyGrid contentSize shrink with LazyList** — remove measure-time contentSize growth in `LazyGridState`; recalculate content size when item count increases in `LazyGrid` and `LazyStaggeredGrid`
- **fix(pager): clamp page boundary offset for contentPadding** — clamp first/last page `pageBoundaryOffset` to `minScrollOffset`/`maxScrollOffset`; use matching fraction during native/compose alignment and snap fallback to avoid trailing padding being clipped on the last page

## Changed files (5)

- `compose/.../lazy/grid/LazyGrid.kt`
- `compose/.../lazy/grid/LazyGridState.kt`
- `compose/.../lazy/staggeredgrid/LazyStaggeredGridMeasure.kt`
- `compose/.../pager/PagerState.kt`
- `compose/.../scroller/PagerStateExtensions.kt`

## Test plan

- [ ] LazyGrid with short content: no default 3000dp scroll bounce after item count changes
- [ ] LazyStaggeredGrid: same item-count increase/decrease behavior as LazyList
- [ ] HorizontalPager with `contentPadding`: last page trailing padding visible after scroll to end
- [ ] Middle-page pager snap unaffected


Made with [Cursor](https://cursor.com)