### PR TITLE
fix(compose): move string text field cursor to end

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/BasicTextField.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/BasicTextField.kt
@@ -35,6 +35,7 @@ import com.tencent.kuikly.compose.ui.graphics.Brush
 import com.tencent.kuikly.compose.ui.graphics.Color
 import com.tencent.kuikly.compose.ui.graphics.SolidColor
 import com.tencent.kuikly.compose.ui.text.TextLayoutResult
+import com.tencent.kuikly.compose.ui.text.TextRange
 import com.tencent.kuikly.compose.ui.text.TextStyle
 import com.tencent.kuikly.compose.ui.text.input.ImeAction
 import com.tencent.kuikly.compose.ui.text.input.KeyboardType
@@ -263,13 +264,21 @@ fun BasicTextField(
     // Holds the latest internal TextFieldValue state. We need to keep it to have the correct value
     // of the composition.
     var textFieldValueState by remember { mutableStateOf(TextFieldValue(text = value)) }
-    // Holds the latest TextFieldValue that BasicTextField was recomposed with. We couldn't simply
-    // pass `TextFieldValue(text = value)` to the CoreTextField because we need to preserve the
-    // composition.
-    val textFieldValue = textFieldValueState.copy(text = value)
+    // When the external String value changes programmatically, move the cursor to the end so the
+    // String overload has a deterministic cursor behavior without exposing selection control.
+    val textFieldValue = if (value != textFieldValueState.text) {
+        textFieldValueState.copy(
+            text = value,
+            selection = TextRange(value.length),
+            composition = null
+        )
+    } else {
+        textFieldValueState.copy(text = value)
+    }
 
     SideEffect {
-        if (textFieldValue.selection != textFieldValueState.selection ||
+        if (textFieldValue.text != textFieldValueState.text ||
+            textFieldValue.selection != textFieldValueState.selection ||
             textFieldValue.composition != textFieldValueState.composition
         ) {
             textFieldValueState = textFieldValue

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/TextFieldDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/TextFieldDemo.kt
@@ -16,6 +16,7 @@
 package com.tencent.kuikly.demo.pages.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -67,6 +68,7 @@ import com.tencent.kuikly.compose.ui.platform.LocalSoftwareKeyboardController
 import com.tencent.kuikly.compose.ui.text.TextStyle
 import com.tencent.kuikly.compose.ui.text.input.ImeAction
 import com.tencent.kuikly.compose.ui.text.input.KeyboardType
+import com.tencent.kuikly.compose.ui.text.input.TextFieldValue
 import com.tencent.kuikly.compose.ui.unit.dp
 import com.tencent.kuikly.compose.ui.unit.sp
 import com.tencent.kuikly.core.annotations.Page
@@ -169,6 +171,113 @@ class TextFieldDemo : ComposeContainer() {
                                     text2 = ""
                                 },
                             )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+                    var programmaticUpdateText by remember { mutableStateOf("把光标移到中间后点按钮") }
+                    Text(text = "1.1 BasicTextField(value:String) 程序化更新 value 后观察光标：$programmaticUpdateText")
+                    Box(
+                        modifier = Modifier.fillMaxWidth()
+                            .border(1.dp, color = Color.Black)
+                            .padding(12.dp)
+                    ) {
+                        BasicTextField(
+                            cursorBrush = SolidColor(Color.Red),
+                            value = programmaticUpdateText,
+                            onValueChange = {
+                                programmaticUpdateText = it
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true,
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row {
+                        Button(
+                            onClick = {
+                                programmaticUpdateText += " +追加"
+                            }
+                        ) {
+                            Text("程序追加")
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Button(
+                            onClick = {
+                                programmaticUpdateText = "整体替换后的新文本"
+                            }
+                        ) {
+                            Text("整体替换")
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Button(
+                            onClick = {
+                                programmaticUpdateText = ""
+                            }
+                        ) {
+                            Text("清空")
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+                    var legacyProgrammaticText by remember { mutableStateOf("把光标移到中间后点按钮") }
+                    var legacyEditorValue by remember { mutableStateOf(TextFieldValue(text = legacyProgrammaticText)) }
+                    val legacyTextFieldValue = if (legacyProgrammaticText != legacyEditorValue.text) {
+                        legacyEditorValue.copy(text = legacyProgrammaticText)
+                    } else {
+                        legacyEditorValue
+                    }
+                    SideEffect {
+                        if (legacyTextFieldValue.text != legacyEditorValue.text ||
+                            legacyTextFieldValue.selection != legacyEditorValue.selection ||
+                            legacyTextFieldValue.composition != legacyEditorValue.composition
+                        ) {
+                            legacyEditorValue = legacyTextFieldValue
+                        }
+                    }
+                    Text(text = "1.2 修复前行为模拟：程序化更新后保留旧光标")
+                    Box(
+                        modifier = Modifier.fillMaxWidth()
+                            .border(1.dp, color = Color.Black)
+                            .padding(12.dp)
+                    ) {
+                        BasicTextField(
+                            cursorBrush = SolidColor(Color.Red),
+                            value = legacyTextFieldValue,
+                            onValueChange = {
+                                legacyEditorValue = it
+                                if (legacyProgrammaticText != it.text) {
+                                    legacyProgrammaticText = it.text
+                                }
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true,
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row {
+                        Button(
+                            onClick = {
+                                legacyProgrammaticText += " +追加"
+                            }
+                        ) {
+                            Text("程序追加")
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Button(
+                            onClick = {
+                                legacyProgrammaticText = "整体替换后的新文本"
+                            }
+                        ) {
+                            Text("整体替换")
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Button(
+                            onClick = {
+                                legacyProgrammaticText = ""
+                            }
+                        ) {
+                            Text("清空")
                         }
                     }
 


### PR DESCRIPTION
## Summary
- move the cursor to the end when `BasicTextField(value: String)` receives a programmatic external value update
- keep manual input behavior unchanged while making String overload cursor behavior deterministic
- add `TextFieldDemo` cases for the fixed behavior and the legacy behavior comparison

## Verification
- bash ./gradlew :compose:compileDebugKotlinAndroid
- bash ./gradlew :demo:compileDebugKotlinAndroid
- install Android demo app and verify the `TextFieldDemo` comparison cases on device