### PR TITLE
fix(compose): dispatch key input events

### DIFF
--- a/compose/src/androidMain/kotlin/com/tencent/kuikly/compose/ui/input/key/KeyEvent.android.kt
+++ b/compose/src/androidMain/kotlin/com/tencent/kuikly/compose/ui/input/key/KeyEvent.android.kt
@@ -1,0 +1,37 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.compose.ui.input.key
+
+import android.view.KeyEvent as AndroidKeyEvent
+
+/**
+ * Convert an Android hardware key event into the Kuikly Compose key event model.
+ */
+fun AndroidKeyEvent.toComposeKeyEvent(): KeyEvent =
+    KeyEvent(
+        key = Key(keyCode.toLong()),
+        type = when (action) {
+            AndroidKeyEvent.ACTION_UP -> KeyEventType.KeyUp
+            AndroidKeyEvent.ACTION_DOWN -> KeyEventType.KeyDown
+            else -> KeyEventType.Unknown
+        },
+        utf16CodePoint = unicodeChar,
+        isAltPressed = isAltPressed,
+        isCtrlPressed = isCtrlPressed,
+        isMetaPressed = isMetaPressed,
+        isShiftPressed = isShiftPressed,
+        nativeKeyEvent = this,
+    )

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ComposeContainer.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ComposeContainer.kt
@@ -35,6 +35,9 @@ import com.tencent.kuikly.core.module.FileModule
 import com.tencent.kuikly.core.module.Module
 import com.tencent.kuikly.compose.ui.ExperimentalComposeUiApi
 import com.tencent.kuikly.compose.ui.InternalComposeUiApi
+import com.tencent.kuikly.compose.ui.input.key.Key
+import com.tencent.kuikly.compose.ui.input.key.KeyEvent
+import com.tencent.kuikly.compose.ui.input.key.KeyEventType
 import com.tencent.kuikly.compose.ui.platform.WindowInfoImpl
 import com.tencent.kuikly.compose.ui.scene.ComposeScene
 import com.tencent.kuikly.compose.ui.scene.KuiklyComposeScene
@@ -80,6 +83,22 @@ open class ComposeContainer :
          * 建议在ComposeContainer.willInit方法内使用，在setContent之前设置
          */
         var enableConsumeSnapshot: Boolean = true
+
+        /**
+         * Pager event name that render hosts can use to send hardware key events to Compose.
+         */
+        const val PAGER_EVENT_KEY_EVENT = "keyEvent"
+
+        const val KEY_EVENT_KEY_CODE = "keyCode"
+        const val KEY_EVENT_TYPE = "type"
+        const val KEY_EVENT_TYPE_UNKNOWN = 0
+        const val KEY_EVENT_TYPE_UP = 1
+        const val KEY_EVENT_TYPE_DOWN = 2
+        const val KEY_EVENT_UTF16_CODE_POINT = "utf16CodePoint"
+        const val KEY_EVENT_ALT_PRESSED = "altPressed"
+        const val KEY_EVENT_CTRL_PRESSED = "ctrlPressed"
+        const val KEY_EVENT_META_PRESSED = "metaPressed"
+        const val KEY_EVENT_SHIFT_PRESSED = "shiftPressed"
     }
 
     override var ignoreLayout = true
@@ -261,6 +280,15 @@ open class ComposeContainer :
         return mediator
     }
 
+    /**
+     * Dispatch a hardware key event into the Compose focus tree.
+     *
+     * Platform render hosts can normalize their native key event into [KeyEvent] and call this
+     * method to drive [Modifier.onPreviewKeyEvent] and [Modifier.onKeyEvent] handlers.
+     */
+    fun sendKeyEvent(keyEvent: KeyEvent): Boolean =
+        mediator?.sendKeyEvent(keyEvent) ?: false
+
     override fun onReceivePagerEvent(pagerEvent: String, eventData: JSONObject) {
         super.onReceivePagerEvent(pagerEvent, eventData)
         if (pagerEvent == PAGER_EVENT_ROOT_VIEW_SIZE_CHANGED) {
@@ -283,8 +311,34 @@ open class ComposeContainer :
             val fontWeightScale = eventData.optDouble("fontWeightScale", 1.0)
             val fontSizeScale = eventData.optDouble("fontSizeScale", 1.0)
             configuration?.onFontConfigChange(fontSizeScale, fontWeightScale)
+        } else if (pagerEvent == PAGER_EVENT_KEY_EVENT) {
+            sendKeyEvent(eventData.toKeyEvent())
         }
     }
+
+    private fun JSONObject.toKeyEvent(): KeyEvent =
+        KeyEvent(
+            key = Key(optLong(KEY_EVENT_KEY_CODE, Key.Unknown.keyCode)),
+            type = optKeyEventType(),
+            utf16CodePoint = optInt(KEY_EVENT_UTF16_CODE_POINT, 0),
+            isAltPressed = optBoolean(KEY_EVENT_ALT_PRESSED, false),
+            isCtrlPressed = optBoolean(KEY_EVENT_CTRL_PRESSED, false),
+            isMetaPressed = optBoolean(KEY_EVENT_META_PRESSED, false),
+            isShiftPressed = optBoolean(KEY_EVENT_SHIFT_PRESSED, false),
+        )
+
+    private fun JSONObject.optKeyEventType(): KeyEventType =
+        when (optInt(KEY_EVENT_TYPE, KEY_EVENT_TYPE_UNKNOWN)) {
+            KEY_EVENT_TYPE_UP -> KeyEventType.KeyUp
+            KEY_EVENT_TYPE_DOWN -> KeyEventType.KeyDown
+            else -> {
+                when (optString(KEY_EVENT_TYPE, "")) {
+                    "KeyUp", "keyUp", "up" -> KeyEventType.KeyUp
+                    "KeyDown", "keyDown", "down" -> KeyEventType.KeyDown
+                    else -> KeyEventType.Unknown
+                }
+            }
+        }
 
     private fun updateWindowContainer(frame: Frame) {
         windowInfo.containerSize = IntSize(
@@ -356,4 +410,5 @@ open class ComposeContainer :
     override fun createExternalModules(): Map<String, Module>? {
         return null
     }
+
 }

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ComposeSceneMediator.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ComposeSceneMediator.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import com.tencent.kuikly.compose.ui.ExperimentalComposeUiApi
 import com.tencent.kuikly.compose.ui.InternalComposeUiApi
+import com.tencent.kuikly.compose.ui.input.key.KeyEvent
 import com.tencent.kuikly.compose.ui.platform.LocalConfiguration
 import com.tencent.kuikly.compose.ui.platform.WindowInfo
 import com.tencent.kuikly.compose.ui.scene.ComposeScene
@@ -113,6 +114,9 @@ class ComposeSceneMediator(
             scene.render(null, timestamp)
         }
     }
+
+    fun sendKeyEvent(keyEvent: KeyEvent): Boolean =
+        scene.sendKeyEvent(keyEvent)
 
     fun updateDensity(toFloat: Float) {
         scene.density = Density(toFloat)

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/focus/FocusOwner.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/focus/FocusOwner.kt
@@ -18,7 +18,7 @@ package com.tencent.kuikly.compose.ui.focus
 
 import com.tencent.kuikly.compose.ui.Modifier
 import com.tencent.kuikly.compose.ui.geometry.Rect
-//import com.tencent.kuikly.compose.ui.input.key.KeyEvent
+import com.tencent.kuikly.compose.ui.input.key.KeyEvent
 //import com.tencent.kuikly.compose.ui.input.rotary.RotaryScrollEvent
 
 /**
@@ -126,20 +126,20 @@ internal interface FocusOwner : FocusManager {
      */
     fun getFocusRect(): Rect?
 
-//    /**
-//     * Dispatches a key event through the compose hierarchy.
-//     *
-//     * When an embedded subview has focus, we call onPreviewKeyEvents for all the parents, and then
-//     * invoke onFocusedItem before we call onKeyEvent on all the parents.
-//     *
-//     * @param keyEvent the key event to be dispatched
-//     *
-//     * @param onFocusedItem the block that is run after calling onPreviewKeyEvents on all the
-//     * parents. Returning true will consume the event and prevent the event from propagating
-//     * to the onKeyEvent modifiers on parents. This is used to dispatch key events to embedded
-//     * sub-views.
-//     */
-//    fun dispatchKeyEvent(keyEvent: KeyEvent, onFocusedItem: () -> Boolean = { false }): Boolean
+    /**
+     * Dispatches a key event through the compose hierarchy.
+     *
+     * When an embedded subview has focus, we call onPreviewKeyEvents for all the parents, and then
+     * invoke onFocusedItem before we call onKeyEvent on all the parents.
+     *
+     * @param keyEvent the key event to be dispatched
+     *
+     * @param onFocusedItem the block that is run after calling onPreviewKeyEvents on all the
+     * parents. Returning true will consume the event and prevent the event from propagating
+     * to the onKeyEvent modifiers on parents. This is used to dispatch key events to embedded
+     * sub-views.
+     */
+    fun dispatchKeyEvent(keyEvent: KeyEvent, onFocusedItem: () -> Boolean = { false }): Boolean
 //
 //    /**
 //     * Dispatches an intercepted soft keyboard key event through the compose hierarchy.

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/focus/FocusOwnerImpl.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/focus/FocusOwnerImpl.kt
@@ -29,11 +29,9 @@ import com.tencent.kuikly.compose.ui.focus.FocusDirection.Companion.Previous
 import com.tencent.kuikly.compose.ui.focus.FocusRequester.Companion.Cancel
 import com.tencent.kuikly.compose.ui.focus.FocusRequester.Companion.Default
 import com.tencent.kuikly.compose.ui.geometry.Rect
-//import com.tencent.kuikly.compose.ui.input.key.KeyEvent
-//import com.tencent.kuikly.compose.ui.input.key.KeyEventType.Companion.KeyDown
-//import com.tencent.kuikly.compose.ui.input.key.KeyEventType.Companion.KeyUp
-//import com.tencent.kuikly.compose.ui.input.key.key
-//import com.tencent.kuikly.compose.ui.input.key.type
+import com.tencent.kuikly.compose.ui.input.key.KeyEvent
+import com.tencent.kuikly.compose.ui.input.key.KeyEventType.Companion.KeyDown
+import com.tencent.kuikly.compose.ui.input.key.KeyEventType.Companion.KeyUp
 //import com.tencent.kuikly.compose.ui.input.rotary.RotaryScrollEvent
 import com.tencent.kuikly.compose.ui.node.DelegatableNode
 import com.tencent.kuikly.compose.ui.node.ModifierNodeElement
@@ -255,30 +253,30 @@ internal class FocusOwnerImpl(
         }
     }
 
-//    /**
-//     * Dispatches a key event through the compose hierarchy.
-//     */
-//    override fun dispatchKeyEvent(keyEvent: KeyEvent, onFocusedItem: () -> Boolean): Boolean {
-//        if (focusInvalidationManager.hasPendingInvalidation()) {
-//            // Ignoring this to unblock b/346370327.
-//            println("$Warning: Dispatching key event while focus system is invalidated.")
-//            return false
-//        }
-//        if (!validateKeyEvent(keyEvent)) return false
-//
-//        val activeFocusTarget = rootFocusNode.findActiveFocusNode()
-//        val focusedKeyInputNode = activeFocusTarget?.lastLocalKeyInputNode()
-//                ?: activeFocusTarget?.nearestAncestorIncludingSelf(Nodes.KeyInput)?.node
-//                ?: rootFocusNode.nearestAncestor(Nodes.KeyInput)?.node
-//
-//        focusedKeyInputNode?.traverseAncestorsIncludingSelf(
-//            type = Nodes.KeyInput,
-//            onPreVisit = { if (it.onPreKeyEvent(keyEvent)) return true },
-//            onVisit = { if (onFocusedItem.invoke()) return true },
-//            onPostVisit = { if (it.onKeyEvent(keyEvent)) return true }
-//        )
-//        return false
-//    }
+    /**
+     * Dispatches a key event through the compose hierarchy.
+     */
+    override fun dispatchKeyEvent(keyEvent: KeyEvent, onFocusedItem: () -> Boolean): Boolean {
+        if (focusInvalidationManager.hasPendingInvalidation()) {
+            // Ignoring this to unblock b/346370327.
+            println("$Warning: Dispatching key event while focus system is invalidated.")
+            return false
+        }
+        if (!validateKeyEvent(keyEvent)) return false
+
+        val activeFocusTarget = rootFocusNode.findActiveFocusNode()
+        val focusedKeyInputNode = activeFocusTarget?.lastLocalKeyInputNode()
+            ?: activeFocusTarget?.nearestAncestorIncludingSelf(Nodes.KeyInput)?.node
+            ?: rootFocusNode.nearestAncestor(Nodes.KeyInput)?.node
+
+        focusedKeyInputNode?.traverseAncestorsIncludingSelf(
+            type = Nodes.KeyInput,
+            onPreVisit = { if (it.onPreKeyEvent(keyEvent)) return true },
+            onVisit = { if (onFocusedItem.invoke()) return true },
+            onPostVisit = { if (it.onKeyEvent(keyEvent)) return true }
+        )
+        return false
+    }
 //
 //    @OptIn(ExperimentalComposeUiApi::class)
 //    override fun dispatchInterceptedSoftKeyboardEvent(keyEvent: KeyEvent): Boolean {
@@ -381,38 +379,38 @@ internal class FocusOwnerImpl(
     override val rootState: FocusState
         get() = rootFocusNode.focusState
 
-//    private fun DelegatableNode.lastLocalKeyInputNode(): Modifier.Node? {
-//        var focusedKeyInputNode: Modifier.Node? = null
-//        visitLocalDescendants(Nodes.FocusTarget or Nodes.KeyInput) { modifierNode ->
-//            if (modifierNode.isKind(Nodes.FocusTarget)) return focusedKeyInputNode
-//
-//            focusedKeyInputNode = modifierNode
-//        }
-//        return focusedKeyInputNode
-//    }
-//
-//    // TODO(b/307580000) Factor this out into a class to manage key inputs.
-//    private fun validateKeyEvent(keyEvent: KeyEvent): Boolean {
-//        val keyCode = keyEvent.key.keyCode
-//        when (keyEvent.type) {
-//            KeyDown -> {
-//                // It's probably rare for more than 3 hardware keys to be pressed simultaneously.
-//                val keysCurrentlyDown = keysCurrentlyDown ?: MutableLongSet(initialCapacity = 3)
-//                    .also { keysCurrentlyDown = it }
-//                keysCurrentlyDown += keyCode
-//            }
-//
-//            KeyUp -> {
-//                if (keysCurrentlyDown?.contains(keyCode) != true) {
-//                    // An UP event for a key that was never DOWN is invalid, ignore it.
-//                    return false
-//                }
-//                keysCurrentlyDown?.remove(keyCode)
-//            }
-//            // Always process Unknown event types.
-//        }
-//        return true
-//    }
+    private fun DelegatableNode.lastLocalKeyInputNode(): Modifier.Node? {
+        var focusedKeyInputNode: Modifier.Node? = null
+        visitLocalDescendants(Nodes.FocusTarget or Nodes.KeyInput) { modifierNode ->
+            if (modifierNode.isKind(Nodes.FocusTarget)) return focusedKeyInputNode
+
+            focusedKeyInputNode = modifierNode
+        }
+        return focusedKeyInputNode
+    }
+
+    // TODO(b/307580000) Factor this out into a class to manage key inputs.
+    private fun validateKeyEvent(keyEvent: KeyEvent): Boolean {
+        val keyCode = keyEvent.key.keyCode
+        when (keyEvent.type) {
+            KeyDown -> {
+                // It's probably rare for more than 3 hardware keys to be pressed simultaneously.
+                val keysCurrentlyDown = keysCurrentlyDown ?: MutableLongSet(initialCapacity = 3)
+                    .also { keysCurrentlyDown = it }
+                keysCurrentlyDown += keyCode
+            }
+
+            KeyUp -> {
+                if (keysCurrentlyDown?.contains(keyCode) != true) {
+                    // An UP event for a key that was never DOWN is invalid, ignore it.
+                    return false
+                }
+                keysCurrentlyDown?.remove(keyCode)
+            }
+            // Always process Unknown event types.
+        }
+        return true
+    }
 }
 
 /**

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/input/key/KeyEvent.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/input/key/KeyEvent.kt
@@ -17,12 +17,6 @@
 package com.tencent.kuikly.compose.ui.input.key
 
 /**
- * The native platform-specific keyboard key event.
- */
-//expect class NativeKeyEvent
-typealias NativeKeyEvent = Any
-
-/**
  * When a user presses a key on a hardware keyboard, a [KeyEvent] is sent to the item that is
  * currently focused. Any parent composable can intercept this [key event][KeyEvent] on its way to
  * the focused item by using [Modifier.onPreviewKeyEvent()]][onPreviewKeyEvent]. If the item is
@@ -31,106 +25,56 @@ typealias NativeKeyEvent = Any
  *
  * @sample androidx.compose.ui.samples.KeyEventSample
  */
-@kotlin.jvm.JvmInline
-value class KeyEvent(val nativeKeyEvent: NativeKeyEvent)
+data class KeyEvent(
+    val key: Key,
+    val type: KeyEventType = KeyEventType.Unknown,
+    val utf16CodePoint: Int = 0,
+    val isAltPressed: Boolean = false,
+    val isCtrlPressed: Boolean = false,
+    val isMetaPressed: Boolean = false,
+    val isShiftPressed: Boolean = false,
+    val nativeKeyEvent: Any? = null
+) {
+    companion object
+}
 
-///**
-// * The key that was pressed.
-// *
-// * @sample androidx.compose.ui.samples.KeyEventIsAltPressedSample
-// */
-//val KeyEvent.key: Key get() = Key(nativeKeyEvent.key)
-//
-///**
-// * The UTF16 value corresponding to the key event that was pressed. The unicode character
-// * takes into account any meta keys that are pressed (eg. Pressing shift results in capital
-// * alphabets). The UTF16 value uses the
-// * [U+n notation][http://www.unicode.org/reports/tr27/#notation] of the Unicode Standard.
-// *
-// * An [Int] is used instead of a [Char] so that we can support supplementary characters. The
-// * Unicode Standard allows for characters whose representation requires more than 16 bits.
-// * The range of legal code points is U+0000 to U+10FFFF, known as Unicode scalar value.
-// *
-// * The set of characters from U+0000 to U+FFFF is sometimes referred to as the Basic
-// * Multilingual Plane (BMP). Characters whose code points are greater than U+FFFF are called
-// * supplementary characters. In this representation, supplementary characters are represented
-// * as a pair of char values, the first from the high-surrogates range, (\uD800-\uDBFF), the
-// * second from the low-surrogates range (\uDC00-\uDFFF).
-// */
-//expect val KeyEvent.utf16CodePoint: Int
-//
-///**
-// * The [type][KeyEventType] of key event.
-// *
-// * @sample androidx.compose.ui.samples.KeyEventTypeSample
-// */
-//expect val KeyEvent.type: KeyEventType
-//
-///**
-// * Indicates whether the Alt key is pressed.
-// *
-// * @sample androidx.compose.ui.samples.KeyEventIsAltPressedSample
-// */
-//expect val KeyEvent.isAltPressed: Boolean
-//
-///**
-// * Indicates whether the Ctrl key is pressed.
-// *
-// * @sample androidx.compose.ui.samples.KeyEventIsCtrlPressedSample
-// */
-//expect val KeyEvent.isCtrlPressed: Boolean
-//
-///**
-// * Indicates whether the Meta key is pressed.
-// *
-// * @sample androidx.compose.ui.samples.KeyEventIsMetaPressedSample
-// */
-//expect val KeyEvent.isMetaPressed: Boolean
-//
-///**
-// * Indicates whether the Shift key is pressed.
-// *
-// * @sample androidx.compose.ui.samples.KeyEventIsShiftPressedSample
-// */
-//expect val KeyEvent.isShiftPressed: Boolean
-//
-///**
-// * The type of Key Event.
-// *
-// * @sample androidx.compose.ui.samples.KeyEventTypeSample
-// */
-//@kotlin.jvm.JvmInline
-//value class KeyEventType internal constructor(@Suppress("unused") private val value: Int) {
-//
-//    override fun toString(): String {
-//        return when (this) {
-//            KeyUp -> "KeyUp"
-//            KeyDown -> "KeyDown"
-//            Unknown -> "Unknown"
-//            else -> "Invalid"
-//        }
-//    }
-//
-//    companion object {
-//        /**
-//         * Unknown key event.
-//         *
-//         * @sample androidx.compose.ui.samples.KeyEventTypeSample
-//         */
-//        val Unknown: KeyEventType = KeyEventType(0)
-//
-//        /**
-//         * Type of KeyEvent sent when the user lifts their finger off a key on the keyboard.
-//         *
-//         * @sample androidx.compose.ui.samples.KeyEventTypeSample
-//         */
-//        val KeyUp: KeyEventType = KeyEventType(1)
-//
-//        /**
-//         * Type of KeyEvent sent when the user presses down their finger on a key on the keyboard.
-//         *
-//         * @sample androidx.compose.ui.samples.KeyEventTypeSample
-//         */
-//        val KeyDown: KeyEventType = KeyEventType(2)
-//    }
-//}
+/**
+ * The type of Key Event.
+ *
+ * @sample androidx.compose.ui.samples.KeyEventTypeSample
+ */
+@kotlin.jvm.JvmInline
+value class KeyEventType internal constructor(@Suppress("unused") private val value: Int) {
+
+    override fun toString(): String {
+        return when (this) {
+            KeyUp -> "KeyUp"
+            KeyDown -> "KeyDown"
+            Unknown -> "Unknown"
+            else -> "Invalid"
+        }
+    }
+
+    companion object {
+        /**
+         * Unknown key event.
+         *
+         * @sample androidx.compose.ui.samples.KeyEventTypeSample
+         */
+        val Unknown: KeyEventType = KeyEventType(0)
+
+        /**
+         * Type of KeyEvent sent when the user lifts their finger off a key on the keyboard.
+         *
+         * @sample androidx.compose.ui.samples.KeyEventTypeSample
+         */
+        val KeyUp: KeyEventType = KeyEventType(1)
+
+        /**
+         * Type of KeyEvent sent when the user presses down their finger on a key on the keyboard.
+         *
+         * @sample androidx.compose.ui.samples.KeyEventTypeSample
+         */
+        val KeyDown: KeyEventType = KeyEventType(2)
+    }
+}

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/input/key/KeyInputModifier.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/input/key/KeyInputModifier.kt
@@ -17,6 +17,7 @@
 package com.tencent.kuikly.compose.ui.input.key
 
 import com.tencent.kuikly.compose.ui.Modifier
+import com.tencent.kuikly.compose.ui.node.DelegatableNode
 import com.tencent.kuikly.compose.ui.node.ModifierNodeElement
 import com.tencent.kuikly.compose.ui.platform.InspectorInfo
 
@@ -30,9 +31,9 @@ import com.tencent.kuikly.compose.ui.platform.InspectorInfo
  *
  * @sample androidx.compose.ui.samples.KeyEventSample
  */
-fun Modifier.onKeyEvent( // todo pel: noop currently, need render support
+fun Modifier.onKeyEvent(
     onKeyEvent: (KeyEvent) -> Boolean
-): Modifier = this // then KeyInputElement(onKeyEvent = onKeyEvent, onPreKeyEvent = null)
+): Modifier = this then KeyInputElement(onKeyEvent = onKeyEvent, onPreKeyEvent = null)
 
 /**
  * Adding this [modifier][Modifier] to the [modifier][Modifier] parameter of a component will
@@ -46,37 +47,43 @@ fun Modifier.onKeyEvent( // todo pel: noop currently, need render support
  *
  * @sample androidx.compose.ui.samples.KeyEventSample
  */
-fun Modifier.onPreviewKeyEvent( // todo pel: noop currently, need render support
+fun Modifier.onPreviewKeyEvent(
     onPreviewKeyEvent: (KeyEvent) -> Boolean
-): Modifier = this // then KeyInputElement(onKeyEvent = null, onPreKeyEvent = onPreviewKeyEvent)
+): Modifier = this then KeyInputElement(onKeyEvent = null, onPreKeyEvent = onPreviewKeyEvent)
 
-//internal data class KeyInputElement(
-//    val onKeyEvent: ((KeyEvent) -> Boolean)?,
-//    val onPreKeyEvent: ((KeyEvent) -> Boolean)?
-//) : ModifierNodeElement<KeyInputNode>() {
-//    override fun create() = KeyInputNode(onKeyEvent, onPreKeyEvent)
-//
-//    override fun update(node: KeyInputNode) {
-//        node.onEvent = onKeyEvent
-//        node.onPreEvent = onPreKeyEvent
-//    }
-//
-//    override fun InspectorInfo.inspectableProperties() {
-//        onKeyEvent?.let {
-//            name = "onKeyEvent"
-//            properties["onKeyEvent"] = it
-//        }
-//        onPreKeyEvent?.let {
-//            name = "onPreviewKeyEvent"
-//            properties["onPreviewKeyEvent"] = it
-//        }
-//    }
-//}
-//
-//internal class KeyInputNode(
-//    var onEvent: ((KeyEvent) -> Boolean)?,
-//    var onPreEvent: ((KeyEvent) -> Boolean)?
-//) : KeyInputModifierNode, Modifier.Node() {
-//    override fun onKeyEvent(event: KeyEvent): Boolean = this.onEvent?.invoke(event) ?: false
-//    override fun onPreKeyEvent(event: KeyEvent): Boolean = this.onPreEvent?.invoke(event) ?: false
-//}
+interface KeyInputModifierNode : DelegatableNode {
+    fun onKeyEvent(event: KeyEvent): Boolean
+
+    fun onPreKeyEvent(event: KeyEvent): Boolean
+}
+
+internal data class KeyInputElement(
+    val onKeyEvent: ((KeyEvent) -> Boolean)?,
+    val onPreKeyEvent: ((KeyEvent) -> Boolean)?
+) : ModifierNodeElement<KeyInputNode>() {
+    override fun create() = KeyInputNode(onKeyEvent, onPreKeyEvent)
+
+    override fun update(node: KeyInputNode) {
+        node.onEvent = onKeyEvent
+        node.onPreEvent = onPreKeyEvent
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        onKeyEvent?.let {
+            name = "onKeyEvent"
+            properties["onKeyEvent"] = it
+        }
+        onPreKeyEvent?.let {
+            name = "onPreviewKeyEvent"
+            properties["onPreviewKeyEvent"] = it
+        }
+    }
+}
+
+internal class KeyInputNode(
+    var onEvent: ((KeyEvent) -> Boolean)?,
+    var onPreEvent: ((KeyEvent) -> Boolean)?
+) : KeyInputModifierNode, Modifier.Node() {
+    override fun onKeyEvent(event: KeyEvent): Boolean = this.onEvent?.invoke(event) ?: false
+    override fun onPreKeyEvent(event: KeyEvent): Boolean = this.onPreEvent?.invoke(event) ?: false
+}

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/NodeKind.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/NodeKind.kt
@@ -27,6 +27,7 @@ import com.tencent.kuikly.compose.ui.focus.FocusTargetNode
 import com.tencent.kuikly.compose.ui.focus.invalidateFocusEvent
 import com.tencent.kuikly.compose.ui.focus.invalidateFocusProperties
 import com.tencent.kuikly.compose.ui.focus.invalidateFocusTarget
+import com.tencent.kuikly.compose.ui.input.key.KeyInputModifierNode
 import com.tencent.kuikly.compose.ui.input.pointer.PointerInputModifier
 import com.tencent.kuikly.compose.ui.internal.checkPrecondition
 import com.tencent.kuikly.compose.ui.internal.checkPreconditionNotNull
@@ -94,8 +95,8 @@ internal object Nodes {
     inline val FocusProperties get() = NodeKind<FocusPropertiesModifierNode>(0b1 shl 11)
     @JvmStatic
     inline val FocusEvent get() = NodeKind<FocusEventModifierNode>(0b1 shl 12)
-//    @JvmStatic
-//    inline val KeyInput get() = NodeKind<KeyInputModifierNode>(0b1 shl 13)
+    @JvmStatic
+    inline val KeyInput get() = NodeKind<KeyInputModifierNode>(0b1 shl 13)
 //    @JvmStatic
 //    inline val RotaryInput get() = NodeKind<RotaryInputModifierNode>(0b1 shl 14)
     @JvmStatic
@@ -205,9 +206,9 @@ internal fun calculateNodeKindSetFrom(node: Modifier.Node): Int {
         if (node is FocusEventModifierNode) {
             mask = mask or Nodes.FocusEvent
         }
-//        if (node is KeyInputModifierNode) {
-//            mask = mask or Nodes.KeyInput
-//        }
+        if (node is KeyInputModifierNode) {
+            mask = mask or Nodes.KeyInput
+        }
 //        if (node is RotaryInputModifierNode) {
 //            mask = mask or Nodes.RotaryInput
 //        }

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/BaseComposeScene.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/BaseComposeScene.kt
@@ -35,6 +35,7 @@ import com.tencent.kuikly.compose.ui.GlobalSnapshotManager
 import com.tencent.kuikly.compose.ui.InternalComposeUiApi
 import com.tencent.kuikly.compose.ui.geometry.Offset
 import com.tencent.kuikly.compose.ui.graphics.Canvas
+import com.tencent.kuikly.compose.ui.input.key.KeyEvent
 import com.tencent.kuikly.compose.ui.input.pointer.PointerButton
 import com.tencent.kuikly.compose.ui.input.pointer.PointerEventType
 import com.tencent.kuikly.compose.ui.input.pointer.PointerInputEvent
@@ -261,6 +262,10 @@ internal abstract class BaseComposeScene(
         throwRuntimeError("invalid invoke")
     }
 
+    override fun sendKeyEvent(keyEvent: KeyEvent): Boolean = postponeInvalidation {
+        processKeyEvent(keyEvent)
+    }
+
     private fun doLayout() {
         snapshotInvalidationTracker.onMeasureAndLayout()
         measureAndLayout()
@@ -307,6 +312,8 @@ internal abstract class BaseComposeScene(
     protected abstract fun createComposition(content: @Composable () -> Unit): Composition
 
     protected abstract fun processPointerInputEvent(event: PointerInputEvent)
+
+    protected abstract fun processKeyEvent(event: KeyEvent): Boolean
 
     protected abstract fun measureAndLayout()
 

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/ComposeScene.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/ComposeScene.kt
@@ -26,6 +26,7 @@ import com.tencent.kuikly.compose.ui.ExperimentalComposeUiApi
 import com.tencent.kuikly.compose.ui.InternalComposeUiApi
 import com.tencent.kuikly.compose.ui.geometry.Offset
 import com.tencent.kuikly.compose.ui.graphics.Canvas
+import com.tencent.kuikly.compose.ui.input.key.KeyEvent
 import com.tencent.kuikly.compose.ui.input.pointer.PointerButton
 import com.tencent.kuikly.compose.ui.input.pointer.PointerEventType
 import com.tencent.kuikly.compose.ui.input.pointer.PointerType
@@ -149,6 +150,14 @@ interface ComposeScene {
         canvas: Canvas?,
         nanoTime: Long,
     )
+
+    /**
+     * Send a hardware key event to the content.
+     *
+     * The event is routed through focus first with preview handlers from ancestors to the focused
+     * item, then normal handlers from the focused item back to ancestors.
+     */
+    fun sendKeyEvent(keyEvent: KeyEvent): Boolean
 
     /**
      * Send pointer event to the content.

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/KuiklyComposeScene.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/KuiklyComposeScene.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Composition
 import com.tencent.kuikly.compose.ui.InternalComposeUiApi
 import com.tencent.kuikly.compose.ui.graphics.Canvas
+import com.tencent.kuikly.compose.ui.input.key.KeyEvent
 import com.tencent.kuikly.compose.ui.input.pointer.PointerInputEvent
 import com.tencent.kuikly.compose.ui.node.RootNodeOwner
 import com.tencent.kuikly.compose.ui.platform.setContent
@@ -131,6 +132,9 @@ private class KuiklyComposeSceneImpl @InternalComposeUiApi constructor(
     override fun processPointerInputEvent(event: PointerInputEvent) =
         mainOwner.onPointerInput(event)
 
+    override fun processKeyEvent(event: KeyEvent): Boolean =
+        mainOwner.focusOwner.dispatchKeyEvent(event)
+
     override fun measureAndLayout() {
         mainOwner.measureAndLayout()
     }
@@ -145,4 +149,3 @@ private class KuiklyComposeSceneImpl @InternalComposeUiApi constructor(
     private fun onOwnerRemoved(owner: RootNodeOwner) {
     }
 }
-

--- a/compose/src/nativeMain/kotlin/com/tencent/kuikly/compose/ui/input/key/KeyEvent.native.kt
+++ b/compose/src/nativeMain/kotlin/com/tencent/kuikly/compose/ui/input/key/KeyEvent.native.kt
@@ -1,0 +1,65 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.compose.ui.input.key
+
+/**
+ * Build a Kuikly Compose key event from a native-family platform key code.
+ *
+ * iOS, macOS and OHOS hosts can use this when they already normalize their native key code to the
+ * same key-code space as [Key] on Kotlin/Native targets.
+ */
+fun nativePlatformKeyEvent(
+    keyCode: Long,
+    type: KeyEventType = KeyEventType.Unknown,
+    utf16CodePoint: Int = 0,
+    isAltPressed: Boolean = false,
+    isCtrlPressed: Boolean = false,
+    isMetaPressed: Boolean = false,
+    isShiftPressed: Boolean = false,
+    nativeKeyEvent: Any? = null,
+): KeyEvent =
+    KeyEvent(
+        key = Key(keyCode),
+        type = type,
+        utf16CodePoint = utf16CodePoint,
+        isAltPressed = isAltPressed,
+        isCtrlPressed = isCtrlPressed,
+        isMetaPressed = isMetaPressed,
+        isShiftPressed = isShiftPressed,
+        nativeKeyEvent = nativeKeyEvent,
+    )
+/**
+ * Build a Kuikly Compose key event from a [SkikoKey] value used by Kuikly native targets.
+ */
+fun SkikoKey.toComposeKeyEvent(
+    type: KeyEventType = KeyEventType.Unknown,
+    utf16CodePoint: Int = 0,
+    isAltPressed: Boolean = false,
+    isCtrlPressed: Boolean = false,
+    isMetaPressed: Boolean = false,
+    isShiftPressed: Boolean = false,
+    nativeKeyEvent: Any? = null,
+): KeyEvent =
+    nativePlatformKeyEvent(
+        keyCode = platformKeyCode.toLong(),
+        type = type,
+        utf16CodePoint = utf16CodePoint,
+        isAltPressed = isAltPressed,
+        isCtrlPressed = isCtrlPressed,
+        isMetaPressed = isMetaPressed,
+        isShiftPressed = isShiftPressed,
+        nativeKeyEvent = nativeKeyEvent,
+    )

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/KuiklyRenderView.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/KuiklyRenderView.kt
@@ -27,6 +27,7 @@ import android.util.Log
 import android.util.Size
 import android.util.SizeF
 import android.util.SparseArray
+import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.accessibility.AccessibilityManager
@@ -609,6 +610,25 @@ class KuiklyRenderView(
         sendEvent(ON_BACK_PRESSED, mapOf())
     }
 
+    fun sendKeyEvent(event: KeyEvent) {
+        sendEvent(
+            KEY_EVENT,
+            mapOf(
+                KEY_EVENT_KEY_CODE to event.keyCode,
+                KEY_EVENT_TYPE to when (event.action) {
+                    KeyEvent.ACTION_UP -> KEY_EVENT_TYPE_UP
+                    KeyEvent.ACTION_DOWN -> KEY_EVENT_TYPE_DOWN
+                    else -> KEY_EVENT_TYPE_UNKNOWN
+                },
+                KEY_EVENT_UTF16_CODE_POINT to event.unicodeChar,
+                KEY_EVENT_ALT_PRESSED to event.isAltPressed,
+                KEY_EVENT_CTRL_PRESSED to event.isCtrlPressed,
+                KEY_EVENT_META_PRESSED to event.isMetaPressed,
+                KEY_EVENT_SHIFT_PRESSED to event.isShiftPressed,
+            )
+        )
+    }
+
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         if (delegate?.debugLogEnable() == true) {
             if (requestedLayout) {
@@ -683,6 +703,17 @@ class KuiklyRenderView(
         private const val ACCESSIBILITY_RUNNING = "isAccessibilityRunning" // 无障碍化是否开启
 
         private const val ON_BACK_PRESSED = "onBackPressed"
+        private const val KEY_EVENT = "keyEvent"
+        private const val KEY_EVENT_KEY_CODE = "keyCode"
+        private const val KEY_EVENT_TYPE = "type"
+        private const val KEY_EVENT_TYPE_UNKNOWN = 0
+        private const val KEY_EVENT_TYPE_UP = 1
+        private const val KEY_EVENT_TYPE_DOWN = 2
+        private const val KEY_EVENT_UTF16_CODE_POINT = "utf16CodePoint"
+        private const val KEY_EVENT_ALT_PRESSED = "altPressed"
+        private const val KEY_EVENT_CTRL_PRESSED = "ctrlPressed"
+        private const val KEY_EVENT_META_PRESSED = "metaPressed"
+        private const val KEY_EVENT_SHIFT_PRESSED = "shiftPressed"
 
         // RenderView 生命周期状态
         private const val STATE_INIT = 0

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/KuiklyRenderViewBaseDelegator.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/KuiklyRenderViewBaseDelegator.kt
@@ -18,6 +18,7 @@ package com.tencent.kuikly.core.render.android.expand
 import android.content.Context
 import android.content.Intent
 import android.util.Size
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.view.WindowManager
@@ -548,6 +549,16 @@ open class KuiklyRenderViewBaseDelegator(private val delegate: KuiklyRenderViewB
             isBackPressedConsumed.set(isBackConsumed)
         }
         return isBackPressedConsumed.get()
+    }
+
+    /**
+     * Dispatch a hardware key event to a Kuikly Compose page.
+     *
+     * Apps can call this from Activity.dispatchKeyEvent. Compose pages receive it through
+     * Modifier.onPreviewKeyEvent/Modifier.onKeyEvent when the focused tree has key handlers.
+     */
+    fun sendKeyEvent(event: KeyEvent) {
+        renderView?.sendKeyEvent(event)
     }
 
 }

--- a/core-render-ios/Extension/KuiklyRenderViewControllerBaseDelegator.h
+++ b/core-render-ios/Extension/KuiklyRenderViewControllerBaseDelegator.h
@@ -130,6 +130,19 @@ FOUNDATION_EXTERN NSString *const KRPageDataSnapshotKey;
  */
 - (void)onBackPressedWithCompletion:(nullable KuiklyBackPressCompletion)completion;
 
+/*
+ * @brief 向 Kuikly Compose 页面发送硬件键盘事件.
+ * @param keyCode 平台 key code，对应 Kuikly Compose Native Key.keyCode 编码
+ * @param type 事件类型：0 unknown，1 key up，2 key down
+ */
+- (void)sendKeyEventWithKeyCode:(NSInteger)keyCode
+                           type:(NSInteger)type
+                utf16CodePoint:(NSInteger)utf16CodePoint
+                     altPressed:(BOOL)altPressed
+                    ctrlPressed:(BOOL)ctrlPressed
+                    metaPressed:(BOOL)metaPressed
+                   shiftPressed:(BOOL)shiftPressed;
+
 @end
 
 @protocol KuiklyRenderViewControllerBaseDelegatorDelegate<NSObject>
@@ -304,4 +317,3 @@ FOUNDATION_EXTERN NSString *const KRPageDataSnapshotKey;
 
 
 NS_ASSUME_NONNULL_END
-

--- a/core-render-ios/Extension/KuiklyRenderViewControllerBaseDelegator.m
+++ b/core-render-ios/Extension/KuiklyRenderViewControllerBaseDelegator.m
@@ -148,6 +148,25 @@ NSString *const KRPageDataSnapshotKey = @"kr_snapshotKey";
     }
 }
 
+- (void)sendKeyEventWithKeyCode:(NSInteger)keyCode
+                           type:(NSInteger)type
+                utf16CodePoint:(NSInteger)utf16CodePoint
+                     altPressed:(BOOL)altPressed
+                    ctrlPressed:(BOOL)ctrlPressed
+                    metaPressed:(BOOL)metaPressed
+                   shiftPressed:(BOOL)shiftPressed {
+    [self sendWithEvent:@"keyEvent"
+                   data:@{
+                       @"keyCode": @(keyCode),
+                       @"type": @(type),
+                       @"utf16CodePoint": @(utf16CodePoint),
+                       @"altPressed": @(altPressed),
+                       @"ctrlPressed": @(ctrlPressed),
+                       @"metaPressed": @(metaPressed),
+                       @"shiftPressed": @(shiftPressed),
+                   }];
+}
+
 - (BOOL)syncSendEvent:(NSString *)event {
     // onBackPressed 固定同步执行
     if ([event isEqualToString:@"onBackPressed"]) {
@@ -567,5 +586,4 @@ NSString *const KRPageDataSnapshotKey = @"kr_snapshotKey";
 }
 
 @end
-
 

--- a/core-render-ios/View/KuiklyRenderView.h
+++ b/core-render-ios/View/KuiklyRenderView.h
@@ -74,6 +74,19 @@ FOUNDATION_EXTERN NSString *const KRRootViewSizeDidChangedEventKey;
 - (void)sendWithEvent:(NSString *)event data:(NSDictionary *)data sync:(BOOL)sync;
 
 /*
+ * @brief 向 Kuikly Compose 页面发送硬件键盘事件.
+ * @param keyCode 平台 key code，对应 Kuikly Compose Native Key.keyCode 编码
+ * @param type 事件类型：0 unknown，1 key up，2 key down
+ */
+- (void)sendKeyEventWithKeyCode:(NSInteger)keyCode
+                           type:(NSInteger)type
+                utf16CodePoint:(NSInteger)utf16CodePoint
+                     altPressed:(BOOL)altPressed
+                    ctrlPressed:(BOOL)ctrlPressed
+                    metaPressed:(BOOL)metaPressed
+                   shiftPressed:(BOOL)shiftPressed;
+
+/*
  * @brief 获取模块对应的实例（仅支持在主线程调用）.
  * @param moduleName 模块名
  * @return module实例
@@ -169,4 +182,3 @@ FOUNDATION_EXTERN NSString *const KRRootViewSizeDidChangedEventKey;
 @end
 
 NS_ASSUME_NONNULL_END
-

--- a/core-render-ios/View/KuiklyRenderView.m
+++ b/core-render-ios/View/KuiklyRenderView.m
@@ -92,6 +92,26 @@ NSString *const KRDensity = @"density";
 - (void)sendWithEvent:(NSString *)event data:(NSDictionary *)data sync:(BOOL)sync {
     [_renderCore sendWithEvent:event data:data sync:sync];
 }
+
+- (void)sendKeyEventWithKeyCode:(NSInteger)keyCode
+                           type:(NSInteger)type
+                utf16CodePoint:(NSInteger)utf16CodePoint
+                     altPressed:(BOOL)altPressed
+                    ctrlPressed:(BOOL)ctrlPressed
+                    metaPressed:(BOOL)metaPressed
+                   shiftPressed:(BOOL)shiftPressed {
+    [self sendWithEvent:@"keyEvent"
+                   data:@{
+                       @"keyCode": @(keyCode),
+                       @"type": @(type),
+                       @"utf16CodePoint": @(utf16CodePoint),
+                       @"altPressed": @(altPressed),
+                       @"ctrlPressed": @(ctrlPressed),
+                       @"metaPressed": @(metaPressed),
+                       @"shiftPressed": @(shiftPressed),
+                   }];
+}
+
 /*
  * @brief 获取模块对应的实例（仅支持在主线程调用）.
  * @param moduleName 模块名
@@ -355,4 +375,3 @@ NSString *const KRDensity = @"density";
 }
 
 @end
-

--- a/core-render-ohos/src/main/ets/IKuiklyRenderView.ets
+++ b/core-render-ohos/src/main/ets/IKuiklyRenderView.ets
@@ -39,6 +39,21 @@ export interface IKuiklyRenderView {
   sendEventSync(event: string, data: KRRecord, sync: boolean): void;
 
   /**
+   * Send a hardware key event to a Kuikly Compose page.
+   * @param keyCode platform key code normalized to Kuikly Compose Native Key.keyCode
+   * @param type event type: 0 unknown, 1 key up, 2 key down
+   */
+  sendKeyEvent(
+    keyCode: number,
+    type: number,
+    utf16CodePoint?: number,
+    altPressed?: boolean,
+    ctrlPressed?: boolean,
+    metaPressed?: boolean,
+    shiftPressed?: boolean
+  ): void;
+
+  /**
    * 获取 [KuiklyRenderBaseModule]
    * @param name module 的名字
    * @return [KuiklyRenderBaseModule] 的子类

--- a/core-render-ohos/src/main/ets/KRNativeRenderController.ets
+++ b/core-render-ohos/src/main/ets/KRNativeRenderController.ets
@@ -525,6 +525,19 @@ export class KRNativeRenderController {
     this.doSendEvent(event, data, sync);
   }
 
+  sendKeyEvent(keyCode: number, type: number, utf16CodePoint?: number, altPressed?: boolean,
+    ctrlPressed?: boolean, metaPressed?: boolean, shiftPressed?: boolean) {
+    this.doSendEvent('keyEvent', {
+      'keyCode': keyCode,
+      'type': type,
+      'utf16CodePoint': utf16CodePoint ?? 0,
+      'altPressed': altPressed ?? false,
+      'ctrlPressed': ctrlPressed ?? false,
+      'metaPressed': metaPressed ?? false,
+      'shiftPressed': shiftPressed ?? false,
+    });
+  }
+
   onBackPress() {
     const sendTime = Date.now();
     this.doSendEvent(KROnBackPressedKey, {}, this.syncSendEvent(KROnBackPressedKey));


### PR DESCRIPTION
## Summary

This restores Kuikly Compose hardware key input dispatch so `Modifier.onPreviewKeyEvent` and `Modifier.onKeyEvent` are no longer no-op once a render host sends key events into the page.

Changes:
- add a normalized common `KeyEvent` / `KeyEventType` model
- restore `KeyInputModifierNode`, node-kind registration, and focus-owner key dispatch traversal
- add `ComposeScene` / `ComposeContainer.sendKeyEvent` plus a `keyEvent` pager-event entry point
- add Android and native-family conversion helpers for key events
- expose host helper entry points for Android, iOS/macOS render, and OHOS render to send key events with key code, type, utf16 code point, and modifier flags

## Notes

The generic render pager event path is fire-and-forget, so this PR delivers events into the Compose focus tree and lets Compose handlers consume internally. It does not add a synchronous native host `dispatchKeyEvent` consumed-return contract; Android back press has a separate sync path today, and a fully synchronous key-event return path would be a larger host protocol change.

## Validation

Passed on this branch based on latest `upstream/main`:

```bash
./gradlew :core-render-android:compileDebugKotlin :compose:compileDebugKotlinAndroid --console=plain --no-daemon --max-workers=1
./gradlew :compose:compileKotlinIosSimulatorArm64 :compose:compileKotlinMacosArm64 --console=plain --no-daemon --max-workers=1
git diff --check upstream/main..HEAD
```

OHOS note: on latest `upstream/main`, local `./gradlew -c settings.2.0.ohos.gradle.kts :compose:compileKotlinOhosArm64` is blocked before source compilation by an existing Gradle Kotlin DSL script issue in `core/build.2.0.ohos.gradle.kts` (`System.getProperty("os.name").lowercase()` unresolved in this local Gradle/Kotlin DSL environment). The same key-event source change was also compiled through the Slock OHOS consumer path earlier on the Slock Kuikly staging branch.
