### PR TITLE
feat: support SPAN selection type for rich text across Android, iOS and OHOS

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/text/SelectionContainer.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/text/SelectionContainer.kt
@@ -45,7 +45,8 @@ enum class TextSelectionType {
     CHARACTER,
     WORD,
     PARAGRAPH,
-    SENTENCE
+    SENTENCE,
+    SPAN
 }
 
 /**
@@ -284,6 +285,7 @@ class SelectionContainerState internal constructor(
             TextSelectionType.WORD -> SelectionType.WORD
             TextSelectionType.PARAGRAPH -> SelectionType.PARAGRAPH
             TextSelectionType.SENTENCE -> SelectionType.SENTENCE
+            TextSelectionType.SPAN -> SelectionType.SPAN
         }
         // Convert pixels to points for rendering layer
         val pointX = x / density

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRRichTextView.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRRichTextView.kt
@@ -932,7 +932,8 @@ enum class SelectionType {
     CHARACTER,
     WORD,
     PARAGRAPH,
-    SENTENCE
+    SENTENCE,
+    SPAN
 }
 
 data class SelectionEdge(

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRTextSelector.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRTextSelector.kt
@@ -46,6 +46,7 @@ private const val SELECTION_TYPE_CHARACTER = 0
 private const val SELECTION_TYPE_WORD = 1
 private const val SELECTION_TYPE_PARAGRAPH = 2
 private const val SELECTION_TYPE_SENTENCE = 3
+private const val SELECTION_TYPE_SPAN = 4
 
 private inline fun logInfo(msg: () -> String) {
     if (DEBUG_LOG) {
@@ -424,6 +425,7 @@ internal class KRTextSelector(
             SELECTION_TYPE_WORD -> SelectionType.WORD
             SELECTION_TYPE_PARAGRAPH -> SelectionType.PARAGRAPH
             SELECTION_TYPE_SENTENCE -> SelectionType.SENTENCE
+            SELECTION_TYPE_SPAN -> SelectionType.SPAN
             else -> SelectionType.WORD
         }
 

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/text/KRRichTextViewDrawer.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/text/KRRichTextViewDrawer.kt
@@ -89,6 +89,8 @@ class KRRichTextViewDrawer(val textLayout: Layout) {
                     SelectionType.SENTENCE -> layout.expandSelectionToSentence(position, sentenceIterator)
 
                     SelectionType.PARAGRAPH -> layout.expandSelectionToParagraph(position)
+
+                    SelectionType.SPAN -> layout.expandSelectionToSpan(position, x, y)
                 }
                 setTextSelection(start, end)
                 return true
@@ -299,6 +301,53 @@ class KRRichTextViewDrawer(val textLayout: Layout) {
                 start -= Character.charCount(c)
             }
             return Pair(getUnitStart(start), getUnitEnd(end))
+        }
+
+        /**
+         * 根据触摸位置定位到富文本 Span，选中整个 Span 的文字范围。
+         *
+         * 富文本中每个 Span 都会被附加 [FontWeightSpan]（携带 spanIndex），
+         * 因此通过 [Spanned.getSpans] 查找该位置上的 FontWeightSpan，
+         * 再用 [Spanned.getSpanStart] / [Spanned.getSpanEnd] 获取 Span 的起止偏移。
+         *
+         * 如果当前位置不在任何 Span 范围内（如普通文本模式），回退到字符级选择。
+         */
+        private fun Layout.expandSelectionToSpan(
+            position: Int,
+            x: Float,
+            y: Float
+        ): Pair<Int, Int> {
+            val text = text
+            if (text is Spanned) {
+                val spans = text.getSpans(position, position, FontWeightSpan::class.java)
+                // 优先选取真正覆盖 position 的 Span（start <= position < end），
+                // 避免在两个 Span 交界处（position 恰好等于前一个 Span 的 end）误取相邻 Span。
+                for (span in spans) {
+                    val start = text.getSpanStart(span)
+                    val end = text.getSpanEnd(span)
+                    if (start <= position && position < end) {
+                        return Pair(start, end)
+                    }
+                }
+                // 边界兜底：position 恰好落在末尾等特殊位置时，选取 end 最接近 position 的有效 Span。
+                var bestSpan: FontWeightSpan? = null
+                var bestDist = Int.MAX_VALUE
+                for (span in spans) {
+                    val start = text.getSpanStart(span)
+                    val end = text.getSpanEnd(span)
+                    if (start < end) {
+                        val dist = kotlin.math.abs(end - position)
+                        if (dist < bestDist) {
+                            bestDist = dist
+                            bestSpan = span
+                        }
+                    }
+                }
+                if (bestSpan != null) {
+                    return Pair(text.getSpanStart(bestSpan), text.getSpanEnd(bestSpan))
+                }
+            }
+            return expandSelectionToCharacter(position, x, y)
         }
 
         private fun Layout.getPositionForOffset(

--- a/core-render-ios/Extension/TextSelection/KRTextSelectionHelper.h
+++ b/core-render-ios/Extension/TextSelection/KRTextSelectionHelper.h
@@ -27,7 +27,8 @@ typedef NS_ENUM(NSInteger, KRTextSelectionType) {
     KRTextSelectionTypeCharacter = 0,
     KRTextSelectionTypeWord = 1,
     KRTextSelectionTypeParagraph = 2,
-    KRTextSelectionTypeSentence = 3
+    KRTextSelectionTypeSentence = 3,
+    KRTextSelectionTypeSpan = 4
 };
 
 /// Delegate protocol for text selection events

--- a/core-render-ios/Extension/TextSelection/KRTextSelectionHelper.m
+++ b/core-render-ios/Extension/TextSelection/KRTextSelectionHelper.m
@@ -16,6 +16,7 @@
 #import "KRTextSelectionHelper.h"
 #import "KRTextSelectionAnchorView.h"
 #import "KRLabel.h"
+#import "KRRichTextView.h"
 #import "KRTextMagnifierView.h"
 #import "KRScrollView.h"
 #import "KRLogModule.h"
@@ -176,6 +177,10 @@ static void *KRTextSelectionContainerFrameObserverContext = &KRTextSelectionCont
                 // Expand to sentence
                 selectionRange = [self rangeOfSentenceAtIndex:charIndex inString:text];
                 break;
+            case KRTextSelectionTypeSpan:
+                // Expand to rich-text Span range via KuiklyIndexAttributeName
+                selectionRange = [self rangeOfSpanAtIndex:charIndex inLabel:touchedLabel];
+                break;
             default:
                 selectionRange = NSMakeRange(charIndex, 1);
                 break;
@@ -194,6 +199,40 @@ static void *KRTextSelectionContainerFrameObserverContext = &KRTextSelectionCont
         [KRLogModule logInfo:[NSString stringWithFormat:@"[TextSelection] selectAtPoint:(%.1f,%.1f) type:%ld range:(%ld,%ld)",
                               point.x, point.y, (long)type, (long)selectionRange.location, (long)selectionRange.length]];
     }
+}
+
+/// Find the rich-text Span range at the given character index.
+/// Uses -attribute:atIndex:longestEffectiveRange:inRange: to directly obtain the range
+/// over which KuiklyIndexAttributeName keeps the same value (i.e. the containing span),
+/// avoiding a full-string enumeration.
+/// Falls back to the composed character sequence at charIndex when no span is found, so
+/// the fallback stays character-level and safe for emoji / surrogate pairs (aligned with
+/// the Android fallback behaviour).
+- (NSRange)rangeOfSpanAtIndex:(NSInteger)charIndex inLabel:(KRLabel *)label {
+    NSAttributedString *attributedText = label.attributedText;
+    if (attributedText == nil || attributedText.length == 0) {
+        return NSMakeRange(0, 0);
+    }
+    NSUInteger textLength = attributedText.length;
+    // Clamp charIndex to valid range
+    NSInteger idx = charIndex;
+    if (idx < 0) {
+        idx = 0;
+    }
+    if ((NSUInteger)idx >= textLength) {
+        idx = (NSInteger)textLength - 1;
+    }
+
+    NSRange effectiveRange = NSMakeRange(NSNotFound, 0);
+    id value = [attributedText attribute:KuiklyIndexAttributeName
+                                 atIndex:(NSUInteger)idx
+                   longestEffectiveRange:&effectiveRange
+                                 inRange:NSMakeRange(0, textLength)];
+    if (value != nil && effectiveRange.length > 0) {
+        return effectiveRange;
+    }
+    // No span found, fall back to the composed character sequence at idx.
+    return [attributedText.string rangeOfComposedCharacterSequenceAtIndex:(NSUInteger)idx];
 }
 
 - (void)selectAll {

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
@@ -431,6 +431,21 @@ std::pair<int, int> KRParagraphInfo::GetParagraphBoundary(int offset) {
     return std::make_pair(offset, offset);
 }
 
+// Returns the half-open interval [begin, end) of the span that contains `offset`.
+// span_offsets_ entries are tuples of (span_index, begin_offset, end_offset) where
+// end_offset is exclusive. When no span contains `offset`, returns an empty range
+// (offset, offset) so callers can treat span_start == span_end as "no span found".
+std::pair<int, int> KRParagraphInfo::GetSpanBoundary(int offset) {
+    for (const auto &span_off : span_offsets_) {
+        int begin = std::get<1>(span_off);
+        int end = std::get<2>(span_off);
+        if (offset >= begin && offset < end) {
+            return std::make_pair(begin, end);
+        }
+    }
+    return std::make_pair(offset, offset);
+}
+
 KRParagraphSelectionInfo KRParagraphInfo::GetSelectionRectsAll() {
     float density = KRConfig::GetDpi();
     std::vector<KRRect> selected_rect_list;
@@ -455,7 +470,6 @@ KRParagraphSelectionInfo KRParagraphInfo::GetSelectionRectsAll() {
 }
 
 KRParagraphSelectionInfo KRParagraphInfo::GetSelectionRects2(KRPoint p0, KRPoint p1, int type) {
-    (void)type;
     float density = KRConfig::GetDpi();
     auto points = std::array{p0, p1};
     int line_numbers[2];
@@ -518,6 +532,60 @@ KRParagraphSelectionInfo KRParagraphInfo::GetSelectionRects2(KRPoint p0, KRPoint
         std::swap(first_line_text_offset, last_line_text_offset);
         std::swap(first_line_text_is_first_in_line, last_line_text_is_first_in_line);
         std::swap(first_line_text_is_last_in_line, last_line_text_is_last_in_line);
+    }
+
+    // SPAN type: expand the selection to the whole span that contains the touched offset.
+    // GetSpanBoundary returns a half-open interval [span_start, span_end).
+    if (type == KRTextSelectionType::SPAN && first_line_text_offset >= 0) {
+        auto [span_start, span_end] = GetSpanBoundary(first_line_text_offset);
+        if (span_start < span_end) {
+            first_line_text_offset = span_start;
+            // Keep last_line_text_offset inclusive (it points at the last selected char).
+            // info.end below re-adds +1 to convert it back into the exclusive span_end.
+            last_line_text_offset = span_end - 1;
+
+            // The is_first/is_last/which_part flags were derived from the raw touch points
+            // and no longer describe the span range. Reset them so the rect-building logic
+            // always takes the "has-width" branches: this guarantees a non-zero-width
+            // selection rect and, in turn, info.end == span_end (never off-by-one).
+            first_line_text_is_first_in_line = false;
+            first_line_text_is_last_in_line = false;
+            last_line_text_is_first_in_line = false;
+            last_line_text_is_last_in_line = false;
+            which_part_of_first_line_text = SelectionStrategy::Leading;
+            which_part_of_last_line_text = SelectionStrategy::Trailing;
+
+            // Recalculate the line range that covers [span_start, span_end - 1].
+            // The start line must lock onto the FIRST matching line: at a soft-wrap
+            // boundary an offset can satisfy both line i (as BackOffset) and line i+1
+            // (as startIndex), so without this guard the start line would be pushed
+            // one line too far.
+            line_numbers[0] = 0;
+            line_numbers[1] = static_cast<int>(line_info_list_.size()) - 1;
+            bool first_line_found = false;
+            for (size_t i = 0; i < line_info_list_.size(); ++i) {
+                const auto &metrics = line_info_list_[i].line_metrics_;
+                // BackOffset() returns the last character offset of this line
+                // (inclusive), i.e. the line covers [startIndex, BackOffset()].
+                int back_offset = line_info_list_[i].BackOffset();
+                if (!first_line_found && first_line_text_offset >= metrics.startIndex &&
+                    first_line_text_offset <= back_offset) {
+                    line_numbers[0] = static_cast<int>(i);
+                    first_line_found = true;
+                }
+                if (last_line_text_offset >= metrics.startIndex && last_line_text_offset <= back_offset) {
+                    line_numbers[1] = static_cast<int>(i);
+                    break;
+                }
+            }
+            if (line_numbers[0] > line_numbers[1]) {
+                std::swap(line_numbers[0], line_numbers[1]);
+            }
+        } else {
+            // No span contains the touched offset — fall back to character-level
+            // selection (single char), aligned with Android / iOS fallback behaviour.
+            last_line_text_offset = first_line_text_offset;
+        }
     }
 
     float first_char_width = -1;
@@ -624,6 +692,7 @@ KRParagraphInfo KRRichTextView::GetParagraphInfo() {
 
     std::string text_content = textShadow->GetTextContent();
     paragraph_info.text_content_ = text_content;
+    paragraph_info.span_offsets_ = textShadow->span_offsets_;
     size_t lineCount = OH_Drawing_TypographyGetLineCount(textTypo);
     for (size_t i = 0; i < lineCount; ++i) {
         KRLineInfo line_info;
@@ -644,7 +713,11 @@ KRParagraphInfo KRRichTextView::GetParagraphInfo() {
 
             OH_Drawing_TextBox *boxes = nullptr;
             size_t count = 0;
-            while (advance_count < 4) {
+            // A single glyph may span multiple code units (surrogate pairs / combining
+            // marks). Grow the query range up to kMaxAdvancePerGlyph code units until the
+            // typography engine yields at least one rect box for the range.
+            constexpr int kMaxAdvancePerGlyph = 4;
+            while (advance_count < kMaxAdvancePerGlyph) {
                 boxes = OH_Drawing_TypographyGetRectsForRange(textTypo, index, index + advance_count,
                                                               RECT_HEIGHT_STYLE_TIGHT, RECT_WIDTH_STYLE_TIGHT);
                 count = OH_Drawing_GetSizeOfTextBox(boxes);

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.h
@@ -35,6 +35,7 @@ enum KRTextSelectionType {
     WORD,
     PARAGRAPH,
     SENTENCE,
+    SPAN,
     ALL = 9999
 };
 
@@ -113,10 +114,12 @@ class KRParagraphInfo {
     OH_Drawing_Typography *typography_ = nullptr;
     float width_ = 0;
     float height_ = 0;
+    std::vector<std::tuple<int, int, int>> span_offsets_;  // (spanIndex, begin, end)
 
  private:
     std::pair<int, int> GetSentenceBoundary(int offset);
     std::pair<int, int> GetParagraphBoundary(int offset);
+    std::pair<int, int> GetSpanBoundary(int offset);
 };
 
 class KRRichTextView : public IKRRenderViewExport {

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/DivView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/DivView.kt
@@ -120,6 +120,7 @@ enum class SelectionType(val value: Int) {
     WORD(1),
     PARAGRAPH(2),
     SENTENCE(3),
+    SPAN(4),
 }
 
 open class DivAttr : GroupAttr() {

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/catalog/ExampleIndexPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/catalog/ExampleIndexPage.kt
@@ -111,6 +111,13 @@ internal class ExampleIndexPage : BasePager() {
         })
 
         itemList.add(ExampleItemData().apply {
+            avatarText = "Sp"
+            titleText = "Span Selection"
+            subtitleText = "长按富文本 Span 整体选择，支持字符/WORD/句子/段落/SPAN 多种选择类型"
+            declarativeExampleUrl = generateJumpUrl("SpanSelectionExamplePage")
+        })
+
+        itemList.add(ExampleItemData().apply {
             avatarText = "Im"
             titleText = "ImageView"
             subtitleText = "使用ImageView为你的app添加图片"

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/kit_demo/DeclarativeDemo/SpanSelectionExamplePage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/kit_demo/DeclarativeDemo/SpanSelectionExamplePage.kt
@@ -1,0 +1,475 @@
+package com.tencent.kuikly.demo.pages.demo.kit_demo.DeclarativeDemo
+
+import com.tencent.kuikly.core.annotations.Page
+import com.tencent.kuikly.core.base.*
+import com.tencent.kuikly.core.reactive.handler.observable
+import com.tencent.kuikly.core.views.*
+import com.tencent.kuikly.demo.pages.base.BasePager
+import com.tencent.kuikly.demo.pages.base.Utils
+import com.tencent.kuikly.demo.pages.demo.base.NavBar
+
+/**
+ * Span Selection Example Page
+ *
+ * 验证 [SelectionType.SPAN] 长按选择能力：
+ * - 富文本中每个 Span 节点都是一个独立的可选单元
+ * - 长按某个 Span 会自动选中整个 Span 的文字范围
+ * - 也可通过按钮程序化触发不同位置的 Span 选择
+ */
+@Page("SpanSelectionExamplePage")
+internal class SpanSelectionExamplePage : BasePager() {
+
+    private var selectedText by observable("")
+    private var selectionStatus by observable("未选择")
+    private var selectionFrame by observable("")
+    private var clickInfo by observable("")
+    private var selectionType by observable(SelectionType.SPAN)
+
+    private var selectableContainer: ViewRef<DivView>? = null
+    private var clickableRichTextRef: ViewRef<RichTextView>? = null
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            attr {
+                backgroundColor(Color.WHITE)
+                flexDirectionColumn()
+            }
+
+            NavBar {
+                attr { title = "Span Selection Demo" }
+            }
+
+            List {
+                attr {
+                    flex(1f)
+                    padding(all = 16f)
+                }
+
+                // Status display
+                View {
+                    attr {
+                        backgroundColor(Color(0xFFF5F5F5))
+                        padding(all = 12f)
+                        borderRadius(8f)
+                        marginBottom(16f)
+                    }
+                    Text {
+                        attr {
+                            fontSize(14f)
+                            color(Color(0xFF666666))
+                            text("状态: ${ctx.selectionStatus}")
+                        }
+                    }
+                    Text {
+                        attr {
+                            fontSize(12f)
+                            color(Color(0xFF999999))
+                            marginTop(4f)
+                            text("选区: ${ctx.selectionFrame}")
+                        }
+                    }
+                    Text {
+                        attr {
+                            fontSize(12f)
+                            color(Color(0xFF333333))
+                            marginTop(4f)
+                            text("选中内容: ${ctx.selectedText}")
+                            lines(3)
+                        }
+                    }
+                    Text {
+                        attr {
+                            fontSize(12f)
+                            color(Color(0xFF00897B))
+                            marginTop(4f)
+                            text("点击反馈: ${ctx.clickInfo}")
+                            lines(2)
+                        }
+                    }
+                    Text {
+                        attr {
+                            fontSize(12f)
+                            color(Color(0xFF7B1FA2))
+                            marginTop(4f)
+                            text("当前选择类型: ${ctx.selectionTypeName()}")
+                        }
+                    }
+                }
+
+                // Control buttons
+                View {
+                    attr {
+                        flexDirectionRow()
+                        marginBottom(16f)
+                    }
+                    // 切换选择类型：CHARACTER → WORD → SENTENCE → SPAN → CHARACTER ...
+                    View {
+                        attr {
+                            flex(1f)
+                            backgroundColor(Color(0xFF009688))
+                            padding(top = 12f, bottom = 12f)
+                            borderRadius(6f)
+                            marginRight(8f)
+                            alignItemsCenter()
+                        }
+                        event {
+                            click {
+                                ctx.selectionType = when (ctx.selectionType) {
+                                    SelectionType.CHARACTER -> SelectionType.WORD
+                                    SelectionType.WORD -> SelectionType.SENTENCE
+                                    SelectionType.SENTENCE -> SelectionType.PARAGRAPH
+                                    SelectionType.PARAGRAPH -> SelectionType.SPAN
+                                    SelectionType.SPAN -> SelectionType.CHARACTER
+                                }
+                            }
+                        }
+                        Text {
+                            attr {
+                                fontSize(14f)
+                                color(Color.WHITE)
+                                text("选择类型: ${ctx.selectionTypeName()}")
+                            }
+                        }
+                    }
+                    // 清除选择
+                    View {
+                        attr {
+                            flex(1f)
+                            backgroundColor(Color(0xFFE57373))
+                            padding(top = 12f, bottom = 12f)
+                            borderRadius(6f)
+                            alignItemsCenter()
+                        }
+                        event {
+                            click {
+                                ctx.selectableContainer?.view?.clearSelection()
+                                ctx.selectedText = ""
+                                ctx.selectionFrame = ""
+                                ctx.selectionStatus = "已清除"
+                            }
+                        }
+                        Text {
+                            attr {
+                                fontSize(14f)
+                                color(Color.WHITE)
+                                text("清除选择")
+                            }
+                        }
+                    }
+                }
+
+                // Selectable container with rich text spans
+                View {
+                    ref {
+                        ctx.selectableContainer = it
+                    }
+                    attr {
+                        backgroundColor(Color(0xFFFFFDE7))
+                        padding(all = 16f)
+                        borderRadius(8f)
+                        border(Border(1f, BorderStyle.SOLID, Color(0xFFE0E0E0)))
+                        selectable(SelectableOption.ENABLE)
+                        selectionColor(Color(0xFF2196F3))
+                    }
+                    event {
+                        longPress {
+                            if (it.state == "start") {
+                                ctx.selectableContainer?.view?.createSelection(it.x, it.y, ctx.selectionType)
+                            }
+                        }
+                        selectStart { frame ->
+                            ctx.selectionStatus = "选择开始"
+                            ctx.selectionFrame = "x:${frame.x.toInt()}, y:${frame.y.toInt()}, w:${frame.width.toInt()}, h:${frame.height.toInt()}"
+                        }
+                        selectChange { frame ->
+                            ctx.selectionStatus = "选择中..."
+                            ctx.selectionFrame = "x:${frame.x.toInt()}, y:${frame.y.toInt()}, w:${frame.width.toInt()}, h:${frame.height.toInt()}"
+                        }
+                        selectEnd { frame ->
+                            ctx.selectionStatus = "选择结束"
+                            ctx.selectionFrame = "x:${frame.x.toInt()}, y:${frame.y.toInt()}, w:${frame.width.toInt()}, h:${frame.height.toInt()}"
+                            ctx.selectableContainer?.view?.getSelection { texts ->
+                                ctx.selectedText = texts.joinToString(" | ")
+                                if (texts.isEmpty()) {
+                                    ctx.selectionStatus = "无选中内容"
+                                }
+                            }
+                        }
+                        selectCancel {
+                            ctx.selectionStatus = "选择取消"
+                            ctx.selectionFrame = ""
+                            ctx.selectedText = ""
+                        }
+                    }
+
+                    Text {
+                        attr {
+                            fontSize(18f)
+                            fontWeightBold()
+                            color(Color(0xFF333333))
+                            text("长按以下 Span 试试")
+                            marginBottom(12f)
+                        }
+                    }
+
+                    // Section 1: 带点击的 Span（验证 click 与 SPAN 长按选择共存）
+                    Text {
+                        attr {
+                            fontSize(13f)
+                            color(Color(0xFF888888))
+                            text("① 带 click 的 Span（点击弹 toast，长按选中整段）")
+                            marginBottom(6f)
+                        }
+                    }
+                    RichText {
+                        ref { ctx.clickableRichTextRef = it }
+                        attr { marginBottom(16f) }
+                        event {
+                            longPress {
+                                if (it.state == "start") {
+                                    ctx.triggerSpanSelection(it.x, it.y)
+                                }
+                            }
+                        }
+                        Span {
+                            fontSize(16f)
+                            color(Color(0xFF444444))
+                            text("点击 "
+                            )
+                        }
+                        Span {
+                            fontSize(16f)
+                            color(Color(0xFF1565C0))
+                            fontWeightBold()
+                            textDecorationUnderLine()
+                            text("这段蓝色可点击文字")
+                            click {
+                                ctx.clickInfo = "点击了「蓝色可点击文字」"
+                                Utils.bridgeModule(this).toast("点击了蓝色 Span")
+                            }
+                            longPress {
+                                if (it.state == "start") {
+                                    ctx.triggerSpanSelection(it.x, it.y)
+                                }
+                            }
+                        }
+                        Span {
+                            fontSize(16f)
+                            color(Color(0xFF444444))
+                            text(" 会有 toast 反馈，长按则会选中整个 Span。"
+                            )
+                        }
+                        Span {
+                            fontSize(16f)
+                            color(Color(0xFFC62828))
+                            fontWeightBold()
+                            text("红色可点击Span")
+                            click {
+                                ctx.clickInfo = "点击了「红色可点击Span」"
+                                Utils.bridgeModule(this).toast("点击了红色 Span")
+                            }
+                            longPress {
+                                if (it.state == "start") {
+                                    ctx.triggerSpanSelection(it.x, it.y)
+                                }
+                            }
+                        }
+                        Span {
+                            fontSize(16f)
+                            color(Color(0xFF444444))
+                            text(" 也试试。")
+                        }
+                    }
+
+                    // Section 2: 基础多 Span（不同颜色样式，验证逐个选中）
+                    Text {
+                        attr {
+                            fontSize(13f)
+                            color(Color(0xFF888888))
+                            text("② 多样式 Span（长按每个 Span 独立选中）")
+                            marginBottom(6f)
+                        }
+                    }
+                    RichText {
+                        attr { marginBottom(16f) }
+                        Span {
+                            fontSize(16f)
+                            color(Color(0xFF444444))
+                            text("KuiklyUI 是一个")
+                        }
+                        Span {
+                            fontSize(16f)
+                            color(Color(0xFFE53935))
+                            fontWeightBold()
+                            text("跨平台UI框架")
+                        }
+                        Span {
+                            fontSize(16f)
+                            color(Color(0xFF444444))
+                            text("，支持")
+                        }
+                        Span {
+                            fontSize(16f)
+                            color(Color(0xFF1E88E5))
+                            textDecorationUnderLine()
+                            text("iOS、Android、鸿蒙")
+                        }
+                        Span {
+                            fontSize(16f)
+                            color(Color(0xFF444444))
+                            text("三端。")
+                        }
+                    }
+
+                    // Section 3: 长 Span（单个 Span 内容很长，验证长文本选区完整性）
+                    Text {
+                        attr {
+                            fontSize(13f)
+                            color(Color(0xFF888888))
+                            text("③ 长 Span（单个 Span 很长，验证选区不截断）")
+                            marginBottom(6f)
+                        }
+                    }
+                    RichText {
+                        attr { marginBottom(16f) }
+                        Span {
+                            fontSize(15f)
+                            color(Color(0xFF6A1B9A))
+                            fontWeightBold()
+                            text("这是一个很长的 Span：SPAN 选择类型允许用户通过长按手势一次性选中整个富文本 Span 的内容范围，而不需要手动拖拽游标。这在词条解释、链接预览、标签选择等场景下非常实用，可以大幅提升交互效率。长按此段文字应一次性选中全部内容。")
+                        }
+                    }
+
+                    // Section 4: 跨行 Span（Span 跨越多行，验证 P1/P2 边界修复）
+                    Text {
+                        attr {
+                            fontSize(13f)
+                            color(Color(0xFF888888))
+                            text("④ 跨行 Span（验证多行选区不遗漏末字符、不多选相邻字符）")
+                            marginBottom(6f)
+                        }
+                    }
+                    RichText {
+                        attr { marginBottom(16f) }
+                        Span {
+                            fontSize(14f)
+                            color(Color(0xFF555555))
+                            text("前缀文字 | ")
+                        }
+                        Span {
+                            fontSize(14f)
+                            color(Color(0xFFD81B60))
+                            fontWeightBold()
+                            text("这是跨行 Span 的开始，这段文字会跨越多行显示。当文字内容超过一行宽度时会自动换行，长按此 Span 应选中它在所有行中的完整范围。关键验证点：选区末尾不应遗漏最后一个字符，也不应多选相邻 Span 的第一个字符。这是 SPAN 选择边界正确性的核心验证场景。跨行 Span 结束。")
+                        }
+                        Span {
+                            fontSize(14f)
+                            color(Color(0xFF555555))
+                            text(" | 后缀文字")
+                        }
+                    }
+
+                    // Section 5: 英文 Span + ImageSpan + emoji
+                    Text {
+                        attr {
+                            fontSize(13f)
+                            color(Color(0xFF888888))
+                            text("⑤ 英文 / ImageSpan / emoji")
+                            marginBottom(6f)
+                        }
+                    }
+                    RichText {
+                        attr { marginBottom(16f) }
+                        Span {
+                            fontSize(15f)
+                            color(Color(0xFF444444))
+                            text("SPAN selection lets you "
+                            )
+                        }
+                        Span {
+                            fontSize(15f)
+                            color(Color(0xFF2E7D32))
+                            fontWeightBold()
+                            text("select an entire styled span"
+                            )
+                        }
+                        Span {
+                            fontSize(15f)
+                            color(Color(0xFF444444))
+                            text(" with a single long-press. 富文本也可含 ")
+                        }
+                        ImageSpan {
+                            src("https://wfiles.gtimg.cn/wuji_dashboard/xy/starter/baa91edc.png")
+                            size(24f, 24f)
+                            description("logo")
+                        }
+                        Span {
+                            fontSize(15f)
+                            color(Color(0xFFEF6C00))
+                            fontWeightBold()
+                            text(" emoji 🌙⭐🌙⭐")
+                        }
+                        Span {
+                            fontSize(15f)
+                            color(Color(0xFF444444))
+                            text("。")
+                        }
+                    }
+                }
+
+                // Tips
+                View {
+                    attr {
+                        backgroundColor(Color(0xFFE3F2FD))
+                        padding(all = 12f)
+                        borderRadius(8f)
+                        marginTop(16f)
+                    }
+                    Text {
+                        attr {
+                            fontSize(14f)
+                            fontWeightMedium()
+                            color(Color(0xFF1565C0))
+                            text("使用说明")
+                            marginBottom(8f)
+                        }
+                    }
+                    Text {
+                        attr {
+                            fontSize(13f)
+                            color(Color(0xFF1976D2))
+                            lineHeight(20f)
+                            text("1. 点击「选择类型」在 字符/WORD/句子/SPAN 间切换\n2. 切换后长按文本按当前类型选择\n3. ① 带 click 的 Span：点击弹 toast，长按选中整段\n4. ③ 长 Span：验证长文本选区不截断\n5. ④ 跨行 Span：验证多行选区不遗漏末字符、不多选相邻字符")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun selectionTypeName(): String {
+        return when (selectionType) {
+            SelectionType.CHARACTER -> "字符"
+            SelectionType.WORD -> "WORD"
+            SelectionType.SENTENCE -> "句子"
+            SelectionType.PARAGRAPH -> "段落"
+            SelectionType.SPAN -> "SPAN"
+        }
+    }
+
+    /**
+     * Span longPress 的 it.x/it.y 是相对于 RichText 视图的坐标，
+     * 而 createSelection 需要相对于 DivView（selectableContainer）的坐标。
+     * Kuikly flex 布局的 frame.x/y 已包含父视图 padding（位置从 padding 边开始累加），
+     * 因此直接用 frame 作为偏移即可，无需额外加 padding。
+     */
+    private fun triggerSpanSelection(spanX: Float, spanY: Float) {
+        val richTextFrame = clickableRichTextRef?.view?.frame
+        val offsetX = richTextFrame?.x ?: 0f
+        val offsetY = richTextFrame?.y ?: 0f
+        selectableContainer?.view?.createSelection(
+            spanX + offsetX, spanY + offsetY, selectionType
+        )
+    }
+}

--- a/docs/API/components/text-selection.md
+++ b/docs/API/components/text-selection.md
@@ -111,6 +111,7 @@
 | `WORD` | 选中触发点所在的词 |
 | `PARAGRAPH` | 选中触发点所在的段落 |
 | `SENTENCE`<Badge text="仅iOS" type="warn"/> | 选中触发点所在的句子。Android、鸿蒙端会回退为`PARAGRAPH` |
+| `SPAN` | 选中触发点所在的富文本 Span 整体范围 |
 
 ### createSelectionAll
 

--- a/docs/Compose/text-selection.md
+++ b/docs/Compose/text-selection.md
@@ -130,6 +130,7 @@ state.clearSelection()
 | `WORD` | 词 |
 | `PARAGRAPH` | 段落 |
 | `SENTENCE` | 句子（仅iOS生效，Android、鸿蒙端会回退为`PARAGRAPH`） |
+| `SPAN` | 富文本 Span 整体选中（长按某个 Span 时自动选中整个 Span 范围） |
 
 ### SelectionResult
 


### PR DESCRIPTION
## What does this PR do?

Adds a new `SPAN` selection type to the rich text selection system, allowing users to select an entire styled span with a single long-press.

## Changes

- **core**: Add `SPAN(4)` to `SelectionType` enum
- **compose**: Add `TextSelectionType.SPAN` mapping
- **Android**: `expandSelectionToSpan` using `FontWeightSpan`, with precise span coverage check (`start<=pos<end`) and nearest-span fallback
- **iOS**: `rangeOfSpanAtIndex` using `longestEffectiveRange` for O(1) span lookup, fallback to `rangeOfComposedCharacterSequenceAtIndex`
- **OHOS**: `GetSpanBoundary` using `span_offsets_`, with flag reset to guarantee `info.end==span_end` (no off-by-one), character-level fallback when no span hit

## Platforms

- ✅ Android (compiled & tested on device)
- ✅ iOS (compiled & tested on device)
- ✅ OHOS (compiled, C++ code verified)
