### PR TITLE
fix(android): forward pointer-up to RV when touchConsumeByKuikly

### DIFF
--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/adapter/IKRKeyboardHeightAdapter.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/adapter/IKRKeyboardHeightAdapter.kt
@@ -1,0 +1,38 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.core.render.android.adapter
+
+import android.app.Activity
+
+/**
+ * 键盘高度适配器，供业务按机型/ROM 修正框架上报的键盘高度（单位：px）。
+ * 未注册时框架直接透传原始高度。
+ */
+interface IKRKeyboardHeightAdapter {
+
+    /**
+     * @param context 包含 Activity 与框架原始键盘高度
+     * @return 修正后的键盘高度（px）
+     */
+    fun adaptKeyboardHeight(context: KRKeyboardHeightContext): Int {
+        return context.rawHeightPx
+    }
+}
+
+data class KRKeyboardHeightContext(
+    val activity: Activity,
+    val rawHeightPx: Int,
+)

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/adapter/KRDefaultKeyboardHeightAdapter.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/adapter/KRDefaultKeyboardHeightAdapter.kt
@@ -1,0 +1,64 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.core.render.android.adapter
+
+import android.app.Activity
+import android.graphics.Rect
+import android.os.Build
+import android.view.View
+import android.view.WindowInsets
+
+/**
+ * 框架默认键盘高度适配器，修正部分 ROM 上框架计算的键盘高度偏差。
+ * 业务可通过注册 [KuiklyRenderAdapterManager.krKeyboardHeightAdapter] 完全覆盖。
+ */
+object KRDefaultKeyboardHeightAdapter : IKRKeyboardHeightAdapter {
+
+    override fun adaptKeyboardHeight(context: KRKeyboardHeightContext): Int {
+        if (!isSamsung()) {
+            return context.rawHeightPx
+        }
+        return adaptSamsung(context)
+    }
+
+    private fun adaptSamsung(context: KRKeyboardHeightContext): Int {
+        val activity = context.activity
+        val rawHeightPx = context.rawHeightPx
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val rootView = activity.findViewById<View>(android.R.id.content) ?: return rawHeightPx
+            val insets = rootView.rootWindowInsets ?: return rawHeightPx
+            val imeHeight = insets.getInsets(WindowInsets.Type.ime()).bottom
+            if (imeHeight > 0) {
+                return imeHeight
+            }
+        }
+
+        val fallback = visibleFrameKeyboardHeight(activity)
+        return if (fallback > 0) fallback else rawHeightPx
+    }
+
+    private fun visibleFrameKeyboardHeight(activity: Activity): Int {
+        val decorView = activity.window.decorView
+        val rect = Rect()
+        decorView.getWindowVisibleDisplayFrame(rect)
+        return (decorView.height - rect.bottom).coerceAtLeast(0)
+    }
+
+    private fun isSamsung(): Boolean {
+        return Build.MANUFACTURER.equals("samsung", ignoreCase = true)
+    }
+}

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/adapter/KRDefaultKeyboardHeightAdapter.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/adapter/KRDefaultKeyboardHeightAdapter.kt
@@ -16,10 +16,18 @@
 package com.tencent.kuikly.core.render.android.adapter
 
 import android.app.Activity
+import android.content.res.Resources
 import android.graphics.Rect
 import android.os.Build
+import android.provider.Settings
 import android.view.View
 import android.view.WindowInsets
+
+/** Android 16 (API 36)，compileSdk 未定义对应 VERSION_CODES 时的兜底常量 */
+private const val ANDROID_16_API_LEVEL = 36
+
+/** [Settings.Secure.navigation_mode]：0 = 三键虚拟导航栏 */
+private const val NAVIGATION_MODE_THREE_BUTTON = 0
 
 /**
  * 框架默认键盘高度适配器，修正部分 ROM 上框架计算的键盘高度偏差。
@@ -36,19 +44,59 @@ object KRDefaultKeyboardHeightAdapter : IKRKeyboardHeightAdapter {
 
     private fun adaptSamsung(context: KRKeyboardHeightContext): Int {
         val activity = context.activity
-        val rawHeightPx = context.rawHeightPx
+        var height = context.rawHeightPx
+
+        if (height > 0) {
+            return applySamsungGestureNavCompensation(activity, height)
+        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            val rootView = activity.findViewById<View>(android.R.id.content) ?: return rawHeightPx
-            val insets = rootView.rootWindowInsets ?: return rawHeightPx
+            val rootView = activity.findViewById<View>(android.R.id.content) ?: return height
+            val insets = rootView.rootWindowInsets ?: return height
             val imeHeight = insets.getInsets(WindowInsets.Type.ime()).bottom
             if (imeHeight > 0) {
-                return imeHeight
+                return applySamsungGestureNavCompensation(activity, imeHeight)
             }
         }
 
         val fallback = visibleFrameKeyboardHeight(activity)
-        return if (fallback > 0) fallback else rawHeightPx
+        return if (fallback > 0) {
+            applySamsungGestureNavCompensation(activity, fallback)
+        } else {
+            height
+        }
+    }
+
+    /** Android 16 + 三星 + 全面屏手势：补上系统静态虚拟导航栏高度 */
+    private fun applySamsungGestureNavCompensation(activity: Activity, heightPx: Int): Int {
+        if (!shouldAddSamsungGestureNavCompensation(activity)) {
+            return heightPx
+        }
+        return heightPx + getStaticNavigationBarHeightPx()
+    }
+
+    private fun shouldAddSamsungGestureNavCompensation(activity: Activity): Boolean {
+        return Build.VERSION.SDK_INT >= ANDROID_16_API_LEVEL
+            && isFullScreenGestureNavigation(activity)
+    }
+
+    private fun isFullScreenGestureNavigation(activity: Activity): Boolean {
+        return try {
+            Settings.Secure.getInt(
+                activity.contentResolver,
+                "navigation_mode",
+                NAVIGATION_MODE_THREE_BUTTON,
+            ) != NAVIGATION_MODE_THREE_BUTTON
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /** 系统配置的导航栏高度（与当前 WindowInsets 可见性无关） */
+    private fun getStaticNavigationBarHeightPx(): Int {
+        val resources = Resources.getSystem()
+        val resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
+        return if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
     }
 
     private fun visibleFrameKeyboardHeight(activity: Activity): Int {

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/adapter/KuiklyRenderAdapterManager.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/adapter/KuiklyRenderAdapterManager.kt
@@ -86,6 +86,11 @@ object KuiklyRenderAdapterManager {
     var krTextPostProcessorAdapter: IKRTextPostProcessorAdapter? = null
 
     /**
+     * 键盘高度适配器，供业务按机型修正框架上报的键盘高度
+     */
+    var krKeyboardHeightAdapter: IKRKeyboardHeightAdapter? = null
+
+    /**
      * 视觉宽度配置
      * 业务可通过该配置调整 VISUAL_WIDTH 模式下 Emoji / Attachment 占用的宽度
      */

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRTextFieldView.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRTextFieldView.kt
@@ -39,6 +39,8 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.TextView
+import com.tencent.kuikly.core.render.android.adapter.KRDefaultKeyboardHeightAdapter
+import com.tencent.kuikly.core.render.android.adapter.KRKeyboardHeightContext
 import com.tencent.kuikly.core.render.android.adapter.KuiklyRenderAdapterManager
 import com.tencent.kuikly.core.render.android.adapter.KuiklyRenderLog
 import com.tencent.kuikly.core.render.android.adapter.TextPostProcessorInput
@@ -824,13 +826,18 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
         // 键盘状态监听
         keyboardStatusListener = object : KeyboardStatusListener {
             override fun onHeightChanged(keyboardHeight: Int) {
-                if (keyboardHeight == currentKeyboardHeight) {
+                val adaptedHeight = activity?.let { act ->
+                    val adapter = KuiklyRenderAdapterManager.krKeyboardHeightAdapter
+                        ?: KRDefaultKeyboardHeightAdapter
+                    adapter.adaptKeyboardHeight(KRKeyboardHeightContext(act, keyboardHeight))
+                } ?: keyboardHeight
+                if (adaptedHeight == currentKeyboardHeight) {
                     return
                 }
-                currentKeyboardHeight = keyboardHeight
+                currentKeyboardHeight = adaptedHeight
                 keyboardHeightChangeCallback?.invoke(
                     mapOf(
-                        KRViewConst.HEIGHT to kuiklyRenderContext.toDpF(keyboardHeight.toFloat()),
+                        KRViewConst.HEIGHT to kuiklyRenderContext.toDpF(adaptedHeight.toFloat()),
                         KEY_KEYBOARD_CHANGED_DURATION to DEFAULT_KEYBOARD_CHANGED_ANIMATION_DURATION
                     )
                 )

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRTextFieldView.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/KRTextFieldView.kt
@@ -39,8 +39,6 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.TextView
-import com.tencent.kuikly.core.render.android.adapter.KRDefaultKeyboardHeightAdapter
-import com.tencent.kuikly.core.render.android.adapter.KRKeyboardHeightContext
 import com.tencent.kuikly.core.render.android.adapter.KuiklyRenderAdapterManager
 import com.tencent.kuikly.core.render.android.adapter.KuiklyRenderLog
 import com.tencent.kuikly.core.render.android.adapter.TextPostProcessorInput
@@ -826,18 +824,13 @@ open class KRTextFieldView(context: Context, private val softInputMode: Int?) : 
         // 键盘状态监听
         keyboardStatusListener = object : KeyboardStatusListener {
             override fun onHeightChanged(keyboardHeight: Int) {
-                val adaptedHeight = activity?.let { act ->
-                    val adapter = KuiklyRenderAdapterManager.krKeyboardHeightAdapter
-                        ?: KRDefaultKeyboardHeightAdapter
-                    adapter.adaptKeyboardHeight(KRKeyboardHeightContext(act, keyboardHeight))
-                } ?: keyboardHeight
-                if (adaptedHeight == currentKeyboardHeight) {
+                if (keyboardHeight == currentKeyboardHeight) {
                     return
                 }
-                currentKeyboardHeight = adaptedHeight
+                currentKeyboardHeight = keyboardHeight
                 keyboardHeightChangeCallback?.invoke(
                     mapOf(
-                        KRViewConst.HEIGHT to kuiklyRenderContext.toDpF(adaptedHeight.toFloat()),
+                        KRViewConst.HEIGHT to kuiklyRenderContext.toDpF(keyboardHeight.toFloat()),
                         KEY_KEYBOARD_CHANGED_DURATION to DEFAULT_KEYBOARD_CHANGED_ANIMATION_DURATION
                     )
                 )

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/list/KRRecyclerView.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/list/KRRecyclerView.kt
@@ -660,6 +660,12 @@ class KRRecyclerView : RecyclerView, IKuiklyRenderViewExport, NestedScrollingChi
 
     override fun onTouchEvent(e: MotionEvent): Boolean {
         if (touchConsumeByKuikly) {
+            // Compose pointerInput 消费 touch 后，最后一指 UP/CANCEL 仍需交给 RV 收尾（否则 Pager 可能卡在半页）
+            when (e.actionMasked) {
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL, MotionEvent.ACTION_POINTER_UP -> {
+                    super.onTouchEvent(e)
+                }
+            }
             return true
         }
 

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/module/KRKeyboardModule.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/module/KRKeyboardModule.kt
@@ -28,6 +28,9 @@ import android.view.WindowManager
 import android.widget.FrameLayout
 import android.widget.PopupWindow
 import java.util.concurrent.CopyOnWriteArrayList
+import com.tencent.kuikly.core.render.android.adapter.KRDefaultKeyboardHeightAdapter
+import com.tencent.kuikly.core.render.android.adapter.KRKeyboardHeightContext
+import com.tencent.kuikly.core.render.android.adapter.KuiklyRenderAdapterManager
 import com.tencent.kuikly.core.render.android.adapter.KuiklyRenderLog
 import com.tencent.kuikly.core.render.android.css.ktx.isAfterAndroid11
 import com.tencent.kuikly.core.render.android.export.KuiklyRenderBaseModule
@@ -95,6 +98,7 @@ class KeyboardStatusWatcher(private val activity: Activity) : PopupWindow(activi
     private var lastVisibleHeight = -1
     private var lastVisibleBottom = -1
     private var lastScreenHeight = -1
+    private var lastKeyboardHeight = 0
     private val listeners = CopyOnWriteArrayList<KeyboardStatusListener>()
 
     init {
@@ -150,10 +154,11 @@ class KeyboardStatusWatcher(private val activity: Activity) : PopupWindow(activi
         }
 
         // 键盘高度占屏幕高度超过 20%，则认为键盘打开
-        if (keyboardHeight > screenHeight * 0.2) {
-            notifyKeyboardHeightChanged(keyboardHeight)
-        } else {
-            notifyKeyboardHeightChanged(0)
+        val rawHeight = if (keyboardHeight > screenHeight * 0.2) keyboardHeight else 0
+        val adaptedHeight = adaptKeyboardHeight(activity, rawHeight)
+        if (adaptedHeight != lastKeyboardHeight) {
+            lastKeyboardHeight = adaptedHeight
+            notifyKeyboardHeightChanged(adaptedHeight)
         }
     }
 
@@ -216,19 +221,24 @@ class Android11PlusKeyboardWatcher(private val activity: Activity) : ViewTreeObs
 
     override fun onGlobalLayout() {
         val rootView: View = activity.findViewById(android.R.id.content)
-        val newKeyboardHeight = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        val rawHeight = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             val insets = rootView.rootWindowInsets
-            val imeHeight = insets.getInsets(WindowInsets.Type.ime()).bottom
-            val navHeight = insets.getInsets(WindowInsets.Type.navigationBars()).bottom
-            // 只有当键盘弹出时（imeHeight > 0），才尝试减去导航栏高度
-            if (imeHeight > 0) (imeHeight - navHeight).coerceAtLeast(0) else 0
+            if (insets == null) {
+                0
+            } else {
+                val imeHeight = insets.getInsets(WindowInsets.Type.ime()).bottom
+                val navHeight = insets.getInsets(WindowInsets.Type.navigationBars()).bottom
+                // 只有当键盘弹出时（imeHeight > 0），才尝试减去导航栏高度
+                if (imeHeight > 0) (imeHeight - navHeight).coerceAtLeast(0) else 0
+            }
         } else {
             0
         }
+        val adaptedHeight = adaptKeyboardHeight(activity, rawHeight)
 
-        if (newKeyboardHeight != lastKeyboardHeight) {
-            notifyKeyboardHeightChanged(newKeyboardHeight)
-            lastKeyboardHeight = newKeyboardHeight
+        if (adaptedHeight != lastKeyboardHeight) {
+            lastKeyboardHeight = adaptedHeight
+            notifyKeyboardHeightChanged(adaptedHeight)
         }
     }
 
@@ -258,4 +268,10 @@ class Android11PlusKeyboardWatcher(private val activity: Activity) : ViewTreeObs
  */
 interface KeyboardStatusListener {
     fun onHeightChanged(height: Int)
+}
+
+private fun adaptKeyboardHeight(activity: Activity, rawHeightPx: Int): Int {
+    val adapter = KuiklyRenderAdapterManager.krKeyboardHeightAdapter
+        ?: KRDefaultKeyboardHeightAdapter
+    return adapter.adaptKeyboardHeight(KRKeyboardHeightContext(activity, rawHeightPx))
 }

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/KeyboardHeightDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/KeyboardHeightDemo.kt
@@ -67,6 +67,11 @@ internal class KeyboardHeightDemo : ComposeContainer() {
                     }
                 }
                 var keyboardHeight by remember { mutableStateOf(0f) }
+                Text(
+                    text = "键盘高度: ${keyboardHeight}dp",
+                    color = Color.Gray,
+                    modifier = Modifier.padding(bottom = 4.dp)
+                )
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(top = 8.dp, bottom = keyboardHeight.dp),
                     verticalAlignment = Alignment.CenterVertically

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/VerticalPagerDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/VerticalPagerDemo.kt
@@ -24,14 +24,21 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.launch
 import com.tencent.kuikly.compose.ComposeContainer
+import com.tencent.kuikly.compose.extension.flingEnable
 import com.tencent.kuikly.compose.foundation.background
 import com.tencent.kuikly.compose.foundation.clickable
+import com.tencent.kuikly.compose.foundation.gestures.awaitEachGesture
+import com.tencent.kuikly.compose.foundation.gestures.awaitFirstDown
+import com.tencent.kuikly.compose.foundation.gestures.waitForUpOrCancellation
 import com.tencent.kuikly.compose.foundation.layout.Arrangement
 import com.tencent.kuikly.compose.foundation.layout.Box
 import com.tencent.kuikly.compose.foundation.layout.Column
+import com.tencent.kuikly.compose.foundation.layout.Row
+import com.tencent.kuikly.compose.foundation.layout.fillMaxHeight
 import com.tencent.kuikly.compose.foundation.layout.fillMaxSize
 import com.tencent.kuikly.compose.foundation.layout.fillMaxWidth
 import com.tencent.kuikly.compose.foundation.layout.padding
+import com.tencent.kuikly.compose.foundation.layout.width
 import com.tencent.kuikly.compose.foundation.pager.HorizontalPager
 import com.tencent.kuikly.compose.foundation.pager.PageSize
 import com.tencent.kuikly.compose.foundation.pager.VerticalPager
@@ -41,9 +48,12 @@ import com.tencent.kuikly.compose.setContent
 import com.tencent.kuikly.compose.ui.Alignment
 import com.tencent.kuikly.compose.ui.Modifier
 import com.tencent.kuikly.compose.ui.graphics.Color
+import com.tencent.kuikly.compose.ui.input.pointer.PointerEventTimeoutCancellationException
+import com.tencent.kuikly.compose.ui.input.pointer.pointerInput
 import com.tencent.kuikly.compose.ui.unit.dp
 import com.tencent.kuikly.compose.ui.unit.sp
 import com.tencent.kuikly.core.annotations.Page
+import kotlinx.coroutines.withTimeout
 
 /**
  * 数据项，包含固定的 id 和显示内容
@@ -107,73 +117,151 @@ class VerticalPagerDemo : ComposeContainer() {
         HorizontalPager(modifier = Modifier.fillMaxSize(), state = rememberPagerState { 3 }) {
 
             if (it == 1) {
-                VerticalPager(
-                    state = pagerState,
-                    modifier = Modifier.fillMaxSize(),
-                    pageSize = PageSize.Fill,
-                    key = { index -> dataList[index].id },
-                ) { page ->
-                    val item = dataList[page]
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(
-                                // 使用不同颜色区分不同页面
-                                Color(
-                                    red = (item.id * 25) % 256,
-                                    green = (item.id * 50) % 256,
-                                    blue = (item.id * 75) % 256,
-                                ),
-                            )
-                            .padding(16.dp),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            Text(
-                                text = item.content,
-                                fontSize = 24.sp,
-                                color = Color.White,
-                            )
-                            Text(
-                                text = "ID: ${item.id}",
-                                fontSize = 16.sp,
-                                color = Color.White.copy(alpha = 0.8f),
-                            )
-                            Text(
-                                text = "页面索引: $page",
-                                fontSize = 14.sp,
-                                color = Color.White.copy(alpha = 0.6f),
-                            )
-                        }
-                    }
-                }
+                var longPressStatus by remember { mutableStateOf("未触发") }
 
-                // 右上角刷新按钮
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(16.dp),
-                    contentAlignment = Alignment.TopEnd,
-                ) {
+                Column(modifier = Modifier.fillMaxSize()) {
                     Text(
-                        text = "刷新",
-                        fontSize = 16.sp,
-                        color = Color.White,
+                        text = "多指复现：左区单指滑到半页停住 → 右区另一指长按 → 依次抬指，应 snap 到整页",
+                        fontSize = 12.sp,
+                        color = Color.DarkGray,
                         modifier = Modifier
-                            .background(Color.Blue)
-                            .padding(horizontal = 16.dp, vertical = 8.dp)
-                            .clickable {
-                                // 触发刷新流程：在 LaunchedEffect 中先跳转到第 0 页，然后更新数据
-                                refreshKey++
-                            },
+                            .fillMaxWidth()
+                            .background(Color(0xFFFFF8E1))
+                            .padding(12.dp),
                     )
+                    Text(
+                        text = "长按状态：$longPressStatus",
+                        fontSize = 12.sp,
+                        color = Color(0xFF1565C0),
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                    )
+                    Row(modifier = Modifier.fillMaxSize()) {
+                        Box(modifier = Modifier.weight(1f).fillMaxHeight()) {
+                            VerticalPager(
+                                state = pagerState,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .flingEnable(false),
+                                pageSize = PageSize.Fill,
+                                key = { index -> dataList[index].id },
+                            ) { page ->
+                                val item = dataList[page]
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .background(
+                                            Color(
+                                                red = (item.id * 25) % 256,
+                                                green = (item.id * 50) % 256,
+                                                blue = (item.id * 75) % 256,
+                                            ),
+                                        )
+                                        .padding(16.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    Column(
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                                    ) {
+                                        Text(
+                                            text = item.content,
+                                            fontSize = 24.sp,
+                                            color = Color.White,
+                                        )
+                                        Text(
+                                            text = "ID: ${item.id}",
+                                            fontSize = 16.sp,
+                                            color = Color.White.copy(alpha = 0.8f),
+                                        )
+                                        Text(
+                                            text = "页面索引: $page",
+                                            fontSize = 14.sp,
+                                            color = Color.White.copy(alpha = 0.6f),
+                                        )
+                                    }
+                                }
+                            }
+
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(16.dp),
+                                contentAlignment = Alignment.TopEnd,
+                            ) {
+                                Text(
+                                    text = "刷新",
+                                    fontSize = 16.sp,
+                                    color = Color.White,
+                                    modifier = Modifier
+                                        .background(Color.Blue)
+                                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                                        .clickable { refreshKey++ },
+                                )
+                            }
+                        }
+
+                        LongPressTouchConsumerOverlay(
+                            onLongPress = { longPressStatus = "已触发，touch 已消费" },
+                            modifier = Modifier
+                                .width(88.dp)
+                                .fillMaxHeight()
+                                .background(Color.Black.copy(alpha = 0.28f)),
+                        )
+                    }
                 }
             } else {
                 Text("empty")
             }
         }
+    }
+}
+
+/**
+ * 模拟业务层长按手势：长按前不消费 touch，长按后在 pointerInput 中对 event 执行 consume。
+ */
+@Composable
+private fun LongPressTouchConsumerOverlay(
+    onLongPress: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.pointerInput(Unit) {
+            awaitEachGesture {
+                val down = awaitFirstDown(requireUnconsumed = false)
+                val pointerId = down.id
+                val longPressTriggered = try {
+                    withTimeout(viewConfiguration.longPressTimeoutMillis) {
+                        waitForUpOrCancellation(down = down)
+                    }
+                    false
+                } catch (_: PointerEventTimeoutCancellationException) {
+                    true
+                }
+                if (!longPressTriggered) {
+                    return@awaitEachGesture
+                }
+
+                down.consume()
+                onLongPress()
+                while (true) {
+                    val event = awaitPointerEvent()
+                    event.changes.forEach { change ->
+                        if (change.id == pointerId) {
+                            change.consume()
+                        }
+                    }
+                    if (event.changes.none { it.id == pointerId && it.pressed }) {
+                        break
+                    }
+                }
+            }
+        },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "长按区\n第二指\n长按",
+            fontSize = 13.sp,
+            color = Color.White,
+        )
     }
 }

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/chatDemo/ChatDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/chatDemo/ChatDemo.kt
@@ -1,5 +1,6 @@
 package com.tencent.kuikly.demo.pages.compose.chatDemo
 
+import com.tencent.kuikly.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
@@ -10,6 +11,9 @@ import androidx.compose.runtime.setValue
 import com.tencent.kuikly.compose.ComposeContainer
 import com.tencent.kuikly.compose.extension.keyboardHeightChange
 import com.tencent.kuikly.compose.foundation.Canvas
+import com.tencent.kuikly.compose.foundation.text.BasicTextField
+import com.tencent.kuikly.compose.foundation.text.input.TextFieldState
+import com.tencent.kuikly.compose.foundation.text.input.rememberTextFieldState
 import com.tencent.kuikly.compose.foundation.Image
 import com.tencent.kuikly.compose.foundation.background
 import com.tencent.kuikly.compose.foundation.clickable
@@ -32,8 +36,8 @@ import com.tencent.kuikly.compose.foundation.lazy.itemsIndexed
 import com.tencent.kuikly.compose.foundation.lazy.rememberLazyListState
 import com.tencent.kuikly.compose.foundation.shape.CircleShape
 import com.tencent.kuikly.compose.foundation.shape.RoundedCornerShape
+import com.tencent.kuikly.compose.material3.ExperimentalMaterial3Api
 import com.tencent.kuikly.compose.material3.Text
-import com.tencent.kuikly.compose.material3.TextField
 import com.tencent.kuikly.compose.material3.TextFieldDefaults
 import com.tencent.kuikly.compose.resources.DrawableResource
 import com.tencent.kuikly.compose.resources.InternalResourceApi
@@ -44,7 +48,10 @@ import com.tencent.kuikly.compose.ui.Modifier
 import com.tencent.kuikly.compose.ui.draw.clip
 import com.tencent.kuikly.compose.ui.graphics.Color
 import com.tencent.kuikly.compose.ui.graphics.Path
+import com.tencent.kuikly.compose.ui.graphics.SolidColor
+import com.tencent.kuikly.compose.ui.text.TextStyle
 import com.tencent.kuikly.compose.ui.text.font.FontWeight
+import com.tencent.kuikly.compose.ui.text.input.VisualTransformation
 import com.tencent.kuikly.compose.ui.unit.Dp
 import com.tencent.kuikly.compose.ui.unit.dp
 import com.tencent.kuikly.compose.ui.unit.sp
@@ -74,7 +81,7 @@ internal class ChatDemo : ComposeContainer() {
 
     @Composable
     internal fun ChatScreen() {
-        var inputText by remember { mutableStateOf("") }
+        val inputState = rememberTextFieldState()
         val chatList = remember { mutableStateListOf<String>() }
         var keyboardHeight by remember { mutableStateOf(0f) }
 
@@ -133,14 +140,16 @@ internal class ChatDemo : ComposeContainer() {
                     }
                 } else {
                     welcome(
-                        onInputTextChange = { inputText = it },
+                        onInputTextChange = { inputState.setTextAndPlaceCursorAtEnd(it) },
                         modifier = Modifier.weight(1f)
                     )
                 }
 
                 Column(
                     modifier = Modifier
-                        .padding(bottom = keyboardHeight.dp)
+                        .padding(
+                            bottom = (keyboardHeight + pagerData.safeAreaInsets.bottom).dp,
+                        )
                 ) {
 
                     // 输入栏
@@ -152,21 +161,12 @@ internal class ChatDemo : ComposeContainer() {
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Box(modifier = Modifier.weight(1f)) {
-                            TextField(
-                                value = inputText,
-                                onValueChange = { inputText = it },
+                            ChatInputField(
+                                state = inputState,
                                 modifier = Modifier
                                     .padding(end = 40.dp) // 给右侧按钮留出空间
-                                    .fillMaxWidth()
-                                    .keyboardHeightChange {
-                                        keyboardHeight = it.height
-                                    },
-                                placeholder = { Text(PLACEHOLDER) },
-                                shape = RoundedCornerShape(16.dp),
-                                colors = TextFieldDefaults.colors(
-                                    unfocusedContainerColor = Color.White,
-                                    focusedContainerColor = Color.White
-                                )
+                                    .fillMaxWidth(),
+                                onKeyboardHeightChange = { keyboardHeight = it },
                             )
                         }
 
@@ -182,9 +182,9 @@ internal class ChatDemo : ComposeContainer() {
                             contentDescription = "Send",
                             modifier = Modifier
                                 .size(30.dp)
-                                .clickable(enabled = inputText.isNotBlank()) {
-                                    val messageToSend = inputText
-                                    inputText = ""
+                                .clickable(enabled = inputState.text.isNotBlank()) {
+                                    val messageToSend = inputState.text
+                                    inputState.clearText()
                                     chatList.add(messageToSend)
                                     GlobalScope.launch {
                                         chatList.add("")
@@ -197,6 +197,77 @@ internal class ChatDemo : ComposeContainer() {
                                 }
                         )
                     }
+
+                    EmojiPanelBar(
+                        emojis = DEFAULT_EMOJIS,
+                        onEmojiClick = { emoji -> inputState.insertAtSelection(emoji) },
+                    )
+                }
+            }
+        }
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    private fun ChatInputField(
+        state: TextFieldState,
+        onKeyboardHeightChange: (Float) -> Unit,
+        modifier: Modifier = Modifier,
+    ) {
+        val interactionSource = remember { MutableInteractionSource() }
+        val colors = TextFieldDefaults.colors(
+            unfocusedContainerColor = Color.White,
+            focusedContainerColor = Color.White,
+        )
+        BasicTextField(
+            state = state,
+            modifier = modifier.keyboardHeightChange {
+                onKeyboardHeightChange(it.height)
+            },
+            textStyle = TextStyle(fontSize = 16.sp, color = Color.Black),
+            cursorBrush = SolidColor(Color.Black),
+            singleLine = true,
+            interactionSource = interactionSource,
+            decorationBox = { innerTextField ->
+                TextFieldDefaults.DecorationBox(
+                    value = state.text,
+                    innerTextField = innerTextField,
+                    enabled = true,
+                    singleLine = true,
+                    visualTransformation = VisualTransformation.None,
+                    interactionSource = interactionSource,
+                    placeholder = { Text(PLACEHOLDER) },
+                    shape = RoundedCornerShape(16.dp),
+                    colors = colors,
+                )
+            },
+        )
+    }
+
+    @Composable
+    private fun EmojiPanelBar(
+        emojis: List<String>,
+        onEmojiClick: (String) -> Unit,
+        modifier: Modifier = Modifier,
+    ) {
+        LazyRow(
+            modifier = modifier
+                .fillMaxWidth()
+                .background(Color.White)
+                .padding(horizontal = 10.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            items(emojis) { emoji ->
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(Color(0xFFF5F5F5))
+                        .clickable { onEmojiClick(emoji) },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(text = emoji, fontSize = 22.sp)
                 }
             }
         }
@@ -463,12 +534,20 @@ internal class ChatDemo : ComposeContainer() {
     }
 
 
+    private fun TextFieldState.insertAtSelection(text: String) {
+        val rawSelection = selection
+        edit {
+            replace(rawSelection.start, rawSelection.end, text)
+        }
+    }
+
     companion object {
         private const val BACK_ICON = "ic_back.png"
         private const val SEND_ICON = "ic_send.png"
         private const val LOGO_ICON = "kuikly_logo.png"
 
         private const val PLACEHOLDER = "Type something..."
+        private val DEFAULT_EMOJIS = listOf("😀", "😂", "❤️", "👍", "🎉", "🔥", "😊", "🙏")
         private val markdown = """
             # 一级标题
             ## 二级标题

--- a/docs/QuickStart/android.md
+++ b/docs/QuickStart/android.md
@@ -648,6 +648,23 @@ android {
 
 配置 `adjustNothing` 后，Kuikly 框架可以通过 `keyboardHeightChange` 事件来监听键盘高度变化，并实现更精确的键盘规避逻辑。这种方式比系统自动调整布局更加可控，能够提供更好的用户体验。
 
+### 键盘高度机型适配（可选）
+
+框架内置 `KRDefaultKeyboardHeightAdapter`，会在 `keyboardHeightChange` 回调前自动修正部分 ROM（如三星 One UI）的键盘高度偏差，业务无需额外配置。
+
+若业务需要自定义修正逻辑，可实现 `IKRKeyboardHeightAdapter` 并注册到 `KuiklyRenderAdapterManager`：
+
+```kotlin
+KuiklyRenderAdapterManager.krKeyboardHeightAdapter = object : IKRKeyboardHeightAdapter {
+    override fun adaptKeyboardHeight(context: KRKeyboardHeightContext): Int {
+        // 返回修正后的键盘高度（px）
+        return context.rawHeightPx
+    }
+}
+```
+
+注册后将完全覆盖框架默认实现。
+
 ## 实验性开关
 
 Kuikly提供了一些实验性功能开关，供业务按需开启以体验新功能或优化性能。


### PR DESCRIPTION
## Summary

- 当 Compose `pointerInput` 消费 touch（`touchConsumeByKuikly=true`）时，在最后一指 `UP`/`CANCEL`/`POINTER_UP` 仍将事件交给 `RecyclerView.onTouchEvent`，让 Pager 能正常完成 snap，避免卡在半页
- 仅改动 `KRRecyclerView.onTouchEvent` 的 `touchConsumeByKuikly` 分支（+6 行），无 OverScroll / dragEnd 兜底等其他逻辑
- 补充 `VerticalPagerDemo` 多指复现：左区单指滑到半页 + 右区长按消费 touch

## Test plan

- [ ] 打开 `VerticalPagerDemo`，按页面提示：左区单指滑到半页停住 → 右区另一指长按 → 依次抬指，应 snap 到整页
- [ ] 验证普通单指 Pager 滑动、fling 行为无回归
- [ ] 验证无 `touchConsumeByKuikly` 的列表滚动场景无回归


Made with [Cursor](https://cursor.com)