### PR TITLE
fix(android): play touch sound effect on click

### DIFF
--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/gesture/KRCSSGestureDetector.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/gesture/KRCSSGestureDetector.kt
@@ -18,6 +18,7 @@ package com.tencent.kuikly.core.render.android.css.gesture
 import android.content.Context
 import android.view.GestureDetector
 import android.view.MotionEvent
+import android.view.SoundEffectConstants
 import android.view.View
 import com.tencent.kuikly.core.render.android.export.KuiklyRenderCallback
 import java.lang.ref.WeakReference
@@ -83,6 +84,11 @@ class KRCSSGestureDetector(
                         disallowParentInterceptEvent(true)
                     }
                 }
+                callback(it)
+            }
+        } else if (type == KRCSSGestureListener.TYPE_CLICK) {
+            listener.addListener(type) {
+                targetViewWeakRef.get()?.playSoundEffect(SoundEffectConstants.CLICK)
                 callback(it)
             }
         } else {


### PR DESCRIPTION
## 问题

在系统设置中开启「触屏提示音」后，Kuikly 界面点击无声音反馈，Android 原生控件正常响。

## 根因

`KRCSSGestureListener` 的点击分发路径（`onSingleTapUp` / `onSingleTapConfirmed`）直接调用内部 `dispatchEvent(TYPE_CLICK)`，**绕过了 `View.performClick()`**，导致系统触屏提示音所需的 `playSoundEffect(SoundEffectConstants.CLICK)` 从未被调用。

## 修复

在 `KRCSSGestureDetector.addListener` 中对 `TYPE_CLICK` 增加 callback 包装，在触发业务回调前调用 `targetViewWeakRef.get()?.playSoundEffect(SoundEffectConstants.CLICK)`。

- 复用已有的 `targetViewWeakRef`，无需修改 `KRCSSGestureListener`
- `View.playSoundEffect()` 内部自动遵守系统「触屏提示音」开关，不影响关闭状态
- 不影响无障碍（TalkBack 走 `performClick()` 路径，与本改动独立）