### PR TITLE
fix(core/views): FooterRefresh dead error guard never fires when placed outside a Scroller

### DIFF
--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/FooterRefreshView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/FooterRefreshView.kt
@@ -77,7 +77,7 @@ class FooterRefreshView : ViewContainer<FooterRefreshAttr, FooterRefreshEvent>()
             while (scrollerView != null && scrollerView !is ScrollerView<*, *>) {
                 scrollerView = scrollerView.parent
             }
-            if (scrollerView != null && scrollerView !is ScrollerView<*, *>) {
+            if (scrollerView == null) {
                 throwRuntimeError("FooterRefresh组件需要布局在Scroller容器组件下")
             }
             return scrollerView as? ScrollerView<*, *>


### PR DESCRIPTION
The error guard that is supposed to catch a misplaced `FooterRefresh` component is logically unreachable and silently passes, causing the component to stop working with no diagnostic.

## Root cause

```kotlin
while (scrollerView != null && scrollerView !is ScrollerView<*, *>) {
    scrollerView = scrollerView.parent
}
// After the loop: scrollerView is null OR is a ScrollerView — never both non-null AND non-ScrollerView
if (scrollerView != null && scrollerView !is ScrollerView<*, *>) {  // always false
    throwRuntimeError("FooterRefresh组件需要布局在Scroller容器组件下")
}
```

The while loop already ensures that when it exits, `scrollerView` is either `null` (traversal exhausted) or a `ScrollerView`. The subsequent `if` condition can therefore never be true, so `throwRuntimeError` is dead code. When `FooterRefresh` is placed outside any `Scroller`, the function silently returns `null` instead of throwing.

## Fix

Replace the dead guard with a null check:

```kotlin
if (scrollerView == null) {
    throwRuntimeError("FooterRefresh组件需要布局在Scroller容器组件下")
}
```

## Testing

Place a `FooterRefresh` directly inside a `View` (not a `Scroller`) and confirm `throwRuntimeError` is now called.