### PR TITLE
feat(compose): support minLines parameter in Text component

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/BasicText.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/BasicText.kt
@@ -26,17 +26,10 @@ import androidx.compose.runtime.remember
 import com.tencent.kuikly.compose.KuiklyApplier
 import com.tencent.kuikly.compose.foundation.text.modifiers.TextStringRichElement
 import com.tencent.kuikly.compose.material3.EmptyInlineContent
-import com.tencent.kuikly.compose.resources.toKuiklyFontFamily
 import com.tencent.kuikly.compose.ui.ExperimentalComposeUiApi
 import com.tencent.kuikly.compose.ui.Modifier
-import com.tencent.kuikly.compose.ui.geometry.Offset
 import com.tencent.kuikly.compose.ui.geometry.Rect
-import com.tencent.kuikly.compose.ui.graphics.Color
 import com.tencent.kuikly.compose.ui.graphics.ColorProducer
-import com.tencent.kuikly.compose.ui.graphics.LinearGradient
-import com.tencent.kuikly.compose.ui.graphics.Shadow
-import com.tencent.kuikly.compose.ui.graphics.SolidColor
-import com.tencent.kuikly.compose.ui.graphics.isSpecified
 import com.tencent.kuikly.compose.ui.layout.Layout
 import com.tencent.kuikly.compose.ui.layout.Measurable
 import com.tencent.kuikly.compose.ui.layout.MeasurePolicy
@@ -49,34 +42,15 @@ import com.tencent.kuikly.compose.ui.node.KNode
 import com.tencent.kuikly.compose.ui.platform.LocalDensity
 import com.tencent.kuikly.compose.ui.platform.LocalLayoutDirection
 import com.tencent.kuikly.compose.ui.text.AnnotatedString
-import com.tencent.kuikly.compose.ui.text.LinkAnnotation
-import com.tencent.kuikly.compose.ui.text.SpanStyle
 import com.tencent.kuikly.compose.ui.text.TextLayoutResult
 import com.tencent.kuikly.compose.ui.text.TextStyle
-import com.tencent.kuikly.compose.ui.text.font.FontFamily
-import com.tencent.kuikly.compose.ui.text.font.FontListFontFamily
-import com.tencent.kuikly.compose.ui.text.font.FontStyle
-import com.tencent.kuikly.compose.ui.text.font.FontWeight
-import com.tencent.kuikly.compose.ui.text.font.GenericFontFamily
 import com.tencent.kuikly.compose.ui.text.resolveDefaults
-import com.tencent.kuikly.compose.ui.text.style.TextAlign
-import com.tencent.kuikly.compose.ui.text.style.TextDecoration
-import com.tencent.kuikly.compose.ui.text.style.TextIndent
 import com.tencent.kuikly.compose.ui.text.style.TextOverflow
 import com.tencent.kuikly.compose.ui.unit.Constraints
-import com.tencent.kuikly.compose.ui.unit.Density
 import com.tencent.kuikly.compose.ui.unit.IntOffset
-import com.tencent.kuikly.compose.ui.unit.isSpecified
 import com.tencent.kuikly.compose.ui.util.fastRoundToInt
-import com.tencent.kuikly.compose.extension.scaleToDensity
 import com.tencent.kuikly.compose.ui.platform.LocalConfiguration
-import com.tencent.kuikly.core.views.ISpan
-import com.tencent.kuikly.core.views.PlaceholderSpan
-import com.tencent.kuikly.core.views.RichTextAttr
 import com.tencent.kuikly.core.views.RichTextView
-import com.tencent.kuikly.core.views.TextAttr
-import com.tencent.kuikly.core.views.TextConst
-import com.tencent.kuikly.core.views.TextSpan
 import kotlin.math.floor
 
 /**
@@ -217,6 +191,7 @@ private fun _BasicText(
             overflow,
             softWrap,
             maxLines,
+            minLines,
             onTextLayout,
             inlineContent,
             modifier,
@@ -256,6 +231,7 @@ private fun LayoutWithLinksAndInlineContent(
                 overflow = overflow,
                 softWrap = softWrap,
                 maxLines = maxLines,
+                minLines = minLines,
                 onTextLayout = { result ->
                     // 获取 placeholder 的位置信息
                     measuredPlaceholderPositions.value = result.placeholderRects
@@ -331,6 +307,7 @@ private fun BasicTextWithNoInlinContent(
     overflow: TextOverflow,
     softWrap: Boolean,
     maxLines: Int,
+    minLines: Int,
     onTextLayout: ((TextLayoutResult) -> Unit)?,
     inlineContent: Map<String, InlineTextContent>,
     modifier: Modifier,
@@ -357,13 +334,22 @@ private fun BasicTextWithNoInlinContent(
         overflow = overflow,
         softWrap = softWrap,
         maxLines = maxLines,
+        minLines = minLines,
         onTextLayout = onTextLayout,
         inlineContent = inlineContent,
         fontSizeScale = fontSizeScale,
         fontWeightScale = fontWeightScale
     )
 
-    val materializedModifier = currentComposer.materialize(modifier then textElement)
+    val materializedModifier = currentComposer.materialize(
+        modifier
+            .heightInLines(
+                textStyle = finalStyle,
+                minLines = minLines,
+                maxLines = maxLines
+            )
+            .then(textElement)
+    )
 
     ReusableComposeNode<ComposeUiNode, KuiklyApplier>(
         factory = {

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/HeightInLinesModifier.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/HeightInLinesModifier.kt
@@ -16,9 +16,136 @@
 
 package com.tencent.kuikly.compose.foundation.text
 
+import com.tencent.kuikly.compose.ui.Modifier
+import com.tencent.kuikly.compose.ui.layout.Measurable
+import com.tencent.kuikly.compose.ui.layout.MeasureResult
+import com.tencent.kuikly.compose.ui.layout.MeasureScope
+import com.tencent.kuikly.compose.ui.node.LayoutModifierNode
+import com.tencent.kuikly.compose.ui.node.ModifierNodeElement
+import com.tencent.kuikly.compose.ui.platform.InspectorInfo
+import com.tencent.kuikly.compose.ui.text.TextStyle
+import com.tencent.kuikly.compose.ui.unit.Constraints
+import com.tencent.kuikly.compose.ui.unit.TextUnitType
+import com.tencent.kuikly.compose.ui.unit.isSpecified
+import com.tencent.kuikly.compose.ui.unit.sp
+import kotlin.math.max
+
 /**
  * The default minimum height in terms of minimum number of visible lines.
  *
  * Should not be used in public API and samples unless it's public, too.
  */
 internal const val DefaultMinLines = 1
+
+/**
+ * Constraint the height of the text field so that it minLines and maxLines are honored.
+ */
+internal fun Modifier.heightInLines(
+    textStyle: TextStyle,
+    minLines: Int = DefaultMinLines,
+    maxLines: Int = Int.MAX_VALUE
+): Modifier = this.then(
+    HeightInLinesElement(
+        minLines = minLines,
+        maxLines = maxLines,
+        textStyle = textStyle
+    )
+)
+
+private class HeightInLinesElement(
+    val minLines: Int,
+    val maxLines: Int,
+    val textStyle: TextStyle
+) : ModifierNodeElement<HeightInLinesModifierNode>() {
+    override fun create(): HeightInLinesModifierNode = HeightInLinesModifierNode(
+        minLines = minLines,
+        maxLines = maxLines,
+        textStyle = textStyle
+    )
+
+    override fun update(node: HeightInLinesModifierNode) {
+        node.update(
+            minLines = minLines,
+            maxLines = maxLines,
+            textStyle = textStyle
+        )
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "heightInLines"
+        properties["minLines"] = minLines
+        properties["maxLines"] = maxLines
+        properties["textStyle"] = textStyle
+    }
+
+    override fun hashCode(): Int {
+        var result = minLines
+        result = 31 * result + maxLines
+        result = 31 * result + textStyle.hashCode()
+        return result
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is HeightInLinesElement) return false
+
+        if (minLines != other.minLines) return false
+        if (maxLines != other.maxLines) return false
+        return textStyle == other.textStyle
+    }
+}
+
+private class HeightInLinesModifierNode(
+    var minLines: Int,
+    var maxLines: Int,
+    var textStyle: TextStyle
+) : Modifier.Node(), LayoutModifierNode {
+
+    fun update(
+        minLines: Int,
+        maxLines: Int,
+        textStyle: TextStyle
+    ) {
+        this.minLines = minLines
+        this.maxLines = maxLines
+        this.textStyle = textStyle
+    }
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints
+    ): MeasureResult {
+        // Compute min and max height in lines
+        val lineHeightPx = if (textStyle.lineHeight.isSpecified && textStyle.lineHeight.type == TextUnitType.Sp) {
+            textStyle.lineHeight.toPx()
+        } else {
+            // Fallback: If lineHeight is not specified or not Sp, use fontSize * 1.2 as a rough estimate
+            val fontSize = if (textStyle.fontSize.isSpecified && textStyle.fontSize.type == TextUnitType.Sp) {
+                textStyle.fontSize
+            } else {
+                14.sp // Ultimate fallback
+            }
+            fontSize.toPx() * 1.2f
+        }
+
+        val minHeight = if (minLines > 1) {
+            (lineHeightPx * minLines).toInt()
+        } else {
+            0
+        }
+        val maxHeight = if (maxLines != Int.MAX_VALUE) {
+            (lineHeightPx * maxLines).toInt()
+        } else {
+            constraints.maxHeight
+        }
+
+        val childConstraints = constraints.copy(
+            minHeight = max(constraints.minHeight, minHeight),
+            maxHeight = max(max(constraints.minHeight, minHeight), maxHeight)
+        )
+        val placeable = measurable.measure(childConstraints)
+        return layout(placeable.width, placeable.height) {
+            placeable.placeRelative(0, 0)
+        }
+    }
+}

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/HeightInLinesModifier.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/HeightInLinesModifier.kt
@@ -28,6 +28,7 @@ import com.tencent.kuikly.compose.ui.unit.Constraints
 import com.tencent.kuikly.compose.ui.unit.TextUnitType
 import com.tencent.kuikly.compose.ui.unit.isSpecified
 import com.tencent.kuikly.compose.ui.unit.sp
+import kotlin.math.ceil
 import kotlin.math.max
 
 /**
@@ -38,19 +39,30 @@ import kotlin.math.max
 internal const val DefaultMinLines = 1
 
 /**
+ * The default font size used for line height calculation when no font size is specified.
+ */
+private val DefaultFontSizeForLineHeight = 14.sp
+
+/**
  * Constraint the height of the text field so that it minLines and maxLines are honored.
  */
 internal fun Modifier.heightInLines(
     textStyle: TextStyle,
     minLines: Int = DefaultMinLines,
     maxLines: Int = Int.MAX_VALUE
-): Modifier = this.then(
-    HeightInLinesElement(
-        minLines = minLines,
-        maxLines = maxLines,
-        textStyle = textStyle
+): Modifier {
+    require(minLines >= 1) { "minLines must be >= 1, got $minLines" }
+    require(maxLines >= 1) { "maxLines must be >= 1, got $maxLines" }
+    require(minLines <= maxLines) { "minLines must be <= maxLines, got minLines=$minLines, maxLines=$maxLines" }
+
+    return this.then(
+        HeightInLinesElement(
+            minLines = minLines,
+            maxLines = maxLines,
+            textStyle = textStyle
+        )
     )
-)
+}
 
 private class HeightInLinesElement(
     val minLines: Int,
@@ -123,18 +135,18 @@ private class HeightInLinesModifierNode(
             val fontSize = if (textStyle.fontSize.isSpecified && textStyle.fontSize.type == TextUnitType.Sp) {
                 textStyle.fontSize
             } else {
-                14.sp // Ultimate fallback
+                DefaultFontSizeForLineHeight // Material3 default fallback
             }
             fontSize.toPx() * 1.2f
         }
 
         val minHeight = if (minLines > 1) {
-            (lineHeightPx * minLines).toInt()
+            ceil(lineHeightPx * minLines).toInt()
         } else {
             0
         }
         val maxHeight = if (maxLines != Int.MAX_VALUE) {
-            (lineHeightPx * maxLines).toInt()
+            ceil(lineHeightPx * maxLines).toInt()
         } else {
             constraints.maxHeight
         }

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/material3/Text.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/material3/Text.kt
@@ -36,7 +36,6 @@ import com.tencent.kuikly.compose.ui.text.style.TextAlign
 import com.tencent.kuikly.compose.ui.text.style.TextDecoration
 import com.tencent.kuikly.compose.ui.text.style.TextOverflow
 import com.tencent.kuikly.compose.ui.unit.TextUnit
-import com.tencent.kuikly.compose.ui.unit.sp
 
 /**
  * High level element that displays text and provides semantics / accessibility information.
@@ -104,7 +103,7 @@ fun Text(
     overflow: TextOverflow = TextOverflow.Clip,
     softWrap: Boolean = true,
     maxLines: Int = Int.MAX_VALUE,
-    minLines: Int = 1, // 暂时不支持
+    minLines: Int = 1,
     onTextLayout: ((TextLayoutResult) -> Unit)? = null,
     style: TextStyle = LocalTextStyle.current
 ) {
@@ -205,7 +204,7 @@ fun Text(
     overflow: TextOverflow = TextOverflow.Clip,
     softWrap: Boolean = true,
     maxLines: Int = Int.MAX_VALUE,
-    minLines: Int = 1, // TODO: jonas
+    minLines: Int = 1,
     inlineContent: Map<String, InlineTextContent> = EmptyInlineContent,
     onTextLayout: (TextLayoutResult) -> Unit = {},
     style: TextStyle = LocalTextStyle.current

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/ComposeAllSample.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/ComposeAllSample.kt
@@ -165,6 +165,7 @@ internal class ComposeAllSample : ComposeContainer() {
             DemoItem("InteractionSourceDemo", "交互源Demo", "InteractionSourceDemo"),
             DemoItem("ViewModel示例", "Lifecycle和ViewModel", "ViewModelDemo"),
             DemoItem("GradientAnimationDemo", "Offset or color animate ", "GradientAnimationDemo"),
+            DemoItem("Text minLines", "Text minLines 属性支持验证", "TextMinLinesDemo"),
             DemoItem("重组性能分析", "RecompositionProfiler追踪重组热点", "RecompositionProfilerDemo"),
             DemoItem("TextFieldEmoji", "TextField 自定义表情示例（暂不支持鸿蒙）", "TextFieldEmojiDemo"),
             DemoItem("MoveableDrawer", "侧边栏组件示例（全屏/非全屏）", "MoveableDrawerDemo"),

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/TextMinLinesDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/TextMinLinesDemo.kt
@@ -1,0 +1,199 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.demo.pages.compose
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.tencent.kuikly.compose.ComposeContainer
+import com.tencent.kuikly.compose.foundation.background
+import com.tencent.kuikly.compose.foundation.clickable
+import com.tencent.kuikly.compose.foundation.layout.Arrangement
+import com.tencent.kuikly.compose.foundation.layout.Column
+import com.tencent.kuikly.compose.foundation.layout.Spacer
+import com.tencent.kuikly.compose.foundation.layout.fillMaxSize
+import com.tencent.kuikly.compose.foundation.layout.fillMaxWidth
+import com.tencent.kuikly.compose.foundation.layout.height
+import com.tencent.kuikly.compose.foundation.layout.padding
+import com.tencent.kuikly.compose.foundation.lazy.LazyColumn
+import com.tencent.kuikly.compose.material3.Text
+import com.tencent.kuikly.compose.setContent
+import com.tencent.kuikly.compose.ui.Modifier
+import com.tencent.kuikly.compose.ui.graphics.Color
+import com.tencent.kuikly.compose.ui.text.font.FontWeight
+import com.tencent.kuikly.compose.ui.unit.dp
+import com.tencent.kuikly.compose.ui.unit.sp
+import com.tencent.kuikly.core.annotations.Page
+
+@Page("TextMinLinesDemo")
+class TextMinLinesDemo : ComposeContainer() {
+    override fun willInit() {
+        super.willInit()
+        setContent {
+            ComposeNavigationBar("Text minLines Support") {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.White)
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    item {
+                        Text(
+                            text = "Text minLines Verification",
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+
+                    // 1. Single line text with minLines = 3
+                    item {
+                        Column {
+                            Text("1. Short text, minLines = 3 (Should have 3-line height)")
+                            Text(
+                                text = "This is short text.",
+                                minLines = 3,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(Color.LightGray)
+                            )
+                        }
+                    }
+
+                    // 2. Multi-line text with minLines = 2
+                    item {
+                        Column {
+                            Text("2. Multi-line text, minLines = 2 (Should grow naturally)")
+                            Text(
+                                text = "This is a longer text that will definitely span more than one line to see if it grows correctly beyond minLines.",
+                                minLines = 2,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(Color.Yellow)
+                            )
+                        }
+                    }
+
+                    // 3. minLines and maxLines combined
+                    item {
+                        Column {
+                            Text("3. minLines = 2, maxLines = 4")
+                            var text by remember { mutableStateOf("Initial text.") }
+                            Text(
+                                text = text,
+                                minLines = 2,
+                                maxLines = 4,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(Color(0xFFE3F2FD))
+                                    .clickable {
+                                        text += " Adding more text to trigger more lines."
+                                    }
+                            )
+                            Text("Click text to add content", fontSize = 12.sp, color = Color.Gray)
+                        }
+                    }
+
+                    // 4. Comparison
+                    item {
+                        Column {
+                            Text("4. Comparison: Top (minLines=1), Bottom (minLines=3)")
+                            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Text(
+                                    "No minLines",
+                                    modifier = Modifier.background(Color.Green.copy(alpha = 0.2f))
+                                )
+                                Text(
+                                    "With minLines=3",
+                                    minLines = 3,
+                                    modifier = Modifier.background(Color.Green.copy(alpha = 0.2f)).fillMaxWidth()
+                                )
+                            }
+                        }
+                    }
+                    
+                    // 5. Dynamic minLines
+                    item {
+                        Column {
+                            Text("5. Dynamic minLines")
+                            var minLines by remember { mutableStateOf(1) }
+                            Text(
+                                text = "Current minLines: $minLines. Click to increase.",
+                                minLines = minLines,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(Color(0xFFF1F8E9))
+                                    .clickable {
+                                        minLines = if (minLines >= 5) 1 else minLines + 1
+                                    }
+                                    .padding(4.dp)
+                            )
+                            Text("Click to cycle minLines (1-5)", fontSize = 12.sp, color = Color.Gray)
+                        }
+                    }
+
+                    // 6. Empty text with minLines
+                    item {
+                        Column {
+                            Text("6. Empty text, minLines = 2")
+                            Text(
+                                text = "",
+                                minLines = 2,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(Color(0xFFFFF3E0))
+                            )
+                            Text("Should still occupy 2 lines of height", fontSize = 12.sp, color = Color.Gray)
+                        }
+                    }
+
+                    // 7. minLines with custom lineHeight
+                    item {
+                        Column {
+                            Text("7. minLines = 2 with large lineHeight (30.sp)")
+                            Text(
+                                text = "Line height test.",
+                                minLines = 2,
+                                lineHeight = 30.sp,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(Color(0xFFF3E5F5))
+                            )
+                        }
+                    }
+
+                    // 8. minLines with different font sizes
+                    item {
+                        Column {
+                            Text("8. minLines = 2 with large fontSize (24.sp)")
+                            Text(
+                                text = "Large font.",
+                                minLines = 2,
+                                fontSize = 24.sp,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .background(Color(0xFFE0F7FA))
+                            )
+                        }
+                    }
+
+                    item { Spacer(modifier = Modifier.height(32.dp)) }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Summary
Implemented minLines support for the Text component to ensure correct minimum height reservation when text content is short or empty.
Details
- Core Logic: Added Modifier.heightInLines to calculate and enforce minHeight based on TextStyle.lineHeight.
- Crash Fix: Resolved IllegalStateException in Density.toPx by adding safe unit conversion and fallbacks for Unspecified line heights.
- API Enablement: Enabled the minLines parameter in both BasicText and Material 3 Text APIs.
- Verification
- New Demo: Added TextMinLinesDemo.kt (titled "Text minLines" in the demo list).
- Verified scenarios: short text placeholder height, empty text height reservation, dynamic minLines switching, and combination with maxLines.
