### PR TITLE
fix(core/views): ActionSheet description text uses same color in night mode and light mode

### DIFF
--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/ActionSheetView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/ActionSheetView.kt
@@ -200,7 +200,7 @@ class ActionSheetView : VirtualView<ActionSheetAttr, ActionSheetEvent>() {
                                 lineHeight(18f)
                                 fontWeightSemiBold()
                                 text(ctx.attr.descriptionOfActions)
-                                if (getPager().isNightMode()) { color(0xFF89848a) } else { color(0xFF89848a) }
+                                if (getPager().isNightMode()) { color(0xFFAEAEB2) } else { color(0xFF89848a) }
                                 textAlignCenter()
                             }
                         }


### PR DESCRIPTION
The description text in `ActionSheetView` renders identically in both light and dark mode due to a copy-paste error: both branches of the night-mode check assign the same color value.

## Root cause

```kotlin
// line 203 — both branches are 0xFF89848a
if (getPager().isNightMode()) { color(0xFF89848a) } else { color(0xFF89848a) }
```

The night-mode branch was copied from the light-mode branch without updating the color, so dark-mode users see low-contrast gray-on-dark text.

## Fix

Use a lighter secondary-label color for night mode (matching iOS dark-mode secondary label `0xFFAEAEB2`):

```kotlin
if (getPager().isNightMode()) { color(0xFFAEAEB2) } else { color(0xFF89848a) }
```

## Testing

Set the device to dark mode, open an `ActionSheet` with a `descriptionOfActions` string, and verify the description text is now legible.