### PR TITLE
fix(core/views): disabled CheckBox still toggles checked state on click

### DIFF
--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/CheckBoxView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/CheckBoxView.kt
@@ -92,7 +92,7 @@ class CheckBoxView : ComposeView<CheckBoxAttr, CheckBoxEvent>() {
         val ctx = this
         return {
             attr {
-
+                touchEnable(!ctx.attr.disable)
             }
             event {
                 click {


### PR DESCRIPTION
A disabled `CheckBoxView` (when `disable(true)` is set) still responds to tap events: the click handler mutates `checked`, fires `checkedDidChanged`, and triggers a re-render, making the disabled state purely cosmetic.

## Root cause

The `click` handler in `body()` has no guard against the `disable` flag:

```kotlin
event {
    click {
        ctx.attr.checked = !ctx.attr.checked  // fires regardless of disable
    }
}
```

## Fix

Add an early return when the checkbox is disabled:

```kotlin
event {
    click {
        if (ctx.attr.disable) return@click
        ctx.attr.checked = !ctx.attr.checked
    }
}
```

## Testing

Reproduce by placing a `CheckBox` with `disable(true)` and tapping it — `checkedDidChanged` should not fire after this fix.