### PR TITLE
fix(compose): migrate ComposeOnKuikly changes since 2026-06-14

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/animation/core/InternalMutatorMutex.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/animation/core/InternalMutatorMutex.kt
@@ -60,8 +60,11 @@ internal enum class MutatePriority {
  * javaClass.simpleName lookups to build the exception message and stack trace collection.
  * Remove if these are changed in kotlinx.coroutines.
  */
-private class MutationInterruptedException :
+private object MutationInterruptedException :
     CancellationException("Mutation interrupted")
+
+private object MutationHadHigherPriorityException :
+    CancellationException("Current mutation had a higher priority")
 
 /**
  * Mutual exclusion for UI state mutation over time.
@@ -82,7 +85,7 @@ internal class MutatorMutex {
     private class Mutator(val priority: MutatePriority, val job: Job) {
         fun canInterrupt(other: Mutator) = priority >= other.priority
 
-        fun cancel() = job.cancel(MutationInterruptedException())
+        fun cancel() = job.cancel(MutationInterruptedException)
     }
 
     private val currentMutator = AtomicReference<Mutator?>(null)
@@ -96,7 +99,7 @@ internal class MutatorMutex {
                     oldMutator?.cancel()
                     break
                 }
-            } else throw CancellationException("Current mutation had a higher priority")
+            } else throw MutationHadHigherPriorityException
         }
     }
 

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/extension/FlingEnable.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/extension/FlingEnable.kt
@@ -1,0 +1,65 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.compose.extension
+
+import com.tencent.kuikly.compose.ui.Modifier
+import com.tencent.kuikly.compose.ui.node.KNode
+import com.tencent.kuikly.compose.ui.node.ModifierNodeElement
+import com.tencent.kuikly.compose.ui.node.requireLayoutNode
+import com.tencent.kuikly.core.views.ScrollerView
+
+/**
+ * Dynamically enable or disable native fling for the underlying Kuikly ScrollerView.
+ */
+fun Modifier.flingEnable(enable: Boolean): Modifier =
+    this.then(FlingEnableElement(enable))
+
+private class FlingEnableElement(
+    val enable: Boolean,
+) : ModifierNodeElement<FlingEnableNode>() {
+    override fun create(): FlingEnableNode = FlingEnableNode(enable)
+
+    override fun hashCode(): Int = enable.hashCode()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is FlingEnableElement && enable == other.enable
+    }
+
+    override fun update(node: FlingEnableNode) {
+        node.enable = enable
+        node.update()
+    }
+}
+
+private class FlingEnableNode(
+    var enable: Boolean,
+) : Modifier.Node() {
+
+    override fun onAttach() {
+        super.onAttach()
+        update()
+    }
+
+    fun update() {
+        val layoutNode = requireLayoutNode()
+        val kNode = layoutNode as? KNode<*> ?: return
+        val scrollerView = (kNode.view as? ScrollerView<*, *>)
+            ?: layoutNode.findFirstChildScrollerView()
+            ?: return
+        scrollerView.getViewAttr().flingEnable(enable)
+    }
+}

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/extension/FlingSpeedLimit.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/extension/FlingSpeedLimit.kt
@@ -1,0 +1,66 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.compose.extension
+
+import com.tencent.kuikly.compose.ui.Modifier
+import com.tencent.kuikly.compose.ui.node.KNode
+import com.tencent.kuikly.compose.ui.node.ModifierNodeElement
+import com.tencent.kuikly.compose.ui.node.requireLayoutNode
+import com.tencent.kuikly.core.views.ScrollerView
+
+/**
+ * Limit max initial fling speed (vp/s) on HarmonyOS Scroll (API 18+).
+ * Pass [speedLimit] <= 0 to restore the system default. No-op on API < 18.
+ */
+fun Modifier.flingSpeedLimit(speedLimit: Float): Modifier =
+    this.then(FlingSpeedLimitElement(speedLimit))
+
+private class FlingSpeedLimitElement(
+    val speedLimit: Float,
+) : ModifierNodeElement<FlingSpeedLimitNode>() {
+    override fun create(): FlingSpeedLimitNode = FlingSpeedLimitNode(speedLimit)
+
+    override fun hashCode(): Int = speedLimit.hashCode()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is FlingSpeedLimitElement && speedLimit == other.speedLimit
+    }
+
+    override fun update(node: FlingSpeedLimitNode) {
+        node.speedLimit = speedLimit
+        node.update()
+    }
+}
+
+private class FlingSpeedLimitNode(
+    var speedLimit: Float,
+) : Modifier.Node() {
+
+    override fun onAttach() {
+        super.onAttach()
+        update()
+    }
+
+    fun update() {
+        val layoutNode = requireLayoutNode()
+        val kNode = layoutNode as? KNode<*> ?: return
+        val scrollerView = (kNode.view as? ScrollerView<*, *>)
+            ?: layoutNode.findFirstChildScrollerView()
+            ?: return
+        scrollerView.getViewAttr().flingSpeedLimit(speedLimit)
+    }
+}

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/MutatorMutex.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/MutatorMutex.kt
@@ -59,8 +59,11 @@ enum class MutatePriority {
  * javaClass.simpleName lookups to build the exception message and stack trace collection.
  * Remove if these are changed in kotlinx.coroutines.
  */
-private class MutationInterruptedException :
+private object MutationInterruptedException :
     PlatformOptimizedCancellationException("Mutation interrupted")
+
+private object MutationHadHigherPriorityException :
+    PlatformOptimizedCancellationException("Current mutation had a higher priority")
 
 /**
  * Mutual exclusion for UI state mutation over time.
@@ -82,7 +85,7 @@ class MutatorMutex {
     private class Mutator(val priority: MutatePriority, val job: Job) {
         fun canInterrupt(other: Mutator) = priority >= other.priority
 
-        fun cancel() = job.cancel(MutationInterruptedException())
+        fun cancel() = job.cancel(MutationInterruptedException)
     }
 
     private val currentMutator = AtomicReference<Mutator?>(null)
@@ -96,7 +99,7 @@ class MutatorMutex {
                     oldMutator?.cancel()
                     break
                 }
-            } else throw CancellationException("Current mutation had a higher priority")
+            } else throw MutationHadHigherPriorityException
         }
     }
 

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.structuralEqualityPolicy
 import com.tencent.kuikly.compose.foundation.gestures.snapping.SnapPosition
 import com.tencent.kuikly.compose.foundation.layout.PaddingValues
+import com.tencent.kuikly.compose.ui.PlatformOptimizedCancellationException
 import com.tencent.kuikly.compose.ui.geometry.Offset
 import com.tencent.kuikly.compose.ui.layout.AlignmentLine
 import com.tencent.kuikly.compose.ui.layout.MeasureResult
@@ -520,7 +521,7 @@ abstract class PagerState internal constructor(
         snapTargetReachedAlignmentRequested = false
         snapStallAlignmentRetryRequested = false
         kuiklyInfo.snapAnchorOffsetCorrection = 0
-        kuiklyInfo.appleScrollViewOffsetJob?.cancel()
+        kuiklyInfo.appleScrollViewOffsetJob?.cancel(ScrollViewOffsetAlignmentCancellation)
     }
 
     private fun scheduleScrollViewOffsetAlignment(
@@ -543,7 +544,7 @@ abstract class PagerState internal constructor(
                 "isSnapAnimating=$isSnapAnimating isScrollInProgress=$isScrollInProgress"
         }
         kuiklyInfo.run {
-            appleScrollViewOffsetJob?.cancel()
+            appleScrollViewOffsetJob?.cancel(ScrollViewOffsetAlignmentCancellation)
             appleScrollViewOffsetJob = scope?.launch {
                 delay(delayMs)
                 alignScrollViewOffset(
@@ -1738,3 +1739,10 @@ private fun PagerMeasureResult.calculateNewMinScrollOffset(pageCount: Int): Long
 //        }
 //    }
 //}
+
+/**
+ * Used in place of the standard Job cancellation pathway to avoid reflective
+ * javaClass.simpleName lookups to build the exception message and stack trace collection.
+ */
+internal object ScrollViewOffsetAlignmentCancellation :
+    PlatformOptimizedCancellationException("Scroll view offset alignment superseded")

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
@@ -150,6 +150,12 @@ class KuiklyScrollInfo {
     var cachedTotalItems: Int = 0
 
     /**
+     * When true, [tryExpandStartSize] is skipped. Used by [ScrollableTabRow] whose content
+     * size is already exact via [ScrollState.maxValue] + viewport.
+     */
+    var skipExpandStartSize: Boolean = false
+
+    /**
      * Sticky Header Position Cache Manager
      */
     val stickyHeaderCacheManager = StickyHeaderCacheManager()

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/material3/TabRow.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/material3/TabRow.kt
@@ -80,6 +80,7 @@ import com.tencent.kuikly.compose.ui.util.fastMap
 import com.tencent.kuikly.compose.extension.setProp
 import com.tencent.kuikly.compose.gestures.KuiklyScrollableState
 import com.tencent.kuikly.compose.scroller.fixScrollOffset
+import com.tencent.kuikly.compose.scroller.kuiklyInfo
 import kotlin.math.max
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -521,8 +522,15 @@ fun ScrollableTabRow(
         edgePadding = edgePadding,
         divider = divider,
         tabs = tabs,
-        scrollState = rememberScrollState()
+        scrollState = rememberScrollableTabRowScrollState()
     )
+}
+
+@Composable
+private fun rememberScrollableTabRowScrollState(): ScrollState {
+    val scrollState = rememberScrollState()
+    scrollState.kuiklyInfo.skipExpandStartSize = true
+    return scrollState
 }
 
 /**

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ContentSizeExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ContentSizeExtensions.kt
@@ -24,6 +24,7 @@ import com.tencent.kuikly.compose.foundation.lazy.grid.LazyGridState
 import com.tencent.kuikly.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import com.tencent.kuikly.compose.foundation.drawer.DrawerInternalPagerState
 import com.tencent.kuikly.compose.foundation.pager.PagerState
+import com.tencent.kuikly.compose.foundation.pager.ScrollViewOffsetAlignmentCancellation
 import com.tencent.kuikly.compose.scroller.ScrollableStateConstants.DEFAULT_CONTENT_SIZE
 import com.tencent.kuikly.compose.ui.unit.Dp
 import com.tencent.kuikly.compose.ui.unit.LayoutDirection
@@ -263,6 +264,8 @@ internal fun ScrollableState.calculateBackExpandSize(offset: Int): Int? {
  */
 internal fun ScrollableState.tryExpandStartSize(offset: Int, isScrolling: Boolean) {
     if (kuiklyInfo.scrollView == null) return
+    if (kuiklyInfo.skipExpandStartSize) return
+    if (this is PagerState) return
 
     val density = kuiklyInfo.getDensity()
     // scrollview 到顶了，但是compose没到顶
@@ -296,7 +299,7 @@ internal fun ScrollableState.tryExpandStartSize(offset: Int, isScrolling: Boolea
 internal fun ScrollableState.tryExpandStartSizeNoScroll(forceExpand: Boolean = false) {
     if (this is PagerState || this is DrawerInternalPagerState) return
     kuiklyInfo.run {
-        appleScrollViewOffsetJob?.cancel()
+        appleScrollViewOffsetJob?.cancel(ScrollViewOffsetAlignmentCancellation)
         appleScrollViewOffsetJob = scope?.launch {
             delay(150)
             val minDelta = (DEFAULT_CONTENT_SIZE * getDensity()).toInt()

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/Modifier.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/Modifier.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.cancel
  * javaClass.simpleName lookups to build the exception message and stack trace collection.
  * Remove if these are changed in kotlinx.coroutines.
  */
-private class ModifierNodeDetachedCancellationException : PlatformOptimizedCancellationException(
+private object ModifierNodeDetachedCancellationException : PlatformOptimizedCancellationException(
     "The Modifier.Node was detached"
 )
 
@@ -288,7 +288,7 @@ interface Modifier {
             isAttached = false
 
             scope?.let {
-                it.cancel(ModifierNodeDetachedCancellationException())
+                it.cancel(ModifierNodeDetachedCancellationException)
                 scope = null
             }
         }

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
@@ -510,7 +510,7 @@ internal class SuspendingPointerInputModifierNodeImpl(
     override fun resetPointerInputHandler() {
         val localJob = pointerInputJob
         if (localJob != null) {
-            localJob.cancel(PointerInputResetException())
+            localJob.cancel(PointerInputResetException)
             pointerInputJob = null
         }
     }
@@ -756,7 +756,7 @@ internal class SuspendingPointerInputModifierNodeImpl(
  * javaClass.simpleName lookups to build the exception message and stack trace collection.
  * Remove if these are changed in kotlinx.coroutines.
  */
-private class PointerInputResetException : PlatformOptimizedCancellationException("Pointer input was reset")
+private object PointerInputResetException : PlatformOptimizedCancellationException("Pointer input was reset")
 
 /**
  * Also used in place of standard Job cancellation pathway; since we control this code path

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
@@ -263,7 +263,7 @@ fun SubcomposeLayout(
             }
 
             if (scrollableState is PagerState || scrollableState is DrawerInternalPagerState) {
-                willDragEndBySync(isSync = false, handler = {
+                willDragEndBySync(isSync = scrollableState is PagerState, handler = {
                     val viewportSize = kuiklyInfo.viewportSize
                     val scaleParams = it.scaleWithDensity(kuiklyInfo.getDensity())
                     // 实现分页滑动

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/platform/FlushCoroutineDispatcher.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/platform/FlushCoroutineDispatcher.kt
@@ -21,6 +21,7 @@ import com.tencent.kuikly.compose.ui.synchronized
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
+import com.tencent.kuikly.compose.ui.PlatformOptimizedCancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Delay
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -155,10 +156,17 @@ internal class FlushCoroutineDispatcher(
             }
         }
         continuation.invokeOnCancellation {
-            job.cancel()
+            job.cancel(DelayTaskCancellation)
             synchronized(tasksLock) {
                 delayedTasks.remove(block)
             }
         }
     }
 }
+
+/**
+ * Used in place of the standard Job cancellation pathway to avoid reflective
+ * javaClass.simpleName lookups to build the exception message and stack trace collection.
+ */
+private object DelayTaskCancellation :
+    PlatformOptimizedCancellationException("FlushCoroutineDispatcher delay cancelled")

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerView.cpp
@@ -17,6 +17,7 @@
 
 #include <cfloat>
 #include <cmath>
+#include <deviceinfo.h>
 #include "libohos_render/expand/components/view/KRView.h"
 #include "libohos_render/foundation/type/KRRenderValue.h"
 #include "libohos_render/utils/KRJSONObject.h"
@@ -31,6 +32,14 @@ extern void* OH_ArkUI_GestureInterrupter_GetUserData(ArkUI_GestureInterruptInfo*
 };
 #endif
 
+constexpr int FLING_SPEED_LIMIT_API_LEVEL = 18;
+constexpr ArkUI_NodeAttributeType kScrollFlingSpeedLimitAttr =
+    static_cast<ArkUI_NodeAttributeType>(1002019);
+
+static bool IsFlingSpeedLimitApiAvailable() {
+    return OH_GetSdkApiVersion() >= FLING_SPEED_LIMIT_API_LEVEL;
+}
+
 constexpr char kPropNameDirectionRow[] = "directionRow";
 constexpr char kPropNamePagingEnabled[] = "pagingEnabled";
 constexpr char kPropNameScrollEnabled[] = "scrollEnabled";
@@ -41,6 +50,7 @@ constexpr char kPropNameLimitHeaderBounces[] = "limitHeaderBounces";
 constexpr char kPropNameShowScrollerIndicator[] = "showScrollerIndicator";
 constexpr char kPropNameNestedScroll[] = "nestedScroll";
 constexpr char kPropNameFlingEnable[] = "flingEnable";
+constexpr char kPropNameFlingSpeedLimit[] = "flingSpeedLimit";
 constexpr char kPropKeyNestedScrollForward[] = "forward";
 constexpr char kPropKeyNestedScrollBackward[] = "backward";
 
@@ -193,6 +203,8 @@ bool KRScrollerView::SetProp(const std::string &prop_key, const KRAnyValue &prop
         didHanded = SetNestedScroll(prop_value);
     } else if (kuikly::util::isEqual(prop_key, kPropNameFlingEnable)) {
         didHanded = SetFlingEnable(prop_value->toBool());
+    } else if (kuikly::util::isEqual(prop_key, kPropNameFlingSpeedLimit)) {
+        didHanded = SetFlingSpeedLimit(prop_value);
     }
     return didHanded;
 }
@@ -211,6 +223,11 @@ bool KRScrollerView::ResetProp(const std::string &prop_key) {
         } else if (prop_key == kPropNameFlingEnable) {
             didHanded = true;
             SetFlingEnable(true);
+        } else if (prop_key == kPropNameFlingSpeedLimit) {
+            didHanded = true;
+            if (IsFlingSpeedLimitApiAvailable()) {
+                kuikly::util::GetNodeApi()->resetAttribute(GetNode(), kScrollFlingSpeedLimitAttr);
+            }
         }
     }
     return didHanded;
@@ -752,6 +769,21 @@ ArkUI_GestureInterruptResult KRScrollerView::OnInterruptGestureEvent(const ArkUI
 
 bool KRScrollerView::SetFlingEnable(bool enable) {
     is_fling_enabled_ = enable;
+    return true;
+}
+
+bool KRScrollerView::SetFlingSpeedLimit(const KRAnyValue &value) {
+    if (!IsFlingSpeedLimitApiAvailable()) {
+        return true;
+    }
+    auto speed = value->toFloat();
+    if (speed <= 0) {
+        kuikly::util::GetNodeApi()->resetAttribute(GetNode(), kScrollFlingSpeedLimitAttr);
+    } else {
+        ArkUI_NumberValue values[] = {{.f32 = speed}};
+        ArkUI_AttributeItem item = {values, 1};
+        kuikly::util::GetNodeApi()->setAttribute(GetNode(), kScrollFlingSpeedLimitAttr, &item);
+    }
     return true;
 }
 

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerView.h
@@ -136,6 +136,7 @@ class KRScrollerView : public IKRRenderViewExport {
     void AdjustHeaderBouncesEnableWhenWillScroll(ArkUI_NodeEvent *event);
     void DispatchDidScrollToObservers(KRPoint point);
     bool SetFlingEnable(bool enable);
+    bool SetFlingSpeedLimit(const KRAnyValue &value);
     KRPoint MaxContentOffsetInContentInset(const std::shared_ptr<KRScrollerContentInset> &content_inset);
 
  private:

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/ScrollerView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/ScrollerView.kt
@@ -475,6 +475,14 @@ open class ScrollerAttr : ContainerAttr() {
     }
 
     /**
+     * Limit max initial fling speed after drag ends (HarmonyOS: NODE_SCROLL_FLING_SPEED_LIMIT, API 18+).
+     * Unit: vp/s. Pass value <= 0 to restore system default. No-op on API < 18.
+     */
+    fun flingSpeedLimit(speedLimit: Float) {
+        FLING_SPEED_LIMIT with speedLimit
+    }
+
+    /**
      * 设置是否同步滚动, 也可以通过Event.scroll(sync=true){}开启同步滚动
      * @param syncEnable 同步滚动启用状态(当前kotlin线程ui操作与ui线程同步更新)。
      */
@@ -510,6 +518,7 @@ open class ScrollerAttr : ContainerAttr() {
         const val PAGING_ENABLED = "pagingEnabled"
         const val DIRECTION_ROW =  "directionRow"
         const val FLING_ENABLE = "flingEnable"
+        const val FLING_SPEED_LIMIT = "flingSpeedLimit"
         const val SCROLL_WITH_PARENT = "scrollWithParent"
         const val NESTED_SCROLL = "nestedScroll"
     }


### PR DESCRIPTION
## Summary

Port functional fixes from internal ComposeOnKuikly (jonasluo commits after 2026-06-14) to KuiklyUI:

- **perf(compose)**: reuse singleton cancellation exceptions on hot cancel paths (MutatorMutex, pointer input, Pager alignment jobs, FlushCoroutineDispatcher)
- **feat(ohos)**: add `Modifier.flingSpeedLimit` with HarmonyOS render support (API 18+ guard)
- **feat(compose)**: add `Modifier.flingEnable` for dynamic native fling control
- **fix(ohos)**: prevent ScrollableTabRow jump by skipping `tryExpandStartSize` for tab scroll state
- **fix(ohos)**: skip `tryExpandStartSize` for Pager scroll state
- **fix(compose)**: use sync `willDragEnd` for Pager drag end handler (DrawerInternalPagerState keeps async)

**Excluded intentionally**: version bumps, internal CI config, reverted experiments, debug-only pager logging, and internal-only compose runtime dependency coordinates. LazyGrid/pager snap fixes were already present via #1451/#1461.

**Diff scope**: 15 files in `compose/`, `core/`, `core-render-ohos/` only — no internal CI or unrelated changes.

## Test plan

- [ ] Verify Pager snap/drag-end behavior on iOS/Android/OHOS
- [ ] Verify ScrollableTabRow no longer jumps when selecting first tab (OHOS)
- [ ] Verify `flingSpeedLimit` / `flingEnable` modifiers on HarmonyOS API 18+ device
- [ ] Smoke test scroll performance on Kotlin/Native (cancellation exception path)


Made with [Cursor](https://cursor.com)