### PR TITLE
feat(ohos): disable text render v2 and prevent high frequent logs by …

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/api/include/Kuikly/Kuikly.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/api/include/Kuikly/Kuikly.h
@@ -328,11 +328,6 @@ void KRRegisterColorAdapter(KRColorAdapterParseColor adapter);
  */
 void KRDisableViewReuse();
 
-/**
- * 启用新的文本渲染能力。
- * 这是一个临时API，后续会删除，未经沟通，请勿调用。
- */
-void KREnableTextRenderV2();
 
 /* ============ Text Post Processor Adapter ============
  *

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
@@ -42,7 +42,6 @@
 #include "libohos_render/utils/KRStringUtil.h"
 #include "libohos_render/utils/KRViewUtil.h"
 
-static bool KR_TEXT_RENDER_V2_ENABLED = false;
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -54,9 +53,6 @@ extern void OH_Drawing_DestroyTextLines(OH_Drawing_Array* lines) __attribute__((
 extern void OH_Drawing_SetTypographyVerticalAlignment(OH_Drawing_TypographyStyle* style,
                                                       OH_Drawing_TextVerticalAlignment alignment) __attribute__((weak));
 
-void KREnableTextRenderV2(){
-    KR_TEXT_RENDER_V2_ENABLED = true;
-}
 #ifdef __cplusplus
 };
 #endif

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
@@ -43,6 +43,8 @@ inline constexpr const char *kInternalImageSrcKey = "__kr_image_src__";
 }  // namespace richtext
 }  // namespace kuikly
 
+constexpr bool KR_TEXT_RENDER_V2_ENABLED = false;
+
 /**
  * 跨线程安全的 OH_Drawing_Typography 持有句柄。
  *

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
@@ -69,7 +69,11 @@ static const char * kPropNameClick = "click";
 static const char * kPropNameLongPress = "longPress";
 
 ArkUI_NodeHandle KRRichTextView::CreateNode() {
-    return kuikly::util::GetNodeApi()->createNode(ARKUI_NODE_TEXT);
+    if (KR_TEXT_RENDER_V2_ENABLED){
+        return kuikly::util::GetNodeApi()->createNode(ARKUI_NODE_TEXT);
+    } else {
+        return kuikly::util::GetNodeApi()->createNode(ARKUI_NODE_CUSTOM);
+    }
 }
 
 void KRRichTextView::OnDestroy() {


### PR DESCRIPTION
…system

1. Prevent frequent log generated by ohos internal text rendering stack, aka, skia: "Call generatePaintRegion when paragraph is not formatted"
2. Disable text render v2 by default