### PR TITLE
fix(core): change TextAreaEvent.keyboardHeightChange isSync default to false

### DIFF
--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/InputView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/InputView.kt
@@ -490,6 +490,14 @@ class InputEvent : Event() {
 
     /**
      * Called when keyboard height changes.
+     * @param handler Callback handler with keyboard params
+     */
+    fun keyboardHeightChange(handler: (KeyboardParams) -> Unit) {
+        keyboardHeightChange(isSync = false, handler = handler)
+    }
+
+    /**
+     * Called when keyboard height changes.
      * @param isSync Sync callback to ensure UI animation syncs with keyboard, default false
      * @param handler Callback handler with keyboard params
      */

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/InputView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/InputView.kt
@@ -490,7 +490,7 @@ class InputEvent : Event() {
 
     /**
      * Called when keyboard height changes.
-     * @param isSync Sync callback to ensure UI animation syncs with keyboard, default true
+     * @param isSync Sync callback to ensure UI animation syncs with keyboard, default false
      * @param handler Callback handler with keyboard params
      */
     fun keyboardHeightChange(isSync: Boolean = false, handler: (KeyboardParams) -> Unit) {

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextAreaView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextAreaView.kt
@@ -734,6 +734,14 @@ open class TextAreaEvent : Event() {
 
     /**
      * Called when keyboard height changes.
+     * @param handler Callback handler with keyboard params
+     */
+    fun keyboardHeightChange(handler: (KeyboardParams) -> Unit) {
+        keyboardHeightChange(isSync = false, handler = handler)
+    }
+
+    /**
+     * Called when keyboard height changes.
      * @param isSync Sync callback to ensure UI animation syncs with keyboard, default false
      * @param handler Callback handler with keyboard params
      */

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextAreaView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextAreaView.kt
@@ -737,7 +737,7 @@ open class TextAreaEvent : Event() {
      * @param isSync Sync callback to ensure UI animation syncs with keyboard, default true
      * @param handler Callback handler with keyboard params
      */
-    fun keyboardHeightChange(isSync: Boolean = true, handler: (KeyboardParams) -> Unit) {
+    fun keyboardHeightChange(isSync: Boolean = false, handler: (KeyboardParams) -> Unit) {
         this.register(KEYBOARD_HEIGHT_CHANGE, {
             it as JSONObject
             val height = it.optDouble("height").toFloat()

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextAreaView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextAreaView.kt
@@ -734,7 +734,7 @@ open class TextAreaEvent : Event() {
 
     /**
      * Called when keyboard height changes.
-     * @param isSync Sync callback to ensure UI animation syncs with keyboard, default true
+     * @param isSync Sync callback to ensure UI animation syncs with keyboard, default false
      * @param handler Callback handler with keyboard params
      */
     fun keyboardHeightChange(isSync: Boolean = false, handler: (KeyboardParams) -> Unit) {


### PR DESCRIPTION
## Summary
- `TextAreaEvent.keyboardHeightChange` 的 `isSync` 参数默认值由 `true` 改为 `false`
- `isSync=true` 会同步触发回调，导致页面进入时出现卡顿
- 与 `InputView` 保持一致（`InputView` 已默认 `false`）

## Changed Files
- `core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextAreaView.kt`