### PR TITLE
fix(ohos): use weak_ptr in animation callbacks to prevent UAF crash

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerView.cpp
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+#include <memory>
+
 #include "libohos_render/expand/components/scroller/KRScrollerView.h"
 
 #include <cfloat>
@@ -462,15 +464,17 @@ void KRScrollerView::SetContentInset(const std::shared_ptr<KRScrollerContentInse
         } else {
             auto animate_option = std::make_shared<KRAnimateOption>();
             animate_option->SetDuration(200);
+            auto weak_this = std::weak_ptr<KRScrollerView>(std::dynamic_pointer_cast<KRScrollerView>(shared_from_this()));
             content_inset_animate_ = std::make_shared<KRAnimation>(
-                root_view->GetUIContextHandle(), animate_option, [this, top, start, bottom, end]() {
-                    kuikly::util::SetArkUIMargin(content_view_->GetNode(), start, top, end, bottom);
+                root_view->GetUIContextHandle(), animate_option, [weak_this, top, start, bottom, end]() {
+                    if (auto strong_this = weak_this.lock()) {
+                        kuikly::util::SetArkUIMargin(strong_this->content_view_->GetNode(), start, top, end, bottom);
+                    }
                 });
-            std::weak_ptr<KRScrollerView> weakSelf = std::dynamic_pointer_cast<KRScrollerView>(shared_from_this());
             content_inset_animate_->SetCompleteCallback(
-                ArkUI_FinishCallbackType::ARKUI_FINISH_CALLBACK_LOGICALLY, [weakSelf]() {
-                    if (std::shared_ptr<KRScrollerView> strongSelf = weakSelf.lock()) {
-                        strongSelf->content_inset_animate_ = nullptr;
+                ArkUI_FinishCallbackType::ARKUI_FINISH_CALLBACK_LOGICALLY, [weak_this]() {
+                    if (auto strong_this = weak_this.lock()) {
+                        strong_this->content_inset_animate_ = nullptr;
                     }
                 });
             content_inset_animate_->Start();

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/animate/KRAnimation.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/animate/KRAnimation.h
@@ -17,19 +17,10 @@
 #define CORE_RENDER_OHOS_KRANIMATION_H
 
 #include <functional>
+#include <memory>
 #include "libohos_render/foundation/thread/KRMainThread.h"
 #include "libohos_render/utils/animate/KRAnimateOption.h"
 #include "libohos_render/utils/animate/KRAnimationUtils.h"
-
-class KRAnimation;
-class KRAnimationUserData {
- public:
-    std::shared_ptr<KRAnimation> animation_;
-    explicit KRAnimationUserData(std::shared_ptr<KRAnimation> &animation) : animation_(animation) {}
-    ~KRAnimationUserData() {
-        animation_.reset();
-    }
-};
 
 class KRAnimation : public std::enable_shared_from_this<KRAnimation> {
  public:
@@ -73,15 +64,16 @@ class KRAnimation : public std::enable_shared_from_this<KRAnimation> {
 
     void SetCompleteCallback(const ArkUI_FinishCallbackType &complete_type, const std::function<void()> &complete) {
         complete_callback_ = complete;
-        std::shared_ptr<KRAnimation> self = shared_from_this();
-        KRAnimationUserData *user_data = new KRAnimationUserData(self);
+        auto user_data = new std::weak_ptr<KRAnimation>(weak_from_this());
         arkui_complete_callback_.type = complete_type;
         arkui_complete_callback_.userData = user_data;
         arkui_complete_callback_.callback = [](void *userData) {
-            KRAnimationUserData *animationUserData = (static_cast<KRAnimationUserData *>(userData));
-            if (animationUserData && animationUserData->animation_) {
-                animationUserData->animation_->InvokeCompleteCallback();
-                delete animationUserData;
+            auto weak = static_cast<std::weak_ptr<KRAnimation> *>(userData);
+            if (weak) {
+                if (auto strong = weak->lock()) {
+                    strong->InvokeCompleteCallback();
+                }
+                delete weak;
             }
         };
     }


### PR DESCRIPTION
Replace raw this pointer capture and KRAnimationUserData strong-ref pattern with weak_ptr to prevent Use-After-Free when KRScrollerView is destroyed before animation completion callback fires.

Changes:
- KRAnimation.h: Remove KRAnimationUserData class, use heap-allocated weak_ptr<KRAnimation> in SetCompleteCallback for safe invoke
- KRScrollerView.cpp: Capture weak_ptr<KRScrollerView> instead of raw this in both animation update and completion lambdas

Ported from KuiklyCompose/ComposeOnKuikly@8ed462e3