### PR TITLE
fix(ohos): use NODE_TEXT_AREA_* attrs for TextArea and support real s…

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextAreaView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextAreaView.cpp
@@ -75,10 +75,27 @@ void KRTextAreaView::UpdateInputNodeKeyboardType(const std::string &propValue) {
     kuikly::util::GetNodeApi()->setAttribute(GetNode(), NODE_TEXT_AREA_TYPE, &item);
 }
 
+void KRTextAreaView::UpdateInputNodeEnterKeyType(const std::string &propValue) {
+    // KRTextAreaView 底层是 ARKUI_NODE_TEXT_AREA，需写 NODE_TEXT_AREA_ENTER_KEY_TYPE，
+    // 否则 returnKeyType 不生效或写入到 TextInput 属性上。
+    ArkUI_NumberValue value[] = {{.i32 = kuikly::util::ConvertToEnterKeyType(propValue)}};
+    ArkUI_AttributeItem item = {value, sizeof(value) / sizeof(ArkUI_NumberValue)};
+    kuikly::util::GetNodeApi()->setAttribute(GetNode(), NODE_TEXT_AREA_ENTER_KEY_TYPE, &item);
+}
+
+ArkUI_EnterKeyType KRTextAreaView::GetInputNodeEnterKeyType() {
+    // TextArea 场景需从 NODE_TEXT_AREA_ENTER_KEY_TYPE 读取，否则 OnInputReturn 回调
+    // 拿到的 ime_action 会是 TextInput 属性上的默认值。
+    auto item = kuikly::util::GetNodeApi()->getAttribute(GetNode(), NODE_TEXT_AREA_ENTER_KEY_TYPE);
+    return item ? static_cast<ArkUI_EnterKeyType>(item->value[0].i32) : ARKUI_ENTER_KEY_TYPE_NEW_LINE;
+}
+
 void KRTextAreaView::UpdateInputNodeMaxLength(int maxLength) {
     ArkUI_NumberValue value[] = {{.i32 = maxLength}};
     ArkUI_AttributeItem item = {value, sizeof(value) / sizeof(ArkUI_NumberValue)};
-    kuikly::util::GetNodeApi()->setAttribute(GetNode(), NODE_TEXT_INPUT_MAX_LENGTH, &item);
+    // KRTextAreaView 底层是 ARKUI_NODE_TEXT_AREA，需写 NODE_TEXT_AREA_MAX_LENGTH，
+    // 否则 maxLength 不生效（此前误写为 NODE_TEXT_INPUT_MAX_LENGTH）。
+    kuikly::util::GetNodeApi()->setAttribute(GetNode(), NODE_TEXT_AREA_MAX_LENGTH, &item);
 }
 
 uint32_t KRTextAreaView::GetInputNodeSelectionStartPosition() {
@@ -87,6 +104,13 @@ uint32_t KRTextAreaView::GetInputNodeSelectionStartPosition() {
 }
 void KRTextAreaView::UpdateInputNodeSelectionStartPosition(uint32_t index) {
     std::array<ArkUI_NumberValue, 2> value = {{{.i32 = static_cast<int32_t>(index)}, {.i32 = static_cast<int32_t>(index)}}};
+    ArkUI_AttributeItem item = {value.data(), value.size()};
+    kuikly::util::GetNodeApi()->setAttribute(GetNode(), NODE_TEXT_AREA_TEXT_SELECTION, &item);
+}
+void KRTextAreaView::UpdateInputNodeSelectionRange(int32_t start, int32_t end) {
+    // KRTextAreaView 底层是 ARKUI_NODE_TEXT_AREA，需写 NODE_TEXT_AREA_TEXT_SELECTION，
+    // 否则区间选区会被写到 TextInput 属性上，表现为选区不生效。
+    std::array<ArkUI_NumberValue, 2> value = {{{.i32 = start}, {.i32 = end}}};
     ArkUI_AttributeItem item = {value.data(), value.size()};
     kuikly::util::GetNodeApi()->setAttribute(GetNode(), NODE_TEXT_AREA_TEXT_SELECTION, &item);
 }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextAreaView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextAreaView.h
@@ -56,9 +56,12 @@ class KRTextAreaView : public KRTextFieldView {
     void UpdateInputNodeCaretrColor(const std::string &propValue) override;
     void UpdateInputNodeSelectionColor(const std::string &propValue) override;
     void UpdateInputNodeKeyboardType(const std::string &propValue) override;
+    void UpdateInputNodeEnterKeyType(const std::string &propValue) override;
+    ArkUI_EnterKeyType GetInputNodeEnterKeyType() override;
     void UpdateInputNodeMaxLength(int maxLength) override;
     uint32_t GetInputNodeSelectionStartPosition() override;
     void UpdateInputNodeSelectionStartPosition(uint32_t index) override;
+    void UpdateInputNodeSelectionRange(int32_t start, int32_t end) override;
     std::pair<uint32_t, uint32_t> GetInputNodeTextSelectionRange() override;
     void UpdateInputNodePlaceholderFont(uint32_t font_size, ArkUI_FontWeight font_weight) override;
     void UpdateInputNodeContentText(const std::string &text) override;

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextFieldView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextFieldView.cpp
@@ -134,6 +134,9 @@ void KRTextFieldView::UpdateInputNodeKeyboardType(const std::string& propValue){
 void KRTextFieldView::UpdateInputNodeEnterKeyType(const std::string& propValue){
     kuikly::util::UpdateInputNodeEnterKeyType(GetNode(), kuikly::util::ConvertToEnterKeyType(propValue));
 }
+ArkUI_EnterKeyType KRTextFieldView::GetInputNodeEnterKeyType(){
+    return kuikly::util::GetInputNodeEnterKeyType(GetNode());
+}
 void KRTextFieldView::UpdateInputNodeMaxLength(int maxLength){
     kuikly::util::UpdateInputNodeMaxLength(GetNode(), maxLength);  // 直接限制
 }
@@ -146,6 +149,14 @@ uint32_t KRTextFieldView::GetInputNodeSelectionStartPosition(){
 
 void KRTextFieldView::UpdateInputNodeSelectionStartPosition(uint32_t index){
     kuikly::util::UpdateInputNodeSelectionStartPosition(GetNode(), index);
+}
+
+void KRTextFieldView::UpdateInputNodeSelectionRange(int32_t start, int32_t end){
+    // 基类默认写 NODE_TEXT_INPUT_TEXT_SELECTION，KRTextAreaView 会 override 为
+    // NODE_TEXT_AREA_TEXT_SELECTION，适配 ARKUI_NODE_TEXT_AREA 节点。
+    std::array<ArkUI_NumberValue, 2> value = {{{.i32 = start}, {.i32 = end}}};
+    ArkUI_AttributeItem item = {value.data(), value.size()};
+    kuikly::util::GetNodeApi()->setAttribute(GetNode(), NODE_TEXT_INPUT_TEXT_SELECTION, &item);
 }
 
 void KRTextFieldView::UpdateInputNodePlaceholderFont(uint32_t font_size, ArkUI_FontWeight font_weight){
@@ -407,15 +418,14 @@ std::pair<uint32_t, uint32_t> KRTextFieldView::GetInputNodeTextSelectionRange() 
 }
 
 /**
- * 受控写入 textInputState：解析 JSON 并把 text/光标 写入 ArkUI 节点。
+ * 受控写入 textInputState：解析 JSON 并把 text/选区 写入 ArkUI 节点。
  *
  * 跨端语义参考 Android KRTextFieldView.setTextInputState：
  *   - 仅消费 text / selectionStart / selectionEnd 三字段；
  *   - composition 不消费；
  *
- * ⚠️ OHOS 老节点能力局限：selection 范围写入降级为「只把光标设到 selectionStart」。
- * TODO：后续如有真选区需求，可改用 NODE_TEXT_INPUT_TEXT_SELECTION / NODE_TEXT_AREA_TEXT_SELECTION
- *       的 [start,end] 写入。Q1 已先接受降级。
+ * selection 通过 UpdateInputNodeSelectionRange 写入真实 [start, end] 区间
+ * （TextInput / TextArea 均支持），不再回退为折叠光标。
  */
 void KRTextFieldView::SetTextInputStateInternal(const std::string &json) {
     // KRRenderValue::toMap 内部调 cJSON_Parse 解析 JSON 字符串到 Map；解析失败回空 Map。
@@ -447,25 +457,25 @@ void KRTextFieldView::SetTextInputStateInternal(const std::string &json) {
     int u16_len = GetUTF16Length(text);
     int selection_start = get_int(kKeySelectionStart, u16_len);
     selection_start = std::max(0, std::min(selection_start, u16_len));
-    // selection_end 解析但当前降级为不使用（Q1 TODO）；预留以便日后实现真选区。
     int selection_end = get_int(kKeySelectionEnd, selection_start);
-    (void)selection_end;
+    selection_end = std::max(selection_start, std::min(selection_end, u16_len));
 
     is_setting_text_input_state_ = true;
     SetContentText(text);
 
     // ⚠️ ArkUI NODE_TEXT_INPUT_TEXT/NODE_TEXT_AREA_TEXT 的 setAttribute 会在内部异步触发
-    // onChange，并把光标重置到文本末尾。如果在这里同步调用 UpdateInputNodeSelectionStartPosition，
+    // onChange，并把光标重置到文本末尾。如果在这里同步调用 UpdateInputNodeSelectionRange，
     // 会被随后到来的 ArkUI 内部 caret reset 吞掉，表现为「光标永远跳到末尾」。
-    // 解决：把光标修正 post 到 next-loop，等 ArkUI 内部 onChange 完成后再设选区，
+    // 解决：把选区修正 post 到 next-loop，等 ArkUI 内部 onChange 完成后再设选区，
     // 与 KRTextEditorFieldView 中 RunOnMainThreadForNextLoop 的策略一致，也与 LimitInputContentTextInMaxLength
     // 中已有的「先改文本后异步设光标」pattern 一致。
     // 同时 is_setting_text_input_state_ flag 也延迟到此处清除，以覆盖 SetContentText 异步触发
     // OnTextDidChanged 的整个时窗，避免业务把"末尾光标"的脏 textInputStateChange 写回来形成回环。
     KRMainThread::RunOnMainThreadForNextLoop(
-        [weakSelf = weak_from_this(), selection_start]() {
+        [weakSelf = weak_from_this(), selection_start, selection_end]() {
             if (auto strongSelf = std::dynamic_pointer_cast<KRTextFieldView>(weakSelf.lock())) {
-                strongSelf->UpdateInputNodeSelectionStartPosition(static_cast<uint32_t>(selection_start));
+                strongSelf->UpdateInputNodeSelectionRange(static_cast<int32_t>(selection_start),
+                                                          static_cast<int32_t>(selection_end));
                 strongSelf->is_setting_text_input_state_ = false;
                 if (strongSelf->length_limit_type_ != -1) {
                     strongSelf->NotifyTextInputStateChange();
@@ -625,7 +635,7 @@ void KRTextFieldView::OnInputReturn(ArkUI_NodeEvent *event) {
     if (input_return_callback_) {
         KRRenderValueMap map;
         map["text"] = NewKRRenderValue(GetContentText());
-        auto returnKeyType = kuikly::util::GetInputNodeEnterKeyType(GetNode());
+        auto returnKeyType = GetInputNodeEnterKeyType();
         map["ime_action"] = NewKRRenderValue(kuikly::util::ConvertEnterKeyTypeToString(returnKeyType));
         input_return_callback_(NewKRRenderValue(map));
         
@@ -792,7 +802,7 @@ void KRTextFieldView::OnWillInsertText(ArkUI_NodeEvent *event) {
         OH_ArkUI_NodeEvent_GetStringValue(event, 0, &pBuffer, &size);
         // KR_LOG_DEBUG << "OnWillInsertText: to insert text: " << buffer;
         auto destText = GetContentText();
-        auto range = kuikly::util::GetInputNodeSelectionRange(GetNode());
+        auto range = GetInputNodeTextSelectionRange();
         bool filtered = filter(buffer, destText, range.first, range.second);
         if (filtered || strlen(buffer) >= MAX_INSERT_LENGTH - 1) {
             if (filtered) {
@@ -829,7 +839,7 @@ void KRTextFieldView::OnPasteText(ArkUI_NodeEvent *event) {
         strncpy(buffer, stringAsyncEvent->pStr, size);
         buffer[size] = '\0';
         auto destText = GetContentText();
-        auto range = kuikly::util::GetInputNodeSelectionRange(GetNode());
+        auto range = GetInputNodeTextSelectionRange();
         if (filter(buffer, destText, range.first, range.second)) {
             KR_LOG_DEBUG << "OnPasteText beyond limit";
             // 超过最大输入长度限制

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextFieldView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/input/KRTextFieldView.h
@@ -79,10 +79,22 @@ class KRTextFieldView : public IKRRenderViewExport {
     virtual void UpdateInputNodeFocusable(int propValue);
     virtual void UpdateInputNodeKeyboardType(const std::string &propValue);
     virtual void UpdateInputNodeEnterKeyType(const std::string &propValue);
+    /**
+     * 读取 ArkUI 节点上的 EnterKeyType。
+     * 子类（如 KRTextAreaView）需 override 以读 NODE_TEXT_AREA_ENTER_KEY_TYPE，
+     * 否则会从 NODE_TEXT_INPUT_ENTER_KEY_TYPE 读到错误的枚举值。
+     */
+    virtual ArkUI_EnterKeyType GetInputNodeEnterKeyType();
     virtual void UpdateInputNodeMaxLength(int maxLength);
     virtual void UpdateInputNodeFocusStatus(int status);
     virtual uint32_t GetInputNodeSelectionStartPosition();
     virtual void UpdateInputNodeSelectionStartPosition(uint32_t index);
+    /**
+     * 设置真实区间选区 [start, end]（按 UTF-16 算）。
+     * TextInput 与 TextArea 都支持 [start, end] 双端选区，无需再降级为折叠光标。
+     * 子类（如 KRTextAreaView）需 override 以写 NODE_TEXT_AREA_TEXT_SELECTION。
+     */
+    virtual void UpdateInputNodeSelectionRange(int32_t start, int32_t end);
     /**
      * 获取选区范围 [start, end]（按 UTF-16 算）。
      * 子类（如 KRTextAreaView）可 override 以适配不同的 ArkUI 节点类型。
@@ -138,10 +150,8 @@ class KRTextFieldView : public IKRRenderViewExport {
      *   - 仅消费 text / selectionStart / selectionEnd 三字段；
      *   - composition 区不在 OHOS 老节点的可写能力内，忽略。
      *
-     * ⚠️ 当前 OHOS 老节点的可写能力局限：
-     *   - selection 范围写入降级为「只把光标设到 selectionStart」，不支持真选中态。
-     *   - TODO：后续如有需要，再用 NODE_TEXT_INPUT_TEXT_SELECTION / NODE_TEXT_AREA_TEXT_SELECTION
-     *     的 [start,end] 形式实现真选区。
+     * selection 通过 UpdateInputNodeSelectionRange 写入真实 [start, end] 区间
+     * （TextInput / TextArea 均支持），不再退化为折叠光标。
      *
      * 主动写入期间通过 is_setting_text_input_state_ 抑制 textInputStateChange 回调，
      * 避免业务把状态写回来形成死循环。


### PR DESCRIPTION
…election range

KRTextAreaView 继承自 KRTextFieldView 但底层是 ARKUI_NODE_TEXT_AREA，其属性枚举与 ARKUI_NODE_TEXT_INPUT 不同。此前若干路径直接调用 kuikly::util::* 或子类未 override，导致 TextArea 上的 maxLength / returnKeyType / 选区读写落到错配的 TextInput 属性上，行为异常。

本次修复：

- 将 EnterKeyType 读取（GetInputNodeEnterKeyType）与 SelectionRange 写入（UpdateInputNodeSelectionRange）虚化到 KRTextFieldView，OnInputReturn/OnWillInsertText/OnPasteText 改走虚函数，KRTextAreaView 用 NODE_TEXT_AREA_ENTER_KEY_TYPE / NODE_TEXT_AREA_TEXT_SELECTION override。

- KRTextAreaView::UpdateInputNodeEnterKeyType 新增 override，写 NODE_TEXT_AREA_ENTER_KEY_TYPE。

- 修复 KRTextAreaView::UpdateInputNodeMaxLength 属性名 typo：NODE_TEXT_INPUT_MAX_LENGTH → NODE_TEXT_AREA_MAX_LENGTH。

- SetTextInputStateInternal 不再降级为折叠光标：TextInput/TextArea 均支持 [start, end] 真实区间选区，selection_end 参与 clamp 后与 selection_start 一起写入。