### PR TITLE
fix(android): fix safeAreaInsets.bottom inflated by IME height when soft keyboard shows

### DIFF
--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/KuiklyRenderView.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/KuiklyRenderView.kt
@@ -722,14 +722,10 @@ class KuiklyRenderView(
             private fun getInsetsByPublicApi(view: View): InsetsPx {
                 return try {
                     val windowInsets = view.rootWindowInsets ?: return InsetsPx.ZERO
-                    val left = if (windowInsets.stableInsetLeft > 0) windowInsets.stableInsetLeft
-                        else windowInsets.systemWindowInsetLeft
-                    val top = if (windowInsets.stableInsetTop > 0) windowInsets.stableInsetTop
-                        else windowInsets.systemWindowInsetTop
-                    val right = if (windowInsets.stableInsetRight > 0) windowInsets.stableInsetRight
-                        else windowInsets.systemWindowInsetRight
-                    val bottom = if (windowInsets.stableInsetBottom > 0) windowInsets.stableInsetBottom
-                        else windowInsets.systemWindowInsetBottom
+                    val left = windowInsets.stableInsetLeft
+                    val top = windowInsets.stableInsetTop
+                    val right = windowInsets.stableInsetRight
+                    val bottom = windowInsets.stableInsetBottom
                     InsetsPx(left, top, right, bottom)
                 } catch (e: Throwable) {
                     KuiklyRenderLog.e(TAG, "getInsetsByPublicApi failed: ${e.message}")


### PR DESCRIPTION
## Problem

On Android, when the soft keyboard appears, `safeAreaInsets.bottom` jumps to the keyboard height (e.g. 300dp), causing views that use bottom safe area (e.g. TabBar) to be pushed up unexpectedly.

## Root Cause

In `SafeAreaCompat.getInsetsByPublicApi`, the fallback logic was:

\`\`\`kotlin
val bottom = if (windowInsets.stableInsetBottom > 0) windowInsets.stableInsetBottom
    else windowInsets.systemWindowInsetBottom  // ⚠️ includes IME height
\`\`\`

On devices using gesture navigation, `stableInsetBottom == 0` (no navigation bar), so the fallback to `systemWindowInsetBottom` was always triggered. When the soft keyboard is visible, `systemWindowInsetBottom` includes the IME height, which was incorrectly reported as the safe area bottom inset.

## Fix

Use `stableInset*` directly for all four directions — it only reflects stable system UI (status bar, navigation bar) and never includes IME height:

\`\`\`kotlin
val left   = windowInsets.stableInsetLeft
val top    = windowInsets.stableInsetTop
val right  = windowInsets.stableInsetRight
val bottom = windowInsets.stableInsetBottom
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)