### PR TITLE
feat(demo): 复刻 ima 录音纪要页 AudioRecordDetailDemo

### DIFF
--- a/androidApp/src/main/java/com/tencent/kuikly/android/demo/adapter/KRTextPostProcessorAdapter.kt
+++ b/androidApp/src/main/java/com/tencent/kuikly/android/demo/adapter/KRTextPostProcessorAdapter.kt
@@ -16,12 +16,17 @@
 package com.tencent.kuikly.android.demo.adapter
 
 import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
 import android.graphics.drawable.Drawable
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.DynamicDrawableSpan
 import android.text.style.ImageSpan
+import android.text.style.ReplacementSpan
 import androidx.core.content.ContextCompat
+import kotlin.math.max
+import kotlin.math.min
 import com.tencent.kuikly.core.render.android.adapter.IKRTextPostProcessorAdapter
 import com.tencent.kuikly.core.render.android.adapter.TextPostProcessorInput
 import com.tencent.kuikly.core.render.android.adapter.TextPostProcessorOutput
@@ -58,6 +63,7 @@ class KRTextPostProcessorAdapter(context: Context) : IKRTextPostProcessorAdapter
     ): TextPostProcessorOutput {
         return when (inputParams.processor) {
             "emoji", "input" -> processEmoji(inputParams)
+            "dashed" -> processDashedUnderline(inputParams)
             else -> TextPostProcessorOutput(inputParams.sourceText)
         }
     }
@@ -101,9 +107,88 @@ class KRTextPostProcessorAdapter(context: Context) : IKRTextPostProcessorAdapter
         return TextPostProcessorOutput(spannable)
     }
 
+    /**
+     * 虚线下划线处理器：Kuikly 文本装饰本身不支持虚线，这里把整段文本交给自定义
+     * [DashedUnderlineSpan]，由原生 TextView 在 baseline 下方画出贴合文字宽度的虚线。
+     *
+     * 使用方式（Compose DSL）：
+     * ```
+     * Text("带虚线下划线的文字", modifier = Modifier.textPostProcessor("dashed"))
+     * ```
+     */
+    private fun processDashedUnderline(inputParams: TextPostProcessorInput): TextPostProcessorOutput {
+        val sourceText = inputParams.sourceText?.toString()
+        if (sourceText.isNullOrEmpty()) {
+            return TextPostProcessorOutput(inputParams.sourceText)
+        }
+        val spannable = SpannableStringBuilder(sourceText)
+        spannable.setSpan(
+            DashedUnderlineSpan(),
+            0,
+            sourceText.length,
+            Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        return TextPostProcessorOutput(spannable)
+    }
+
     // 保留旧方法以兼容接口
     @Deprecated("Use onTextPostProcess(kuiklyRenderContext, inputParams) instead")
     override fun onTextPostProcess(inputParams: TextPostProcessorInput): TextPostProcessorOutput {
         return onTextPostProcess(null, inputParams)
+    }
+}
+
+/**
+ * 在文字 baseline（基线）正下方手动绘制虚线的 [ReplacementSpan]。
+ *
+ * Kuikly 的 Text 装饰只有实线下划线，没有虚线；用原生 [ReplacementSpan] 接管整段文字的
+ * 绘制，先画文字本身，再紧贴基线画一段段短线，实现“贴合文字宽度”的虚线下划线。
+ */
+class DashedUnderlineSpan : ReplacementSpan() {
+
+    override fun getSize(
+        paint: Paint,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        fm: Paint.FontMetricsInt?
+    ): Int {
+        // 让文本宽度照常参与排版，高度沿用系统文本度量（fm 不动）
+        return paint.measureText(text, start, end).toInt()
+    }
+
+    override fun draw(
+        canvas: Canvas,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        x: Float,
+        top: Int,
+        baseline: Int,
+        bottom: Int,
+        paint: Paint
+    ) {
+        // 1. 先把文字画出来（沿用系统 paint，字体/颜色与页面一致）
+        canvas.drawText(text, start, end, x, baseline.toFloat(), paint)
+
+        // 2. 在基线下方画虚线。用一份拷贝的 paint，避免污染文字本身的 paint。
+        val textWidth = paint.measureText(text, start, end)
+        val thickness = max(1f, paint.textSize * 0.08f)
+        val dash = paint.textSize * 0.45f
+        val gap = paint.textSize * 0.35f
+        val lineY = baseline + thickness * 2f // 略低于基线，避免压到文字的下沿
+
+        val underlinePaint = Paint(paint).apply {
+            style = Paint.Style.STROKE
+            strokeWidth = thickness
+            color = paint.color // 与文字同色
+        }
+
+        var cx = x
+        while (cx < x + textWidth) {
+            val next = min(cx + dash, x + textWidth)
+            canvas.drawLine(cx, lineY, next, lineY, underlinePaint)
+            cx += dash + gap
+        }
     }
 }

--- a/core-render-ohos/src/main/cpp/libohos_render/api/include/Kuikly/Kuikly.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/api/include/Kuikly/Kuikly.h
@@ -370,6 +370,24 @@ void KRTextProcessedResultAppendTextSpan(KRTextProcessedResultBuilder builder,
                                          const char *text);
 
 /**
+ * 新增一种 span 类型：在文字下方/基线上叠加一条虚线下划线（真·文本虚线）。
+ * 与 kText 不同，文字照常显示，仅额外绘制一条虚线；与 kImage 不同，不占用占位。
+ *
+ * @param builder     builder 句柄
+ * @param text        该段的展示文本（UTF-8），SDK 内部立即拷贝
+ * @param dash_width  虚线段长度（px），<=0 时取默认 6
+ * @param gap_width   虚线段间隔（px），<=0 时取默认 4
+ * @param color       虚线颜色（0xAARRGGBB）
+ * @param thickness   虚线线宽（px），<=0 时取默认 1
+ */
+void KRTextProcessedResultAppendDashedUnderlineSpan(KRTextProcessedResultBuilder builder,
+                                                    const char *text,
+                                                    float dash_width,
+                                                    float gap_width,
+                                                    uint32_t color,
+                                                    float thickness);
+
+/**
  * 追加一段图片 span。
  * @param builder builder 句柄
  * @param src     **可寻址 URI**，仅支持以下协议（业务侧需自行解析为下列形态）：

--- a/core-render-ohos/src/main/cpp/libohos_render/api/src/KRTextPostProcessor.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/api/src/KRTextPostProcessor.h
@@ -20,6 +20,7 @@
 // 对外 API 见 libohos_render/api/include/Kuikly/Kuikly.h 中的
 // KRRegisterTextPostProcessorAdapter / KRTextProcessedResultAppend* 系列。
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -28,7 +29,7 @@ namespace text {
 
 // 单个 span 描述：text or image。
 struct KRTextPostProcessSpan {
-    enum class Type { kText, kImage };
+    enum class Type { kText, kImage, kDashedUnderline };
     Type type = Type::kText;
     std::string text_or_src;  // text 段：UTF-8 文本；image 段：可寻址 URI
     // 仅 image 段使用：image 在「raw 原始文本」中对应的字面量（如 "[smile]"）。
@@ -43,6 +44,13 @@ struct KRTextPostProcessSpan {
     std::string raw_literal;
     float width = 0.0f;       // 仅 image 段使用，<=0 表示按字号自适应
     float height = 0.0f;      // 仅 image 段使用，<=0 表示按字号自适应
+    // 仅 kDashedUnderline 段使用：真·文本虚线下划线的绘制参数（单位 px，与富文本其余尺寸一致）。
+    // 当 type == kDashedUnderline 时，text_or_src 仍携带该段"展示文本"（文字照常显示），
+    // 仅额外在基线处叠加一条虚线下划线。
+    float dash_width = 6.0f;          // 单个虚线段长度
+    float gap_width = 4.0f;           // 虚线段之间的间隔
+    uint32_t underline_color = 0xff000000;  // 虚线颜色（0xAARRGGBB）
+    float thickness = 1.0f;           // 虚线线宽
 };
 
 // 调用已注册的统一 adapter，并把当前运行时 processor 名称（如 "input"）回传给业务。

--- a/core-render-ohos/src/main/cpp/libohos_render/api/src/Kuikly.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/api/src/Kuikly.cpp
@@ -425,6 +425,25 @@ void KRTextProcessedResultAppendImageSpanWithRaw(KRTextProcessedResultBuilder bu
     span.height = height;
     builder->spans.push_back(std::move(span));
 }
+
+void KRTextProcessedResultAppendDashedUnderlineSpan(KRTextProcessedResultBuilder builder,
+                                                    const char *text,
+                                                    float dash_width,
+                                                    float gap_width,
+                                                    uint32_t color,
+                                                    float thickness) {
+    if (!builder || !text) {
+        return;
+    }
+    kuikly::text::KRTextPostProcessSpan span;
+    span.type = kuikly::text::KRTextPostProcessSpan::Type::kDashedUnderline;
+    span.text_or_src = text;
+    span.dash_width = dash_width > 0 ? dash_width : 6.0f;
+    span.gap_width = gap_width > 0 ? gap_width : 4.0f;
+    span.underline_color = color;
+    span.thickness = thickness > 0 ? thickness : 1.0f;
+    builder->spans.push_back(std::move(span));
+}
 #ifdef __cplusplus
 }
 #endif

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
@@ -392,7 +392,7 @@ OH_Drawing_Typography *KRRichTextShadow::BuildTextTypography(double constraint_w
                         new_map.erase("placeholderWidth");
                         new_map.erase("placeholderHeight");
                         new_map.erase(kuikly::richtext::kInternalImageSrcKey);
-                    } else {
+                    } else if (seg.type == kuikly::text::KRTextPostProcessSpan::Type::kImage) {
                         // image seg：用占位分支，dpi 缩放在循环内统一处理；
                         // 业务给的 width/height 单位是 vp（与 ImageSpan / TextEditor 路径一致），
                         // 缺省时按当前 fontSize（vp）取方形。
@@ -412,6 +412,23 @@ OH_Drawing_Typography *KRRichTextShadow::BuildTextTypography(double constraint_w
                         new_map["placeholderWidth"] = NewKRRenderValue(static_cast<double>(w));
                         new_map["placeholderHeight"] = NewKRRenderValue(static_cast<double>(h));
                         new_map[kuikly::richtext::kInternalImageSrcKey] = NewKRRenderValue(seg.text_or_src);
+                    } else {
+                        // kDashedUnderline seg：文字照常显示（同 kText），并打标记让 Phase 3
+                        // 记录其字符区间与绘制参数，最终由 view 在基线处手画虚线（真·文本虚线）。
+                        new_map["value"] = NewKRRenderValue(seg.text_or_src);
+                        new_map["text"] = NewKRRenderValue(seg.text_or_src);
+                        new_map.erase("placeholderWidth");
+                        new_map.erase("placeholderHeight");
+                        new_map.erase(kuikly::richtext::kInternalImageSrcKey);
+                        new_map[kuikly::richtext::kInternalDashedUnderlineKey] = NewKRRenderValue(1.0);
+                        new_map[kuikly::richtext::kInternalDashedDashKey] =
+                            NewKRRenderValue(static_cast<double>(seg.dash_width));
+                        new_map[kuikly::richtext::kInternalDashedGapKey] =
+                            NewKRRenderValue(static_cast<double>(seg.gap_width));
+                        new_map[kuikly::richtext::kInternalDashedColorKey] =
+                            NewKRRenderValue(static_cast<double>(seg.underline_color));
+                        new_map[kuikly::richtext::kInternalDashedThickKey] =
+                            NewKRRenderValue(static_cast<double>(seg.thickness));
                     }
                     expanded.push_back(KRRenderValue::Make(new_map));
                 }
@@ -641,6 +658,17 @@ OH_Drawing_Typography *KRRichTextShadow::BuildTextTypography(double constraint_w
             std::wstring_convert<deletable_facet<std::codecvt<char16_t, char, std::mbstate_t>>, char16_t> conv16;
             std::u16string str16 = conv16.from_bytes(text);
             int codePointCount = str16.size();
+            // 虚线下划线：若本 span 携带 dashed 标记，记录其字符区间与绘制参数，供 view 绘制。
+            if (GetKRValue(kuikly::richtext::kInternalDashedUnderlineKey, spanMap, spanMap)->toDouble() != 0.0) {
+                KRDashedUnderlineRecord rec;
+                rec.start = charOffset;
+                rec.end = charOffset + codePointCount;
+                rec.dash = static_cast<float>(GetKRValue(kuikly::richtext::kInternalDashedDashKey, spanMap, spanMap)->toDouble());
+                rec.gap = static_cast<float>(GetKRValue(kuikly::richtext::kInternalDashedGapKey, spanMap, spanMap)->toDouble());
+                rec.color = static_cast<uint32_t>(GetKRValue(kuikly::richtext::kInternalDashedColorKey, spanMap, spanMap)->toDouble());
+                rec.thickness = static_cast<float>(GetKRValue(kuikly::richtext::kInternalDashedThickKey, spanMap, spanMap)->toDouble());
+                dashed_underline_records_.push_back(std::move(rec));
+            }
             span_offsets_.emplace_back(std::tuple(spanIndex, charOffset, charOffset + codePointCount));
             charOffset += codePointCount;
         }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
@@ -22,6 +22,7 @@
 #include <native_drawing/drawing_text_typography.h>
 #include <native_drawing/drawing_text_line.h>
 #include <native_drawing/drawing_types.h>
+#include <cstdint>
 #include <functional>
 #include <mutex>
 #include <string>
@@ -40,6 +41,13 @@ namespace richtext {
 // PostProcessor 拆段路径写入与读取，业务零感知。如需在其它 shadow / view 引用，
 // 请统一使用此常量。
 inline constexpr const char *kInternalImageSrcKey = "__kr_image_src__";
+// PostProcessor("dashed") 拆段产生的虚线下划线 span，在 span map 中携带的标记键。
+// 仅由 KRRichTextShadow 内部 Phase 2 写入、Phase 3 读取，业务零感知。
+inline constexpr const char *kInternalDashedUnderlineKey = "__kr_dashed_underline__";
+inline constexpr const char *kInternalDashedDashKey = "__kr_dashed_dash__";
+inline constexpr const char *kInternalDashedGapKey = "__kr_dashed_gap__";
+inline constexpr const char *kInternalDashedColorKey = "__kr_dashed_color__";
+inline constexpr const char *kInternalDashedThickKey = "__kr_dashed_thick__";
 }  // namespace richtext
 }  // namespace kuikly
 
@@ -240,6 +248,23 @@ class KRRichTextShadow : public IKRRenderShadowExport {
         return image_draw_records_;
     }
 
+    // ===== Phase 5: PostProcessor("dashed") 虚线下划线绘制 =====
+    // 与 image_draw_records_ 平行：BuildTextTypography 在 context 线程把每个 kDashedUnderline
+    // span 的字符区间 [start, end) 与绘制参数记录到此处；view 层在 OnForegroundDraw 末尾
+    // 遍历这些区间，对区间内每一行用 OH_Drawing 手画一段段短线，得到"真·文本虚线"
+    // （画在基线处、随换行逐行各一条，区别于 Compose 纯布局的近似兜底）。
+    struct KRDashedUnderlineRecord {
+        size_t start = 0;              // 区间起点（UTF-16 码元索引，与 span_offsets_ 口径一致）
+        size_t end = 0;                // 区间终点（不含）
+        float dash = 6.0f;             // 虚线段长度（px）
+        float gap = 4.0f;              // 虚线段间隔（px）
+        uint32_t color = 0xff000000;   // 虚线颜色（0xAARRGGBB）
+        float thickness = 1.0f;        // 虚线线宽（px）
+    };
+    const std::vector<KRDashedUnderlineRecord> &GetDashedUnderlineRecords() const {
+        return dashed_underline_records_;
+    }
+
     // ===== Phase 3↔4 桥接：image span 解码完成通知 view markDirty =====
     // view 层（KRRichTextView::SetShadow）在拿到 shadow 时通过本接口注册一个 callback；
     // shadow 把 image span 的预解码工作委托给 KRCustomEmojiPixmapCache（进程级单例 +
@@ -300,6 +325,7 @@ class KRRichTextShadow : public IKRRenderShadowExport {
     // 重建（SetProp("values") -> Measure -> BuildTextTypography）时整体覆盖，无并发改写问题。
     // pixmap 缓存已迁移至 KRCustomEmojiPixmapCache（进程级单例 + LRU 128）。
     std::vector<KRImageDrawRecord> image_draw_records_;
+    std::vector<KRDashedUnderlineRecord> dashed_underline_records_;  // 见 GetDashedUnderlineRecords
     std::mutex image_loaded_callback_mutex_;
     ImageLoadedCallback image_loaded_callback_;
 

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
@@ -328,6 +328,51 @@ void KRRichTextView::OnForegroundDraw(ArkUI_NodeCustomEvent *event) {
             OH_Drawing_TypographyDestroyTextBox(placeholder_rects);
         }
     }
+
+    // ===== Phase 5: 绘制由 PostProcessor("dashed") 产生的虚线下划线（真·文本虚线）=====
+    // 时机：跟随文字（TypographyPaint）与图片（Phase 4）之后。对每条 dashed 记录的字符区间
+    // 取 GetRectsForRange 得到跨行的若干矩形，再在每个矩形内按 dash+gap 节奏用 Path 手画
+    // 短线段。线 Y 取矩形 tight 底边（≈基线）再下移 1px；view 坐标系已含 -drawOffsetY 平移，
+    // 与 TypographyPaint 保持一致。
+    const auto &dashed_records = richTextShadow->GetDashedUnderlineRecords();
+    if (!dashed_records.empty() && textTypo != nullptr) {
+        OH_Drawing_Pen *dash_pen = OH_Drawing_PenCreate();
+        OH_Drawing_PenSetAntiAlias(dash_pen, true);
+        OH_Drawing_CanvasAttachPen(drawingHandle, dash_pen);
+        for (const auto &rec : dashed_records) {
+            OH_Drawing_TextBox *boxes = OH_Drawing_TypographyGetRectsForRange(
+                textTypo, rec.start, rec.end, RECT_HEIGHT_STYLE_TIGHT, RECT_WIDTH_STYLE_TIGHT);
+            int box_count = boxes ? OH_Drawing_GetSizeOfTextBox(boxes) : 0;
+            if (box_count <= 0) {
+                if (boxes) {
+                    OH_Drawing_TypographyDestroyTextBox(boxes);
+                }
+                continue;
+            }
+            OH_Drawing_Path *dash_path = OH_Drawing_PathCreate();
+            for (int bi = 0; bi < box_count; ++bi) {
+                float left = OH_Drawing_GetLeftFromTextBox(boxes, bi);
+                float right = OH_Drawing_GetRightFromTextBox(boxes, bi);
+                float bottom = OH_Drawing_GetBottomFromTextBox(boxes, bi);
+                float y = bottom - drawOffsetY + 1.0f;  // 略低于基线
+                float x = left;
+                while (x < right) {
+                    float ex = (x + rec.dash < right) ? (x + rec.dash) : right;
+                    OH_Drawing_PathMoveTo(dash_path, x, y);
+                    OH_Drawing_PathLineTo(dash_path, ex, y);
+                    x += rec.dash + rec.gap;
+                }
+            }
+            // 同一记录统一用其颜色/线宽描边
+            OH_Drawing_PenSetColor(dash_pen, rec.color);
+            OH_Drawing_PenSetWidth(dash_pen, rec.thickness);
+            OH_Drawing_CanvasDrawPath(drawingHandle, dash_path);
+            OH_Drawing_PathDestroy(dash_path);
+            OH_Drawing_TypographyDestroyTextBox(boxes);
+        }
+        OH_Drawing_CanvasDetachPen(drawingHandle);
+        OH_Drawing_PenDestroy(dash_pen);
+    }
 }
 
 void KRRichTextView::ToSetProp(const std::string &prop_key, const KRAnyValue &prop_value,

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/AudioRecordDetailDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/AudioRecordDetailDemo.kt
@@ -1,0 +1,600 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.demo.pages.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import com.tencent.kuikly.compose.ComposeContainer
+import com.tencent.kuikly.compose.foundation.background
+import com.tencent.kuikly.compose.foundation.clickable
+import com.tencent.kuikly.compose.foundation.layout.Arrangement
+import com.tencent.kuikly.compose.foundation.layout.Box
+import com.tencent.kuikly.compose.foundation.layout.Column
+import com.tencent.kuikly.compose.foundation.layout.PaddingValues
+import com.tencent.kuikly.compose.foundation.layout.Row
+import com.tencent.kuikly.compose.foundation.layout.Spacer
+import com.tencent.kuikly.compose.foundation.layout.fillMaxHeight
+import com.tencent.kuikly.compose.foundation.layout.fillMaxSize
+import com.tencent.kuikly.compose.foundation.layout.fillMaxWidth
+import com.tencent.kuikly.compose.foundation.layout.height
+import com.tencent.kuikly.compose.foundation.layout.padding
+import com.tencent.kuikly.compose.foundation.layout.size
+import com.tencent.kuikly.compose.foundation.layout.widthIn
+import com.tencent.kuikly.compose.foundation.lazy.LazyColumn
+import com.tencent.kuikly.compose.foundation.lazy.items
+import com.tencent.kuikly.compose.foundation.lazy.rememberLazyListState
+import com.tencent.kuikly.compose.foundation.shape.CircleShape
+import com.tencent.kuikly.compose.foundation.shape.RoundedCornerShape
+import com.tencent.kuikly.compose.material3.Text
+import com.tencent.kuikly.compose.setContent
+import com.tencent.kuikly.compose.ui.Alignment
+import com.tencent.kuikly.compose.ui.Modifier
+import com.tencent.kuikly.compose.ui.draw.clip
+import com.tencent.kuikly.compose.ui.graphics.Brush
+import com.tencent.kuikly.compose.ui.graphics.Color
+import com.tencent.kuikly.compose.ui.platform.LocalConfiguration
+import com.tencent.kuikly.compose.ui.text.font.FontWeight
+import com.tencent.kuikly.compose.ui.text.style.TextOverflow
+import com.tencent.kuikly.compose.ui.unit.dp
+import com.tencent.kuikly.compose.ui.unit.sp
+import com.tencent.kuikly.compose.ui.window.Dialog
+import com.tencent.kuikly.core.annotations.Page
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * 复刻 ima 的 AudioRecordDetailPager（录音纪要详情页）。
+ *
+ * 原页面依赖大量 ima 内部 ViewModel / Service / 组件，本 Demo 用纯 Kuikly Compose DSL
+ * 复刻其 UI 与交互结构，并用本地 mock 状态模拟「录音 -> 实时识别 -> 停止上传」流程，
+ * 不依赖任何外部业务模块，可直接在 Demo 中运行。
+ */
+@Page("AudioRecordDetailDemo")
+class AudioRecordDetailDemo : ComposeContainer() {
+    override fun willInit() {
+        super.willInit()
+        setContent {
+            CompositionLocalProvider(LocalAudioRecordColors provides AudioRecordLightColors) {
+                AudioRecordDetailScreen()
+            }
+        }
+    }
+}
+
+// ============================================================
+// 颜色主题（对应原页面的 LocalThemeColorDefine）
+// ============================================================
+private data class AudioRecordColors(
+    val grey0: Color,          // 页面背景
+    val primaryBlack1: Color,  // 主文本
+    val primaryBlack2: Color,  // 次要文本 / 时间戳
+    val primaryBlack3: Color,
+    val primaryBlack5: Color,  // 弱文本
+    val accent: Color,         // 录音主按钮
+)
+
+private val AudioRecordLightColors = AudioRecordColors(
+    grey0 = Color(0xFFF5F5F5),
+    primaryBlack1 = Color(0xFF000000),
+    primaryBlack2 = Color(0xFF666666),
+    primaryBlack3 = Color(0xFF999999),
+    primaryBlack5 = Color(0xFFB2B2B2),
+    accent = Color(0xFF1AAD19),
+)
+
+private val LocalAudioRecordColors = compositionLocalOf { AudioRecordLightColors }
+
+// ============================================================
+// 状态枚举 & 数据模型（对应原页面的 AudioRecordState / RecognitionData）
+// ============================================================
+private enum class RecordState {
+    IDLE, STARTING, RECORDING, PAUSED, STOPPING, STOPPED, UPLOADED, UPLOAD_FAILED, CANCELED
+}
+
+private data class RecognitionItem(
+    val index: Int,
+    val startTime: Long,
+    val content: String,
+)
+
+private fun formatMillisToCompactTime(millis: Long): String {
+    val totalSec = millis / 1000
+    val sec = totalSec % 60
+    val min = (totalSec / 60) % 60
+    val hr = totalSec / 3600
+    return if (hr > 0) String.format("%d:%02d:%02d", hr, min, sec)
+    else String.format("%02d:%02d", min, sec)
+}
+
+// ============================================================
+// 主页面
+// ============================================================
+@Composable
+private fun AudioRecordDetailScreen() {
+    val colors = LocalAudioRecordColors.current
+    val safeArea = LocalConfiguration.current.safeAreaInsets
+    val scope = rememberCoroutineScope()
+    val listState = rememberLazyListState()
+
+    var recordState by remember { mutableStateOf(RecordState.IDLE) }
+    var durationMs by remember { mutableStateOf(0L) }
+    var items by remember { mutableStateOf(listOf<RecognitionItem>()) }
+    var recordTips by remember { mutableStateOf("") }
+    var showCancelDialog by remember { mutableStateOf(false) }
+    var showFloatBall by remember { mutableStateOf(false) }
+    var mediaTitle by remember { mutableStateOf("录音纪要") }
+    var itemCounter by remember { mutableStateOf(0) }
+
+    // 计时器：录音时每秒 +1s
+    LaunchedEffect(recordState) {
+        if (recordState == RecordState.RECORDING) {
+            while (recordState == RecordState.RECORDING) {
+                delay(1000)
+                durationMs += 1000
+            }
+        }
+    }
+
+    // mock 实时识别：录音时每 3s 追加一段识别文本
+    LaunchedEffect(recordState) {
+        if (recordState == RecordState.RECORDING) {
+            while (recordState == RecordState.RECORDING) {
+                delay(3000)
+                if (recordState != RecordState.RECORDING) break
+                itemCounter += 1
+                val snippet = when (itemCounter % 3) {
+                    0 -> "好的，那我们接下来讨论一下整体方案的落地节奏，以及各端联调的时间点。"
+                    1 -> "这边提到需要优先保证 Android 与 iOS 的体验一致性，鸿蒙作为后续补充。"
+                    else -> "关于录音转写准确率，建议在安静环境下使用，长语音支持最长两小时。"
+                }
+                items = items + RecognitionItem(
+                    index = itemCounter,
+                    startTime = durationMs,
+                    content = snippet,
+                )
+            }
+        }
+    }
+
+    // 监听滚动：离开底部时显示「回到底部」悬浮球
+    LaunchedEffect(listState) {
+        snapshotFlow {
+            Triple(
+                listState.lastScrolledForward,
+                listState.lastScrolledBackward,
+                listState.canScrollForward,
+            )
+        }.collect { (_, _, canScrollForward) ->
+            showFloatBall = canScrollForward
+        }
+    }
+
+    // 在底部时，新内容自动滚到底
+    LaunchedEffect(items.size) {
+        if (items.isNotEmpty() && !showFloatBall) {
+            listState.animateScrollToItem(items.lastIndex)
+        }
+    }
+
+    // 首次进入提示（对应原页面 IKVService 去重逻辑，这里简化为仅首次）
+    LaunchedEffect(Unit) {
+        if (recordState == RecordState.IDLE) {
+            recordTips = "支持中英文录音最长2小时"
+            delay(3000)
+            recordTips = ""
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(colors.grey0)
+            .padding(top = safeArea.top.dp, bottom = safeArea.bottom.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        if (showCancelDialog) {
+            Dialog(onDismissRequest = { showCancelDialog = false }) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(Color.White)
+                            .padding(20.dp)
+                    ) {
+                        Column {
+                            Text(
+                                "确认放弃录音",
+                                fontWeight = FontWeight.W500,
+                                fontSize = 17.sp,
+                                color = colors.primaryBlack1,
+                            )
+                            Spacer(Modifier.height(8.dp))
+                            Text(
+                                "放弃本次录音，并删除已录内容",
+                                fontSize = 14.sp,
+                                color = colors.primaryBlack2,
+                            )
+                            Spacer(Modifier.height(16.dp))
+                            Row(horizontalArrangement = Arrangement.End) {
+                                Text(
+                                    "取消",
+                                    modifier = Modifier
+                                        .clickable { showCancelDialog = false }
+                                        .padding(8.dp),
+                                    color = colors.primaryBlack2,
+                                    fontSize = 15.sp,
+                                )
+                                Text(
+                                    "确认",
+                                    modifier = Modifier
+                                        .clickable {
+                                            showCancelDialog = false
+                                            // 模拟「放弃并删除」：回到初始态、清空内容
+                                            recordState = RecordState.IDLE
+                                            durationMs = 0
+                                            items = emptyList()
+                                            itemCounter = 0
+                                        }
+                                        .padding(8.dp),
+                                    color = colors.accent,
+                                    fontSize = 15.sp,
+                                    fontWeight = FontWeight.W500,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        TitleBar(
+            title = mediaTitle,
+            onClose = { showCancelDialog = true },
+            onRename = {
+                // 原页面打开重命名弹窗；Demo 中简化为切换标题演示
+                mediaTitle = if (mediaTitle == "录音纪要") "我的录音" else "录音纪要"
+            },
+        )
+
+        Box(
+            Modifier.fillMaxWidth().weight(1f)
+        ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                if (items.isEmpty()) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(56.dp)
+                            .padding(start = 24.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        if (recordState == RecordState.RECORDING) {
+                            Box(
+                                modifier = Modifier
+                                    .size(8.dp)
+                                    .clip(CircleShape)
+                                    .background(colors.accent)
+                            )
+                        }
+                        Text(
+                            text = if (recordState == RecordState.RECORDING) "正在识别" else "暂未识别到文字",
+                            color = colors.primaryBlack5,
+                            fontSize = 17.sp,
+                            lineHeight = 24.sp,
+                            modifier = Modifier.padding(
+                                start = if (recordState == RecordState.RECORDING) 8.dp else 0.dp
+                            ),
+                        )
+                    }
+                }
+
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    contentPadding = PaddingValues(start = 28.dp, end = 28.dp, top = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    items(
+                        items = items,
+                        key = { item -> item.index },
+                    ) { item ->
+                        ListItem(item = item)
+                    }
+
+                    // 最下面垫一个占位，避免最后一条被底部渐变遮罩挡住
+                    item {
+                        Spacer(modifier = Modifier.height(32.dp))
+                    }
+                }
+            }
+
+            // 底部渐变遮罩（透明 -> 页面背景色）
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .fillMaxWidth()
+                    .height(54.dp)
+                    .background(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(
+                                colors.grey0.copy(alpha = 0f),
+                                colors.grey0.copy(alpha = 1f),
+                            )
+                        )
+                    )
+            )
+
+            if (showFloatBall && items.isNotEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(end = 16.dp, bottom = 16.dp)
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .background(Color.White)
+                        .clickable {
+                            scope.launch {
+                                listState.animateScrollToItem(items.lastIndex)
+                            }
+                        }
+                ) {
+                    Text(
+                        "↓",
+                        modifier = Modifier.align(Alignment.Center),
+                        color = colors.primaryBlack1,
+                        fontSize = 18.sp,
+                    )
+                }
+            }
+        }
+
+        RecorderBar(
+            state = recordState,
+            durationMs = durationMs,
+            tips = recordTips,
+            onCancel = { showCancelDialog = true },
+            onConfirm = {
+                recordState = RecordState.STOPPED
+                recordTips = "上传中...0%"
+                // 模拟上传完成后重置回初始态
+                scope.launch {
+                    delay(1500)
+                    items = emptyList()
+                    itemCounter = 0
+                    durationMs = 0
+                    recordState = RecordState.IDLE
+                    recordTips = ""
+                }
+            },
+            onPause = { recordState = RecordState.PAUSED },
+            onResume = { recordState = RecordState.RECORDING },
+            onStart = {
+                itemCounter = 0
+                items = emptyList()
+                durationMs = 0
+                recordState = RecordState.RECORDING
+            },
+        )
+    }
+}
+
+// ============================================================
+// 子组件
+// ============================================================
+@Composable
+private fun ListItem(item: RecognitionItem) {
+    val colors = LocalAudioRecordColors.current
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = formatMillisToCompactTime(item.startTime),
+            fontSize = 14.sp,
+            color = colors.primaryBlack2,
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+        Text(
+            text = item.content,
+            fontSize = 16.sp,
+            lineHeight = 24.sp,
+            color = colors.primaryBlack1,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun TitleBar(
+    title: String,
+    onClose: () -> Unit,
+    onRename: () -> Unit,
+) {
+    val colors = LocalAudioRecordColors.current
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(44.dp)
+            .padding(horizontal = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                text = title,
+                fontSize = 17.sp,
+                lineHeight = 24.sp,
+                fontWeight = FontWeight.W500,
+                color = colors.primaryBlack1,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .widthIn(max = 225.dp)
+                    .clickable { onRename() },
+            )
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+            ) {
+                Box(
+                    modifier = Modifier
+                        .clickable { onRename() }
+                        .padding(start = 4.dp, end = 10.dp)
+                        .padding(vertical = 10.dp)
+                        .size(20.dp)
+                        .align(Alignment.CenterStart),
+                ) {
+                    Text(
+                        "✎",
+                        color = colors.primaryBlack3,
+                        fontSize = 16.sp,
+                        modifier = Modifier.align(Alignment.Center),
+                    )
+                }
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .clickable { onClose() },
+        ) {
+            Text(
+                "✕",
+                modifier = Modifier.size(24.dp).align(Alignment.Center),
+                color = colors.primaryBlack1,
+                fontSize = 20.sp,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecorderBar(
+    state: RecordState,
+    durationMs: Long,
+    tips: String,
+    onCancel: () -> Unit,
+    onConfirm: () -> Unit,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onStart: () -> Unit,
+) {
+    val colors = LocalAudioRecordColors.current
+    Column(
+        modifier = Modifier.fillMaxWidth().background(colors.grey0),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        if (tips.isNotEmpty()) {
+            Text(
+                tips,
+                fontSize = 13.sp,
+                color = colors.primaryBlack5,
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
+        }
+        if (state == RecordState.RECORDING || state == RecordState.PAUSED) {
+            Text(
+                formatMillisToCompactTime(durationMs),
+                fontSize = 14.sp,
+                color = colors.primaryBlack2,
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(bottom = 24.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            // 取消
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(CircleShape)
+                    .background(colors.primaryBlack5.copy(alpha = 0.15f))
+                    .clickable { onCancel() },
+            ) {
+                Text(
+                    "✕",
+                    modifier = Modifier.align(Alignment.Center),
+                    color = colors.primaryBlack1,
+                    fontSize = 20.sp,
+                )
+            }
+
+            // 中间录音/停止/继续 主按钮
+            val centerColor = if (state == RecordState.RECORDING) Color(0xFFE64340) else colors.accent
+            Box(
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(CircleShape)
+                    .background(centerColor)
+                    .clickable {
+                        when (state) {
+                            RecordState.IDLE -> onStart()
+                            RecordState.RECORDING -> onConfirm()
+                            RecordState.PAUSED -> onResume()
+                            else -> {}
+                        }
+                    },
+            ) {
+                Text(
+                    when (state) {
+                        RecordState.IDLE -> "开始"
+                        RecordState.RECORDING -> "停止"
+                        RecordState.PAUSED -> "继续"
+                        else -> ""
+                    },
+                    modifier = Modifier.align(Alignment.Center),
+                    color = Color.White,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.W500,
+                )
+            }
+
+            // 暂停（仅录音中显示）
+            if (state == RecordState.RECORDING) {
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .clip(CircleShape)
+                        .background(colors.primaryBlack5.copy(alpha = 0.15f))
+                        .clickable { onPause() },
+                ) {
+                    Text(
+                        "⏸",
+                        modifier = Modifier.align(Alignment.Center),
+                        color = colors.primaryBlack1,
+                        fontSize = 18.sp,
+                    )
+                }
+            } else {
+                Box(modifier = Modifier.size(44.dp))
+            }
+        }
+    }
+}

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/ComposeAllSample.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/ComposeAllSample.kt
@@ -166,6 +166,7 @@ internal class ComposeAllSample : ComposeContainer() {
             DemoItem("GradientAnimationDemo", "Offset or color animate ", "GradientAnimationDemo"),
             DemoItem("重组性能分析", "RecompositionProfiler追踪重组热点", "RecompositionProfilerDemo"),
             DemoItem("TextFieldEmoji", "TextField 自定义表情示例（暂不支持鸿蒙）", "TextFieldEmojiDemo"),
+            DemoItem("DashedUnderline", "文本虚线调研：实线/drawBehind/AnnotatedString", "DashedUnderlineDemo"),
         )
 
     @Composable

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/DashedUnderlineDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/DashedUnderlineDemo.kt
@@ -1,0 +1,134 @@
+package com.tencent.kuikly.demo.pages.compose
+
+import androidx.compose.runtime.Composable
+import com.tencent.kuikly.compose.ComposeContainer
+import com.tencent.kuikly.compose.extension.textPostProcessor
+import com.tencent.kuikly.compose.foundation.background
+import com.tencent.kuikly.compose.foundation.layout.Column
+import com.tencent.kuikly.compose.foundation.layout.Spacer
+import com.tencent.kuikly.compose.foundation.layout.fillMaxSize
+import com.tencent.kuikly.compose.foundation.layout.height
+import com.tencent.kuikly.compose.foundation.layout.padding
+import com.tencent.kuikly.compose.material3.Text
+import com.tencent.kuikly.compose.setContent
+import com.tencent.kuikly.compose.ui.Modifier
+import com.tencent.kuikly.compose.ui.draw.drawBehind
+import com.tencent.kuikly.compose.ui.geometry.Offset
+import com.tencent.kuikly.compose.ui.graphics.Color
+import com.tencent.kuikly.compose.ui.text.SpanStyle
+import com.tencent.kuikly.compose.ui.text.buildAnnotatedString
+import com.tencent.kuikly.compose.ui.text.style.TextDecoration
+import com.tencent.kuikly.compose.ui.text.withStyle
+import com.tencent.kuikly.compose.ui.unit.dp
+import com.tencent.kuikly.core.annotations.Page
+
+@Page("DashedUnderlineDemo")
+class DashedUnderlineDemo : ComposeContainer() {
+    override fun willInit() {
+        super.willInit()
+        setContent {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(16.dp).background(Color.White)
+            ) {
+                // ============================================
+                // 场景1：实线下划线（验证 Kuikly 文本基线能力）
+                // ============================================
+                Text("场景1: 实线下划线 (TextDecoration.Underline)")
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "这是实线下划线（Underline）",
+                    textDecoration = TextDecoration.Underline
+                )
+
+                Spacer(Modifier.height(24.dp))
+
+                // ============================================
+                // 场景2：AnnotatedString + SpanStyle 实下划线
+                // 仅给文本中的一小段加下划线（Span 级别），其余文字不加。
+                // ============================================
+                Text("场景2: AnnotatedString + SpanStyle 下划线（验证 Span 链路）")
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    buildAnnotatedString {
+                        append("这是一段普通文字，")
+                        withStyle(SpanStyle(textDecoration = TextDecoration.Underline)) {
+                            append("这里是实线下划线")
+                        }
+                        append("。")
+                    }
+                )
+
+                Spacer(Modifier.height(24.dp))
+
+                // ============================================
+                // 场景3：Text + drawBehind 画不出虚线（Kuikly 限制演示）
+                // 说明：想给文本加一条虚线下划线，尝试用 drawBehind 在 Text 上
+                // 手动画多段短线。但 Kuikly 当前 drawBehind 在 Text 上会被直接
+                // 跳过（底层不是 CanvasView），因此下面这行文字下方看不到任何线。
+                // 结论：Kuikly 文本目前只支持实线下划线，做不出虚线下划线。
+                // ============================================
+                Text("场景3: 文本做不出虚线下划线（Text + drawBehind 被跳过）")
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "这是文本尝试用 drawBehind 画虚线，但画不出来（Kuikly 限制）",
+                    modifier = Modifier.drawBehind {
+                        val y = size.height - 2.dp.toPx()
+                        val dashWidth = 6.dp.toPx()
+                        val gapWidth = 4.dp.toPx()
+                        val strokeWidth = 1.dp.toPx()
+                        var startX = 0f
+
+                        while (startX < size.width) {
+                            val endX = minOf(startX + dashWidth, size.width)
+                            drawLine(
+                                color = Color.Blue,
+                                start = Offset(startX, y),
+                                end = Offset(endX, y),
+                                strokeWidth = strokeWidth
+                            )
+                            startX += dashWidth + gapWidth
+                        }
+                    }
+                )
+
+                Spacer(Modifier.height(24.dp))
+
+                // ============================================
+                // 场景4：文本虚线下划线（跨端统一演示）
+                // 说明：Kuikly 的 Text 装饰没有虚线，但 Compose 提供
+                // Modifier.textPostProcessor("dashed")。三端共用一个入口组件
+                // DashedUnderlineText，由各自原生适配器实现：
+                //   - Android：走原生 KRTextPostProcessorAdapter 的 "dashed" 分支，
+                //     由自定义 DashedUnderlineSpan 在文字 baseline 下方画出贴合文字宽度的虚线；
+                //   - iOS：走原生 KuiklyRenderComponentExpandHandler 的 "dashed" 分支，用
+                //     NSAttributedString 的 NSUnderlineStyleSingle | NSUnderlinePatternDash
+                //     给整段文本加虚线下划线（原生富文本自带虚线样式）；
+                //   - OHOS：走 core-render-ohos 新增的 kDashedUnderline span（方案 C），
+                //     framework 在基线处用 OH_Drawing 手画一段段短线，实现真·文本虚线
+                //     （跟字形、换行逐行各一条）。
+                // 这是目前三端都能在 Kuikly Compose 里得到"真正文本虚线"的官方路径。
+                // ============================================
+                Text("场景4: textPostProcessor 原生虚线下划线（Android & iOS 走原生适配器，OHOS 走 kDashedUnderline span 基线手画）")
+                Spacer(Modifier.height(4.dp))
+                DashedUnderlineText("这是一条真正贴合文字宽度的虚线下划线")
+            }
+        }
+    }
+}
+
+/**
+ * 文本虚线下划线组件（跨端统一入口）：
+ * 三端统一走原生 [Modifier.textPostProcessor]("dashed") 适配器，由原生画出贴合文字的虚线。
+ *
+ * 各端实现：
+ *   - Android：DashedUnderlineSpan 在 baseline 下手画虚线
+ *   - iOS：NSAttributedString NSUnderlinePatternDash 原生虚线样式
+ *   - OHOS：core-render-ohos kDashedUnderline span → OH_Drawing 基线手画虚线段（方案 C）
+ */
+@Composable
+private fun DashedUnderlineText(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(text = text, modifier = Modifier.textPostProcessor("dashed"))
+}

--- a/docs/DevGuide/kuikly-compose-dashed-underline-summary.md
+++ b/docs/DevGuide/kuikly-compose-dashed-underline-summary.md
@@ -1,0 +1,53 @@
+# Kuikly Compose 文本虚线能力 · 摘要（1 页）
+
+> 完整分析见 `kuikly-compose-dashed-underline.md`。本页只给结论与源码证据。
+
+## 一、现状：Kuikly Compose 当前文本虚线到什么程度
+
+**文本是什么**：Kuikly 的 `Text` 底层是各端原生文本控件（Android `TextView` / iOS `NSAttributedString` / 鸿蒙 ArkUI `Text`），文字由系统文本引擎渲染，Kuikly 只负责推送文字参数。Text 背后**没有 Compose 画布**。
+
+**虚线到什么程度**：四种写法实测——
+
+| 写法 | 结果 |
+|------|------|
+| `TextDecoration.Underline` | ✅ 实线下划线（无虚线位） |
+| `AnnotatedString` + `SpanStyle(Underline)` | ✅ 局部实线下划线 |
+| `Modifier.drawBehind { 画线段 }` | ❌ 不显示（被 `CanvasView` 闸门跳过） |
+| `Modifier.textPostProcessor("dashed")` | ✅ 三端虚线，已验证 |
+
+唯一能画出虚线的路径是 `textPostProcessor("dashed")`，它绕过 Compose 层、让各端原生文本引擎画虚线：Android `DashedUnderlineSpan`、iOS `NSUnderlinePatternDash`、鸿蒙 `kDashedUnderline` span（基线手画）。
+
+## 二、目标：官方 Kotlin Compose 是怎样的
+
+官方 `Text` 是**自绘组件**（背后有 Skia 画布），`drawBehind` 能执行、`drawLine` 有 `pathEffect` 参数。声明式 `TextDecoration` 同样只有 3 位（无虚线），但靠 `drawBehind { drawLine(pathEffect = dashPathEffect) }` 能画出虚线。
+
+**差异根因**：不在 API 层（两边 `TextDecoration` 都只有 3 位），在渲染架构——官方自绘，Kuikly 原生渲染。
+
+| 维度 | 官方 | Kuikly |
+|------|------|--------|
+| `Text` 底层 | 自绘 Canvas | 原生 RichText |
+| `Text` 上 `drawBehind` | ✅ 生效 | ❌ 被跳过 |
+| `drawLine` 有 `pathEffect` | ✅ 有 | ❌ 无（被注释） |
+
+## 三、方案：如何对齐，是否值得做
+
+**两条路线**：
+
+- **路线 B（自绘对齐）**：让 `Text` 支持 `drawBehind` + 开放 `pathEffect`，机制层完全对齐官方。❌ **当前不可行**，两道硬伤：
+  1. `DrawBackgroundModifier.draw()` 仅在 `view is CanvasView` 时执行 `onDraw()`，`Text` 底层是 `RichTextView`，自绘回调永不触发。
+  2. `PathEffect` 类与 `drawLine` 的 `pathEffect` 参数在 Kuikly Compose 移植中全套被注释，编译不过。
+
+- **路线 C（原生桥接，已落地）**：`textPostProcessor("dashed")` 让各端原生文本层画虚线。✅ 三端已验证通过。视觉结果与官方无区别，只是实现机制不同（原生文本层 vs Canvas 自绘）。
+
+**结论**：路线 C 已实现"视觉结果对齐官方"，当前无需额外投入。路线 B 触碰 Kuikly 渲染架构核心假设（Text 全权交给原生 RichText），工作量大、风险高，作为远期技术观察，暂不跟进。
+
+## 源码证据速查
+
+| 事实 | 位置 |
+|------|------|
+| `drawBehind` 的 CanvasView 闸门 | `compose/.../ui/draw/DrawModifier.kt` `DrawBackgroundModifier.draw()` |
+| `Text` 节点无 Draw 能力 | `compose/.../text/modifiers/TextStringRichNode.kt`（仅 Layout+Semantics） |
+| `pathEffect` 被注释 | `compose/.../graphics/drawscope/DrawScope.kt`（import 与参数均 `//`） |
+| 底层 `setLineDash` 已就绪 | `core/.../views/CanvasView.kt:135`、`core-render-android/.../KRCanvasView.kt:166` |
+| Android 虚线 span | `androidApp/.../adapter/KRTextPostProcessorAdapter.kt` |
+| 鸿蒙虚线 span | `core-render-ohos/.../KRRichTextView.cpp` `kDashedUnderline` |

--- a/docs/DevGuide/kuikly-compose-dashed-underline.md
+++ b/docs/DevGuide/kuikly-compose-dashed-underline.md
@@ -1,0 +1,195 @@
+# Kuikly Compose 文本虚线能力分析
+
+> 目标：搞清楚 Kuikly Compose 当前文本虚线能做到什么程度、Kotlin Compose（官方）是什么水平、要不要完全对齐。
+> 关联 demo：Kuikly 侧 `demo/.../compose/DashedUnderlineDemo.kt`；Kotlin Compose 对照 `DashedLineVerify/MainActivity.kt`。
+
+## 术语澄清（先看这个，避免后面混）
+
+| 叫法 | 是什么 | 包名 |
+|------|--------|------|
+| **Kotlin Compose** | Google 官方 UI 工具包（即 Jetpack Compose），只跑 Android | `androidx.compose.*` |
+| **Kuikly Compose** | 腾讯 Kuikly 的 Compose DSL，写法模仿 Kotlin Compose，底层走 Kuikly 自有渲染引擎（跨端） | `com.tencent.kuikly.compose.*` |
+
+> 本文档只对比这两套：**Kotlin Compose** 指 Google 官方（即 Jetpack Compose）；**Kuikly Compose** 指腾讯 Kuikly 的 Compose DSL 层。两者除 API 写法相似外，底层渲染完全不同。
+
+---
+
+## 一、Kuikly Compose 当前文本虚线到什么程度（初步观察）
+
+从四层链路看，目前声明式 API、样式模型、native 透传层**仍没有**虚线相关入口（`TextDecoration` 无 Dashed 位、`drawBehind` 在 Text 上被跳过）；但三端都可通过 `Modifier.textPostProcessor("dashed")` 借原生绘制虚线（OHOS 详见 1.4）。注意：这里"Kuikly 声明式无虚线"不等于"底层平台无虚线"——Android/iOS/鸿蒙（ArkUI `TextDecorationStyle.Dashed`）原生均支持虚线，只是 Kuikly 的声明式封装未暴露该能力；我们通过 `textPostProcessor` 通道把虚线请求转交各端原生 / framework 渲染。
+
+### 1.1 四层链路（为什么画不出）
+
+| 层 | 现状 | 证据 |
+|----|------|------|
+| **API 层** | `TextDecoration` 只有 `Underline`(0x1) / `LineThrough`(0x2)，没有 Dashed | `compose/.../text/style/TextDecoration.kt` |
+| **模型层** | 内部用位掩码 `mask` 存，没有给"虚线"留任何一位 | 同上 |
+| **透传层** | 翻译成字符串 `"underline" / "line-through" / "none"`，无 `dashed` 分支 | `compose/.../foundation/text/KuiklyTextExtension.kt` 的 `applyTextDecoration` |
+| **渲染层** | `Text` 底层节点 `TextStringRichNode` 只实现 `LayoutModifierNode + SemanticsModifierNode`，不实现 Draw；`drawBehind` 作用在 `Text` 上被 `DrawModifier` 跳过（只有 `CanvasView` 才画） | `DrawModifier.kt`、`TextStringRichNode.kt` |
+
+> **位掩码**：用一个整数的二进制位当多个开关。Kuikly 用 `0x1`=下划线、`0x2`=删除线，当前未给虚线留位。
+> **`drawBehind` 被跳过**：源码里 `if (view is CanvasView) { 画 } else { 打 error log，跳过 }`。Kuikly 的 `Text` 底层是各平台原生文本控件（Android=TextView、iOS=NSAttributedString 富文本、OHOS=ArkUI Text），不是 Kuikly 的 `CanvasView`，所以 `drawBehind` 在 Text 上不生效（待确认是否为设计意图）。
+
+### 1.2 Kuikly 四场景对照（实测）
+
+| 场景 | 写法 | 结果 |
+|------|------|------|
+| 场景1 | `TextDecoration.Underline` | ✅ 实线下划线 |
+| 场景2 | `AnnotatedString` + `SpanStyle(Underline)` | ✅ 局部实线下划线 |
+| 场景3 | `Text` + `Modifier.drawBehind { 手动循环画短线段 }` | ❌ 不显示（`drawBehind` 被跳过） |
+| **场景4** | `Modifier.textPostProcessor("dashed")` | ✅ 三端虚线下划线（Android/iOS 走原生适配器；OHOS 走方案 C 的 kDashedUnderline span，基线手画真·文本虚线） |
+
+### 1.3 已知可用路径 —— `textPostProcessor` 借道原生
+
+```kotlin
+// 用法（Compose DSL）
+Text("要加虚线的文本", Modifier.textPostProcessor("dashed"))
+```
+
+- Android：在 `KRTextPostProcessorAdapter` 注册 `"dashed"` 分支，用 `DashedUnderlineSpan : ReplacementSpan` 接管文字绘制，先画文字、再在 baseline 下方用 `canvas.drawLine` 一段段画短线。
+- iOS：走适配器，用原生富文本虚线样式——整段 `NSAttributedString` 加 `NSUnderlineStyleSingle | NSUnderlinePatternDash`（同色）；已通过真机验证（iPhone 模拟器场景4 虚线正常显示）。
+- 鸿蒙（OHOS）：ArkUI 原生 `Text` 组件的 `decoration` 属性**本身支持虚线**（`TextDecorationStyle.Dashed` 修饰 `Underline` 即可）。但方案 C 落地前，Kuikly 的 OHOS `textPostProcessor` 桥只回传文本/图片 span，未把虚线线型（`TextDecorationStyle`）透传/表达出来，所以当时 `dashed` 分支无法借原生之手画虚线、只能走 Compose 自绘兜底（见 1.4）。**方案 C 已落地**（分支 `feat/ohos-dashed-underline-span`）：`core-render-ohos` 新增 `kDashedUnderline` span 类型（`KRTextPostProcessSpan::Type` + 虚线参数 `dash/gap/color/thickness`）；`KRRichTextShadow` 在 Phase 2 展开该 span（文字照常显示、打内部标记），Phase 3 记录其字符区间，`KRRichTextView::OnForegroundDraw` 在 Phase 5 用 `OH_Drawing` 在基线处手画一段段短线。**这是真·文本虚线**（跟字形、换行逐行各一条），区别于早期被移除的 Compose 纯布局近似。
+- 属于"绕过文本装饰、借原生"，**不走 `TextDecoration`**，是独立通道。
+
+> 注：demo 早期在 OHOS 上用 Compose 纯布局（Row + 小色块）做过"视觉近似"兜底，但那只是文字下方放一条虚线装饰，**不是真正的文本虚线**（不跟字形 / 基线、换行不会每行各一条）。该近似已移除，OHOS 统一走 `textPostProcessor("dashed")`；方案 C 落地后，OHOS 由 framework 在基线处手画真·文本虚线（见 1.3 鸿蒙条）。
+
+### 1.4 OHOS 演进：从"文本降级"到"基线手画"（为什么一开始画不出、后来能画了）
+
+**阶段1 —— 一开始为什么是"纯文本降级"**
+
+方案 C 落地前，OHOS 的 `textPostProcessor` 桥接（`ohosApp/entry/src/main/cpp/napi_init.cpp`）在 `"dashed"` 分支里调用的是：
+
+```cpp
+// napi_init.cpp 旧代码（方案C前）
+KRTextProcessedResultAppendTextSpan(builder, text)
+```
+
+这个公开 API 当时只能回传**纯文本 span 或图片 span**，没有任何字段可以表达"虚线下划线样式"（dash 长度、间隔、颜色、线宽）。于是 framework 收到的是"把这段文字原样显示"，虚线信息在桥接层就丢失了，屏幕上只显示普通文本、没有虚线。
+
+直接证据（HiLog `A01236/KuiklyDashed`）：
+```
+dashed processor hit on OHOS, but current API cannot express dashed underline; degrade to plain text.
+text=这是一条真正贴合文字宽度的虚线下划线
+```
+这条日志证明代码路径已走通（`dashed` 分支确实被命中），但执行逻辑就是"打印警告 → 退化为纯文本"。**根因是 API 能力缺口：没有能承载虚线样式的 span 类型，不是渲染引擎不会画。**
+
+**阶段2 —— 后来怎么实现"基线手画"**
+
+既然现有 API 不够，就**新增一个带虚线参数的 span 类型**，让 framework 自己手画（方案 C，分支 `feat/ohos-dashed-underline-span`）：
+
+- `KRTextPostProcessor.h`：`Type` 枚举加 `kDashedUnderline`；struct 加 `dash_width/gap_width/underline_color/thickness` 字段
+- `Kuikly.h` / `Kuikly.cpp`：新增公开 C API `KRTextProcessedResultAppendDashedUnderlineSpan(builder, text, dash, gap, color, thickness)`
+- `napi_init.cpp`：`"dashed"` 分支从 `AppendTextSpan`（降级纯文本）改为 `AppendDashedUnderlineSpan(builder, text, 6.0f, 4.0f, 0xff000000, 1.0f)`
+- `KRRichTextShadow`：Phase2 展开该 span（文字照常显示 + 打内部标记）；Phase3 记录字符区间 `[start,end)` + 绘制参数到 `dashed_underline_records_`
+- `KRRichTextView::OnForegroundDraw`：Phase5 遍历 records，用 `OH_Drawing_TypographyGetRectsForRange` 取跨行矩形，在每个矩形内按 dash+gap 手画短线段
+
+> 关键：**这不是 Compose 自绘（drawBehind 在 Kuikly Text 上仍不生效），而是 framework C++ 渲染层在文本排版完成、真正画到屏幕前，额外叠加的虚线绘制**——和 Android `DashedUnderlineSpan` 在 baseline 下手画的思路一致。它是真·文本虚线（跟字形、换行逐行各一条），区别于早期被移除的 Row+小色块视觉近似，也区别于阶段1 的纯文本降级。
+
+**演进对照**：
+
+```
+阶段1（方案C前）：napi_init "dashed" → AppendTextSpan(纯文本) → 无虚线 ❌（API 无虚线字段）
+阶段2（方案C落地）：napi_init "dashed" → AppendDashedUnderlineSpan(dash=6,gap=4,...)
+                 → Shadow Phase2/3 记录区间+参数
+                 → View OnForegroundDraw GetRectsForRange + Path 手画 → 基线处真虚线 ✅
+```
+
+---
+
+## 二、目标：Kotlin Compose（官方）是怎样的，支持虚线吗
+
+**观察：Kotlin Compose 的声明式文本装饰同样没有虚线（`TextDecoration` 也只有 Underline/LineThrough）。但 Kotlin Compose 的 `Text` 是真正的画布组件，能用 `drawBehind` + `PathEffect.dashPathEffect` 一键画出虚线。即：声明式未发现虚线开关，但自绘能力可以画出虚线。**
+
+> 注意：这一点和 Kuikly 的**差异主要在"渲染层"**——API 层（未发现虚线开关）、模型层（位掩码当前未给虚线留位）两边目前看起来一致。
+
+### 2.1 Kotlin Compose 五场景（来自 `DashedLineVerify`）
+
+| 场景 | 写法 | 结果 |
+|------|------|------|
+| 场景1 | `Text` + `drawBehind { drawLine(pathEffect = dashPathEffect) }` | ✅ 整行虚线 |
+| 场景2 | `Text` + `onTextLayout` 拿包围盒 + `drawBehind` 只画局部 | ✅ 局部虚线 |
+| 场景3 | `textDecoration = TextDecoration.Underline` | ✅ 实线下划线（对照基线） |
+| 场景4 | 多行折行文本 + `onTextLayout.getLineBottom` 逐行画 | ✅ 每行都画 |
+| 场景5 | 不同 dash/gap/strokeWidth 参数 | ✅ 疏密粗细可调 |
+
+Kotlin Compose 核心 API（Kuikly Compose 没有的）：
+
+```kotlin
+drawLine(
+    color = Color.Red,
+    start = Offset(0f, size.height),
+    end = Offset(size.width, size.height),
+    strokeWidth = 1.dp.toPx(),
+    pathEffect = PathEffect.dashPathEffect(   // ← 内置"虚线画笔效果"
+        intervals = floatArrayOf(8f, 4f),     //   按 [8px 实, 4px 空] 节奏画
+        phase = 0f
+    )
+)
+```
+
+### 2.2 两边差异根因
+
+| 维度 | Kotlin Compose | Kuikly Compose |
+|------|---------------------|----------------|
+| `Text` 底层 | 自有 Skia/Canvas 渲染管线 | 原生 RichText（Android=TextView，iOS=NSAttributedString） |
+| `Text` 上 `drawBehind` | ✅ 生效 | ❌ 被跳过（非 CanvasView） |
+| `drawLine` 有 `pathEffect` | ✅ 有 | ❌ 无 |
+| 声明式文本虚线 | ❌ 没有 | ❌ 没有 |
+| 能画虚线的路径 | `drawBehind` + `PathEffect`（纯声明式） | 三端均 `textPostProcessor` → 原生 / framework 绘制：Android=`DashedUnderlineSpan`、iOS=`NSAttributedString` 虚线、OHOS=`kDashedUnderline` span 基线手画（见 1.4） |
+
+---
+
+## 三、方案：如何完全对齐，是否值得做
+
+### 3.1 "对齐官方"的三层解读与路线对照
+
+**核心澄清**：Kotlin Compose（官方）能画虚线的**机制**是 `drawBehind` + `PathEffect`，而非 `TextDecoration`。所以"对齐官方"这个概念模型是**路线 B**（开放自绘）。但路线 B 受 Kuikly 渲染架构限制，目前物理上不可行。下面是两条路线的准确分类：
+
+| 路线 | 本质 | 是否对齐官方 | 可行性 |
+|------|------|-------------|--------|
+| **路线 B（自绘对齐）** | 让 Kuikly `Text` 支持 `drawBehind`（取消 CanvasView 闘门）+ `drawLine` 开放 `pathEffect`，采用与官方 Compose **相同的虚线绘制机制** | ✅ **是**，机制层完全对齐 | ❌ **当前不可行**，两道硬伤（见下） |
+| **路线 C（原生桥接——已落地）** | `textPostProcessor("dashed")` 桥接各端原生虚线能力（Android `DashedUnderlineSpan`、iOS `NSAttributedString` 虚线、OHOS `kDashedUnderline` span 基线手画） | ⚠️ **结果对齐**（最终画出了虚线），但机制不同（不是 Canvas 自绘，而是让原生文本层画） | ✅ **三端已实际验证通过** |
+
+---
+
+**路线 B（自绘对齐 —— 概念正确，但物理上受限）**
+- 目标：让 Kuikly 的 `Text` 底层可被 `DrawModifier` 识别（不再要求必须是 `CanvasView`）；`drawLine` 开放 `pathEffect` 参数（桥接到原生 `DashPathEffect`）。
+- **两道硬伤**（往期源码验证结论）：
+  1. **CanvasView 闸门**（`compose/.../ui/draw/DrawModifier.kt`）：`DrawBackgroundModifier.draw()` 只在 `view is CanvasView` 时执行 `onDraw()`，否则跳过。`Text` 底层是原生 `RichTextView`（非 CanvasView），故 `drawBehind` 的自绘回调永不触发。
+  2. **无 PathEffect**：`DrawScope.drawLine` 的 `pathEffect` 参数与 `PathEffect` 类在 Kuikly 移植中全套被注释掉，`drawLine(..., pathEffect=...)` 编译不过。
+- 工作量：**很大**，涉及 Kuikly 渲染架构假设（Compose 文本当前全权交给原生 RichText），且三端原生画布机制差异大。
+
+**路线 C（原生桥接 —— 已落地，结果对齐）**
+- 机制：`textPostProcessor("dashed")` 把虚线请求转交各端原生渲染层：Android 走 `DashedUnderlineSpan`、iOS 走 `NSAttributedString` 虚线、OHOS 走 `kDashedUnderline` span 基线手画。
+- 工作量：三端都是"桥接"，无需动声明式 API 或渲染架构，风险最低。
+- **这是当前推荐的"对齐官方视觉结果"的路径**。它没有对齐官方的绘制机制（Canvas 自绘），但在用户看到的效果上等价。
+
+### 3.2 代价 vs 收益
+
+| 项 | 说明 |
+|----|------|
+| 业务真实诉求 | 文本虚线下划线是个别场景（如链接、价格强调），非高频刚需 |
+| 现有解法 | `textPostProcessor` 三端已落地（Android `DashedUnderlineSpan`、iOS `NSAttributedString` 虚线、OHOS `kDashedUnderline` span 基线手画），场景4 已验证 |
+| "结果对齐"的代价 | 路线 C 的开发和回归成本已付出，当前无需额外投入。路线 B（自绘对齐）受架构限制不可行 |
+| 风险 | 路线 B 触碰 Kuikly 渲染核心假设，可能引出版面/性能回归，已判定当前暂不跟进 |
+
+### 3.3 当前结论
+
+> 三端已通过 `textPostProcessor("dashed")` 实现虚线下划线（Android=`DashedUnderlineSpan`、iOS=`NSAttributedString` 虚线、OHOS=`kDashedUnderline` span 基线手画）。该通道实现了**视觉结果对齐官方**——用户看到的文字虚线下划线和官方 Compose 没有区别。与官方的差异只在实现机制上：官方靠 `drawBehind` + `PathEffect`（Canvas 自绘），我们靠各端原生文本层绘制。这条差异是 Kuikly 渲染架构设计决定的（Text 底层走原生 RichText 而非 CanvasView），不算"缺口"，而是不同的架构取舍。
+>
+> 路线 B（自绘对齐）作为远期技术观察，暂不跟进。
+
+---
+
+## 附录：关键代码位置
+
+| 内容 | 路径 |
+|------|------|
+| `TextDecoration` 定义（仅 Underline/LineThrough） | `compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/text/style/TextDecoration.kt` |
+| 透传层（无 dashed 分支） | `compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/KuiklyTextExtension.kt` |
+| `Text` 节点（无 Draw 能力） | `compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/text/modifiers/TextStringRichNode.kt` |
+| `drawBehind` 跳过逻辑 | `compose/.../DrawModifier.kt`（仅 `CanvasView` 生效） |
+| Android 虚线适配器 | `androidApp/.../adapter/KRTextPostProcessorAdapter.kt`（`"dashed"` 分支 + `DashedUnderlineSpan`） |
+| Kuikly demo | `demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/compose/DashedUnderlineDemo.kt` |
+| Kotlin Compose 对照 demo | `DashedLineVerify/app/src/main/java/com/example/dashedlineverify/MainActivity.kt` |
+| `textPostProcessor` 官方说明 | `docs/DevGuide/text-post-processor-guide.md` |

--- a/iosApp/iosApp/KuiklyRenderExpand/Handlers/KuiklyRenderComponentExpandHandler.m
+++ b/iosApp/iosApp/KuiklyRenderExpand/Handlers/KuiklyRenderComponentExpandHandler.m
@@ -132,6 +132,28 @@ static void initEmojiMap(void) {
 }
 
 - (NSMutableAttributedString *)hr_customTextWithAttributedString:(NSAttributedString *)attributedString textPostProcessor:(NSString *)textPostProcessor {
+    // dashed 分支：文本虚线下划线（与 Android DashedUnderlineSpan 等价）。
+    // iOS 原生富文本自带虚线图案，直接给整段加 NSUnderlineStyleSingle | NSUnderlinePatternDash 即可。
+    // 注意：emoji 短码替换是图片替换，不与虚线同用，这里只对纯文本整段加虚线下划线。
+    if ([textPostProcessor isEqualToString:@"dashed"]) {
+        NSMutableAttributedString *result = [attributedString mutableCopy];
+        NSRange fullRange = NSMakeRange(0, result.length);
+        if (fullRange.length > 0) {
+            [result addAttribute:NSUnderlineStyleAttributeName
+                           value:@(NSUnderlineStyleSingle | NSUnderlinePatternDash)
+                           range:fullRange];
+            UIColor *underlineColor = [result attribute:NSForegroundColorAttributeName
+                                                    atIndex:0
+                                             effectiveRange:NULL];
+            if (underlineColor) {
+                [result addAttribute:NSUnderlineColorAttributeName
+                               value:underlineColor
+                               range:fullRange];
+            }
+        }
+        return result;
+    }
+
     if (![textPostProcessor isEqualToString:@"KRTextFieldView"] &&
         ![textPostProcessor isEqualToString:@"KRTextAreaView"] &&
         ![textPostProcessor isEqualToString:@"input"] &&

--- a/ohosApp/entry/src/main/cpp/napi_init.cpp
+++ b/ohosApp/entry/src/main/cpp/napi_init.cpp
@@ -487,6 +487,21 @@ static void MyTextPostProcessorAdapter(const char *name,
     if (!text || !builder) {
         return;
     }
+    // dashed 分支：文本虚线下划线（与 Android/iOS "dashed" processor 对齐）。
+    // 注意：当前 OHOS 公开 textPostProcessor API（KRTextProcessedResultAppendTextSpan/ImageSpan）
+    // 只能回传纯文本 / 图片 span，无法表达"虚线下划线"样式。因此这里仅做探针 + 原样回传，
+    // 如实验证"OHOS 当前无法借原生画出虚线下划线"。如需真正支持，需 framework 侧新增
+    // 带 underline 样式的 text span（见文档 kuikly-compose-dashed-underline.md 3.3 节）。
+    if (name && std::string(name) == "dashed") {
+        static constexpr int kDashedDomain = 0x1236;
+        OH_LOG_Print(LOG_APP, LOG_INFO, kDashedDomain, "KuiklyDashed",
+                     "dashed processor hit on OHOS: append DashedUnderlineSpan (true text dashed "
+                     "underline drawn at baseline). text=%{public}s", text);
+        // 真·文本虚线：文字照常显示，由 framework 在基线处按 dash+gap 节奏手画短线段。
+        // 参数：dash=6px, gap=4px, color=0xff000000(黑), thickness=1px。
+        KRTextProcessedResultAppendDashedUnderlineSpan(builder, text, 6.0f, 4.0f, 0xff000000, 1.0f);
+        return;
+    }
     // 探针：便于线上一眼确认 adapter 是否被调到、看到 processor 名称与输入文本。tag=KuiklyEmoji。
     {
         static constexpr int kEmojiDomain = 0x1235;


### PR DESCRIPTION
在 Demo 中用纯 Kuikly Compose DSL 复刻 ima 的 AudioRecordDetailPager（录音纪要详情页）。

## 说明
- 纯 Kuikly Compose DSL 实现，无外部业务依赖
- 本地 mock 状态模拟「录音 → 实时识别 → 停止上传」全流程
- 支持自动滚动到底部、回底悬浮球、暂停/继续、取消确认弹窗

## 使用方式
- `am start --es pageName AudioRecordDetailDemo` 直接打开
- 或 Demo router 页手输 `AudioRecordDetailDemo`