### PR TITLE
fix(ohos): avoid legacy foreground draw for styled rich text

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
@@ -108,7 +108,9 @@ void KRRichTextView::SetShadow(const std::shared_ptr<IKRRenderShadowExport> &sha
     // shadow->StyledStringEnabled()（含 image span 时返 false），本处只读一个结果。
     bool use_styled_string = textShadow && textShadow->StyledStringEnabled();
     bool has_image_span = textShadow && textShadow->HasImageSpans();
+    use_styled_string_ = use_styled_string;
     if(use_styled_string){
+        KREventDispatchCenter::GetInstance().UnregisterCustomEvent(shared_from_this());
         ArkUI_AttributeItem item;
         if(std::shared_ptr<KRParagraph> paragraph = std::dynamic_pointer_cast<KRRichTextShadow>(shadow)->GetParagraph()){
             item.object = paragraph->GetStyledString();
@@ -122,6 +124,8 @@ void KRRichTextView::SetShadow(const std::shared_ptr<IKRRenderShadowExport> &sha
             paragraph_ = paragraph;
         }
     }else {
+        kuikly::util::GetNodeApi()->resetAttribute(GetNode(), NODE_TEXT_CONTENT_WITH_STYLED_STRING);
+        paragraph_ = nullptr;
         KREventDispatchCenter::GetInstance().RegisterCustomEvent(shared_from_this(), ARKUI_NODE_CUSTOM_EVENT_ON_FOREGROUND_DRAW);
         kuikly::util::GetNodeApi()->markDirty(GetNode(), NODE_NEED_RENDER);
     }
@@ -144,6 +148,9 @@ void KRRichTextView::SetShadow(const std::shared_ptr<IKRRenderShadowExport> &sha
 
 void KRRichTextView::DidMoveToParentView() {
     IKRRenderViewExport::DidMoveToParentView();
+    if (use_styled_string_) {
+        return;
+    }
     auto self = shared_from_this();
     KREventDispatchCenter::GetInstance().RegisterCustomEvent(self, ARKUI_NODE_CUSTOM_EVENT_ON_FOREGROUND_DRAW);
 }
@@ -153,10 +160,14 @@ void KRRichTextView::DidRemoveFromParentView() {
     IKRRenderViewExport::DidRemoveFromParentView();
     shadow_ = nullptr;
     paragraph_ = nullptr;
+    use_styled_string_ = false;
     last_draw_frame_width_ = -1.0;
 }
 
 void KRRichTextView::OnForegroundDraw(ArkUI_NodeCustomEvent *event) {
+    if (use_styled_string_) {
+        return;
+    }
     if (shadow_ == nullptr && GetFrame().width == 0) {
         KR_LOG_ERROR << "OnForegroundDraw, shadow or frame not ready, shadow:" << shadow_.get()
                      << ", frame width:" << GetFrame().width;
@@ -740,4 +751,3 @@ bool KRRichTextView::UpdateSelection(std::shared_ptr<IKRRenderViewExport> ancest
 
     return has_intersection;
 }
-

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.h
@@ -166,6 +166,7 @@ class KRRichTextView : public IKRRenderViewExport {
  private:
     std::shared_ptr<KRParagraph> paragraph_;
     std::shared_ptr<IKRRenderShadowExport> shadow_;
+    bool use_styled_string_ = false;
     float last_draw_frame_width_ = -1.0;
     float line_break_margin_ = 0;
     KRParagraphSelectionInfo selection_rects_;


### PR DESCRIPTION
用了 kuikly markdown 渲染这个库之后，渲染的时候非常非常卡，日志里可以看到下面这个消息再刷屏，让 Codex 修复了一下，Codex 修完就不卡了：

```
06-18 18:23:11.258 39582-39582 C01408/xxxxx/Text xxxxxx W generatePaintRegion: Call generatePaintRegion when paragraph is not formatted
06-18 18:23:11.259 39582-39582 C01408/xxxxxx/Text xxxxxx W generatePaintRegion: Call generatePaintRegion when paragraph is not formatted
06-18 18:23:11.260 39582-39582 C01408/xxxxxx/Text xxxxxx W generatePaintRegion: Call generatePaintRegion when paragraph is not formatted
```

### 概要

这个 PR 修复 OHOS `KRRichTextView` 的渲染路径边界：当富文本已经走 V2 StyledString / ArkUI Text 渲染时，不再同时进入旧的 foreground draw typography 手动绘制路径。

### 背景

`KRRichTextView` 目前有两条富文本渲染路径：

- **StyledString / ArkUI Text 路径**：通过 `NODE_TEXT_CONTENT_WITH_STYLED_STRING` 把 styled string 交给 ArkUI Text，由 ArkUI Text 负责 layout 和 paint。
- **旧 typography foreground draw 路径**：Kuikly 监听 `ARKUI_NODE_CUSTOM_EVENT_ON_FOREGROUND_DRAW`，在 foreground draw 中手动 paint typography。

这两条路径的绘制所有权应该互斥。问题在于，节点走 StyledString 路径后，旧的 foreground draw callback 仍可能被注册/触发，导致同一段富文本同时被 ArkUI Text 和 Kuikly foreground draw 两套链路处理。foreground draw 可能在该路径的 paragraph 完成 format/layout 前触发，于是产生 `paragraph is not formatted` / `generatePaintRegion before paragraph formatted` 这类重复 warning。

因此这个修复点是 OHOS rich-text 组件内部的渲染所有权边界，不是 Markdown parser 的专项性能修复。

### 修改内容

- 在 `KRRichTextView` 内记录当前是否走 StyledString 路径。
- StyledString 启用时，设置 `NODE_TEXT_CONTENT_WITH_STYLED_STRING`，并 unregister/跳过旧的 foreground draw callback。
- 回退到旧 typography 路径时，清理 StyledString attribute，并按原逻辑注册 foreground draw。
- `DidMoveToParentView()` 中也遵守 StyledString 状态，避免节点挂载时再次无条件注册 foreground draw。
- View 移除时重置 StyledString 状态，避免复用时串状态。

### 为什么这样修

- 不是过滤/压制日志，而是去掉 StyledString 节点上那次不该发生的额外 foreground draw。
- 不在 foreground draw 中强制 format/layout，因为那仍然是在混用 ArkUI Text 和 Kuikly 手动绘制两套所有权模型。
- 不禁用 StyledString，也不改变旧 typography 路径。
- 非 StyledString 内容，包括 image span fallback，仍然保持原有 foreground draw 行为。

### 验证

- `git diff --check`
- `ohpm install --all --strict_ssl true`
- `DEVECO_SDK_HOME=/Applications/DevEco-Studio.app/Contents/sdk hvigorw assembleHar --mode module -p module=render@default -p product=default -p buildMode=release --no-daemon`
