### PR TITLE
[Bugfix] 为鸿蒙和iOS增加真实的vsync机制

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ComposeContainer.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ComposeContainer.kt
@@ -173,19 +173,18 @@ open class ComposeContainer :
     private fun startFrameDispatcher() {
         mediator?.renderFrame()
         val pageData = getPager().pageData
-        if (pageData.isOhOs || pageData.isMiniApp || pageData.isWeb) {
+        if (pageData.isMiniApp || pageData.isWeb) {
             mediator?.startFrameDispatcher()
         } else {
-            getModule<VsyncModule>(VsyncModule.MODULE_NAME)?.registerVsync {
-                mediator?.renderFrame()
+            getModule<VsyncModule>(VsyncModule.MODULE_NAME)?.registerVsync { frameTimeNanos ->
+                mediator?.renderFrame(frameTimeNanos)
             }
         }
     }
 
     private fun stopFrameDispatcher() {
-        if (getPager().pageData.isOhOs) {
-
-        } else {
+        val pageData = getPager().pageData
+        if (!pageData.isMiniApp && !pageData.isWeb) {
             getModule<VsyncModule>(VsyncModule.MODULE_NAME)?.unRegisterVsync()
         }
     }

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ComposeSceneMediator.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ComposeSceneMediator.kt
@@ -107,8 +107,16 @@ class ComposeSceneMediator(
         return timer
     }
 
-    fun renderFrame() {
-        val timestamp = DateTime.nanoTime()
+    private var lastFrameTimeNanos = 0L
+
+    /**
+     * @param frameTimeNanos 本帧时间戳(纳秒)。VsyncModule 驱动时为真实 vsync 时间戳,
+     * 以减少动画时间抖动;其他驱动(12ms Timer)沿用 [DateTime.nanoTime]。
+     */
+    fun renderFrame(frameTimeNanos: Long = DateTime.nanoTime()) {
+        // 帧时钟必须单调递增,防御 vsync 时间戳与 nanoTime 时基的微小偏差
+        val timestamp = if (frameTimeNanos > lastFrameTimeNanos) frameTimeNanos else lastFrameTimeNanos + 1
+        lastFrameTimeNanos = timestamp
         scene.vsyncTickConditions.onDisplayLinkTick {
             scene.render(null, timestamp)
         }

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/RootNodeOwner.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/RootNodeOwner.kt
@@ -162,6 +162,7 @@ internal class RootNodeOwner(
     }
 
     private var needClearObservations = false
+    private var semanticsChangePending = false
 
     private fun clearInvalidObservations() {
         if (needClearObservations) {
@@ -207,6 +208,10 @@ internal class RootNodeOwner(
 //            graphicsLayer = null // the root node will provide the root graphics layer
         )
         clearInvalidObservations()
+        if (semanticsChangePending) {
+            semanticsChangePending = false
+            semanticsKuiklyHandler.onSemanticsChange(semanticsOwner)
+        }
     }
 
     fun setRootModifier(modifier: Modifier) {
@@ -400,7 +405,10 @@ internal class RootNodeOwner(
 
         override fun onSemanticsChange() {
 //            platformContext.semanticsOwnerListener?.onSemanticsChange(semanticsOwner)
-            semanticsKuiklyHandler.onSemanticsChange(semanticsOwner)
+            // Coalesce to at most once per frame: this fires per semantics invalidation
+            // (dozens of times during a single fling remeasure), and each handler pass
+            // walks the whole merged semantics tree.
+            semanticsChangePending = true
         }
 
         override fun onZIndexChange(layoutNode: LayoutNode) {

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/module/KRVsyncModule.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/module/KRVsyncModule.kt
@@ -38,8 +38,8 @@ class KRVsyncModule : KuiklyRenderBaseModule() {
 
     private fun registerVsync(callback: KuiklyRenderCallback?) {
         if (vsyncFrameCallback == null) {
-            vsyncFrameCallback = Choreographer.FrameCallback {
-                callback?.invoke(null)
+            vsyncFrameCallback = Choreographer.FrameCallback { frameTimeNanos ->
+                callback?.invoke(mapOf(PARAM_TIMESTAMP to frameTimeNanos))
                 Choreographer.getInstance().postFrameCallback(vsyncFrameCallback);
             }
             Choreographer.getInstance().postFrameCallback(vsyncFrameCallback);
@@ -64,6 +64,7 @@ class KRVsyncModule : KuiklyRenderBaseModule() {
         const val MODULE_NAME = "KRVsyncModule"
         const val METHOD_REGISTER_VSYNC = "registerVsync"
         const val METHOD_UNREGISTER_VSYNC = "unRegisterVsync"
+        private const val PARAM_TIMESTAMP = "timestamp"
 
     }
 }

--- a/core-render-ios/Extension/Modules/KRVsyncModule.mm
+++ b/core-render-ios/Extension/Modules/KRVsyncModule.mm
@@ -15,18 +15,68 @@
 
 #import "KRVsyncModule.h"
 #import "KuiklyRenderThreadManager.h"
+#include <TargetConditionals.h>
+#if !TARGET_OS_OSX
+#import <UIKit/UIKit.h>
+#endif
+
+#if !TARGET_OS_OSX
+
+// 内部对象持有 CADisplayLink,避免 CADisplayLink 强引用 module 导致无法释放
+@interface _KRVsyncDisplayLink : NSObject
+
+@property (nonatomic, strong) CADisplayLink *displayLink;
+@property (nonatomic, copy) void (^callback)(NSTimeInterval timestamp);
+
+@end
+
+@implementation _KRVsyncDisplayLink
+
+- (void)startWithPreferredFPS:(NSInteger)fps {
+    [self stop];
+    self.displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(onVsyncTick:)];
+    if (@available(iOS 15.0, *)) {
+        // 自适应区间: 动画时跑满屏幕最大刷新率,静止时允许系统降到 60Hz 以省电
+        CGFloat minFPS = MIN(60, fps);
+        self.displayLink.preferredFrameRateRange = CAFrameRateRangeMake(minFPS, fps, fps);
+    } else {
+        self.displayLink.preferredFramesPerSecond = fps;
+    }
+    [self.displayLink addToRunLoop:NSRunLoop.mainRunLoop forMode:NSRunLoopCommonModes];
+}
+
+- (void)onVsyncTick:(CADisplayLink *)link {
+    if (self.callback) {
+        self.callback(link.timestamp);
+    }
+}
+
+- (void)stop {
+    [self.displayLink invalidate];
+    self.displayLink = nil;
+}
+
+@end
+
+#endif
 
 @implementation KRVsyncModule
 {
     KuiklyRenderCallback _tipCb;
+#if TARGET_OS_OSX
     dispatch_source_t _kotlinTimer;
+#else
+    _KRVsyncDisplayLink *_vsyncDisplayLink;
+#endif
 }
+
+#if TARGET_OS_OSX
 
 - (void)registerVsync:(NSDictionary *)args {
     _tipCb = args[KR_CALLBACK_KEY];
-    
+
     dispatch_queue_t contextQueue = [KuiklyRenderThreadManager contextQueue];
-    
+
     if (!contextQueue) {
         return ;
     }
@@ -39,7 +89,6 @@
         [sself vsyncFire];
     });
     dispatch_resume(_kotlinTimer);
-
 }
 
 - (void)vsyncFire {
@@ -58,5 +107,66 @@
 - (void)unRegisterVsync:(NSDictionary *)args {
     [self invalidateTimer];
 }
+
+#else
+
+// iOS: CADisplayLink 驱动,跟随屏幕最大刷新率(ProMotion 120Hz)。
+// 需配合 Info.plist 的 CADisableMinimumFrameDurationOnPhone,否则 iPhone 上仍被钳制在 60Hz。
+- (void)registerVsync:(NSDictionary *)args {
+    _tipCb = args[KR_CALLBACK_KEY];
+    __weak __typeof__(self) wself = self;
+    // CADisplayLink 需要挂到主 RunLoop
+    [KuiklyRenderThreadManager performOnMainQueueWithTask:^{
+        __strong __typeof__(self) sself = wself;
+        [sself p_startDisplayLinkOnMainThread];
+    } sync:NO];
+}
+
+- (void)p_startDisplayLinkOnMainThread {
+    if (!_tipCb) {
+        return;
+    }
+    NSInteger maxFPS = UIScreen.mainScreen.maximumFramesPerSecond;
+    if (!_vsyncDisplayLink) {
+        _vsyncDisplayLink = [[_KRVsyncDisplayLink alloc] init];
+    }
+    __weak __typeof__(self) wself = self;
+    _vsyncDisplayLink.callback = ^(NSTimeInterval timestamp) {
+        // 主线程 vsync tick,派发到 context 线程触发 Kotlin 侧 renderFrame
+        [KuiklyRenderThreadManager performOnContextQueueWithBlock:^{
+            __strong __typeof__(self) sself = wself;
+            [sself p_vsyncFireWithTimestamp:timestamp];
+        }];
+    };
+    [_vsyncDisplayLink startWithPreferredFPS:maxFPS];
+}
+
+- (void)p_vsyncFireWithTimestamp:(NSTimeInterval)timestamp {
+    if (_tipCb) {
+        // 统一以纳秒透传 vsync 时间戳,供 Kotlin 侧作为帧时钟(与 DateTime.nanoTime 同为开机时基)
+        _tipCb(@{@"timestamp": @((long long)(timestamp * NSEC_PER_SEC))});
+    }
+}
+
+- (void)p_stopDisplayLink {
+    _KRVsyncDisplayLink *displayLink = _vsyncDisplayLink;
+    _vsyncDisplayLink = nil;
+    if (displayLink) {
+        [KuiklyRenderThreadManager performOnMainQueueWithTask:^{
+            [displayLink stop];
+        } sync:NO];
+    }
+}
+
+- (void)unRegisterVsync:(NSDictionary *)args {
+    _tipCb = nil;
+    [self p_stopDisplayLink];
+}
+
+- (void)dealloc {
+    [self p_stopDisplayLink];
+}
+
+#endif
 
 @end

--- a/core-render-ohos/src/main/cpp/CMakeLists.txt
+++ b/core-render-ohos/src/main/cpp/CMakeLists.txt
@@ -88,6 +88,7 @@ set(SOURCE_SET
         libohos_render/expand/modules/calendar/KRDate.cpp
         libohos_render/expand/modules/calendar/KRCalendarModule.cpp
         libohos_render/expand/modules/file/KRFileModule.cpp
+        libohos_render/expand/modules/vsync/KRVsyncModule.cpp
         libohos_render/expand/modules/back_press/KRBackPressModule.cpp
         libohos_render/utils/KRURIHelper.cpp
         libohos_render/utils/KRBase64Util.cpp

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/ModulesRegisterEntry.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/ModulesRegisterEntry.h
@@ -28,6 +28,7 @@
 #include "libohos_render/expand/modules/preferences/KRSharedPreferencesModule.h"
 #include "libohos_render/expand/modules/preferences/KROhSharedPreferencesModule.h"
 #include "libohos_render/expand/modules/file/KRFileModule.h"
+#include "libohos_render/expand/modules/vsync/KRVsyncModule.h"
 #include "libohos_render/export/IKRRenderModuleExport.h"
 
 #endif  // CORE_RENDER_OHOS_MODULESREGISTERENTRY_H
@@ -73,5 +74,9 @@ static void ModulesRegisterEntry() {
 
     IKRRenderModuleExport::RegisterModuleCreator(kuikly::module::KRFileModule::MODULE_NAME, [] {
         return std::make_shared<kuikly::module::KRFileModule>();
+    });
+
+    IKRRenderModuleExport::RegisterModuleCreator(kuikly::module::KRVsyncModule::MODULE_NAME, [] {
+        return std::make_shared<kuikly::module::KRVsyncModule>();
     });
 }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/vsync/KRVsyncModule.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/vsync/KRVsyncModule.cpp
@@ -1,0 +1,144 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "KRVsyncModule.h"
+
+#include <cstring>
+#include <memory>
+
+#include "libohos_render/scheduler/KRContextScheduler.h"
+
+namespace kuikly {
+namespace module {
+
+const char KRVsyncModule::MODULE_NAME[] = "KRVsyncModule";
+const char KRVsyncModule::METHOD_REGISTER_VSYNC[] = "registerVsync";
+const char KRVsyncModule::METHOD_UNREGISTER_VSYNC[] = "unRegisterVsync";
+
+namespace {
+
+// Passed to OH_NativeVSync_RequestFrame as user data. Holds a weak_ptr so an
+// in-flight vsync callback stays safe after the module is destroyed, plus the
+// generation at request time so callbacks from a stale registration are dropped.
+struct VsyncRequestContext {
+    std::weak_ptr<KRVsyncModule> weak_module;
+    uint64_t generation;
+};
+
+KRAnyValue MakeTimestampParam(long long timestamp_nanos) {
+    KRRenderValueMap map;
+    map["timestamp"] = KRRenderValue::Make(static_cast<int64_t>(timestamp_nanos));
+    return KRRenderValue::Make(map);
+}
+
+}  // namespace
+
+KRVsyncModule::~KRVsyncModule() {
+    if (native_vsync_) {
+        OH_NativeVSync_Destroy(native_vsync_);
+        native_vsync_ = nullptr;
+    }
+}
+
+KRAnyValue KRVsyncModule::CallMethod(bool sync, const std::string &method, KRAnyValue params,
+                                     const KRRenderCallback &callback, bool callback_keep_alive) {
+    if (std::strcmp(method.c_str(), METHOD_REGISTER_VSYNC) == 0) {
+        RegisterVsync(callback);
+    } else if (std::strcmp(method.c_str(), METHOD_UNREGISTER_VSYNC) == 0) {
+        UnRegisterVsync();
+    }
+    return KREmptyValue();
+}
+
+void KRVsyncModule::OnDestroy() {
+    UnRegisterVsync();
+}
+
+void KRVsyncModule::RegisterVsync(const KRRenderCallback &callback) {
+    if (!callback) {
+        return;
+    }
+    std::lock_guard<std::mutex> guard(mutex_);
+    callback_ = callback;
+    running_ = true;
+    generation_++;
+    tick_pending_.store(false);
+    if (!native_vsync_) {
+        native_vsync_ = OH_NativeVSync_Create(MODULE_NAME, strlen(MODULE_NAME));
+    }
+    RequestNextVsyncLocked();
+}
+
+void KRVsyncModule::UnRegisterVsync() {
+    std::lock_guard<std::mutex> guard(mutex_);
+    running_ = false;
+    callback_ = nullptr;
+    generation_++;
+}
+
+// Must be called with mutex_ held.
+void KRVsyncModule::RequestNextVsyncLocked() {
+    if (!native_vsync_) {
+        return;
+    }
+    auto *context = new VsyncRequestContext{
+        std::static_pointer_cast<KRVsyncModule>(shared_from_this()), generation_};
+    OH_NativeVSync_RequestFrame(native_vsync_, &KRVsyncModule::OnVsync, context);
+}
+
+// Invoked on the vsync thread. The callback itself dispatches to the context
+// thread inside KRRenderCore, so no extra thread hop is needed here.
+void KRVsyncModule::OnVsync(long long timestamp, void *data) {
+    auto *context = static_cast<VsyncRequestContext *>(data);
+    auto self = context->weak_module.lock();
+    const uint64_t generation = context->generation;
+    delete context;
+    if (!self) {
+        return;
+    }
+    KRRenderCallback cb = nullptr;
+    {
+        std::lock_guard<std::mutex> guard(self->mutex_);
+        if (!self->running_ || generation != self->generation_) {
+            return;
+        }
+        self->RequestNextVsyncLocked();
+        // Back-pressure: if the previous tick is still queued on the context
+        // thread (e.g. a slow frame is blocking it), drop this tick instead of
+        // letting ticks pile up behind it. The next vsync will deliver a fresh
+        // timestamp once the context thread catches up.
+        if (self->tick_pending_.exchange(true)) {
+            return;
+        }
+        cb = self->callback_;
+    }
+    if (cb) {
+        cb(MakeTimestampParam(timestamp));
+        // The callback above enqueues the Kotlin frame task on the context
+        // thread; enqueue the flag reset right behind it so tick_pending_
+        // clears only after that frame task has actually been consumed.
+        std::weak_ptr<KRVsyncModule> weak_module = self;
+        KRContextScheduler::ScheduleTask(0, [weak_module] {
+            if (auto module = weak_module.lock()) {
+                module->tick_pending_.store(false);
+            }
+        });
+    } else {
+        self->tick_pending_.store(false);
+    }
+}
+
+}  // namespace module
+}  // namespace kuikly

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/vsync/KRVsyncModule.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/vsync/KRVsyncModule.h
@@ -1,0 +1,66 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <native_vsync/native_vsync.h>
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include "libohos_render/export/IKRRenderModuleExport.h"
+
+namespace kuikly {
+namespace module {
+
+/**
+ * Vsync module: provides system vsync callbacks (OH_NativeVSync) for the Kotlin-side
+ * VsyncModule, aligning the Compose frame dispatcher with the screen refresh rate
+ * (replacing the previous 12ms timer loop).
+ */
+class KRVsyncModule : public IKRRenderModuleExport {
+ public:
+    static const char MODULE_NAME[];
+
+    KRVsyncModule() = default;
+    ~KRVsyncModule();
+
+    KRAnyValue CallMethod(bool sync, const std::string &method, KRAnyValue params,
+                          const KRRenderCallback &callback, bool callback_keep_alive) override;
+    void OnDestroy() override;
+
+ private:
+    static const char METHOD_REGISTER_VSYNC[];
+    static const char METHOD_UNREGISTER_VSYNC[];
+
+    void RegisterVsync(const KRRenderCallback &callback);
+    void UnRegisterVsync();
+    void RequestNextVsyncLocked();
+
+    static void OnVsync(long long timestamp, void *data);
+
+    std::mutex mutex_;
+    KRRenderCallback callback_ = nullptr;
+    bool running_ = false;
+    // Generation counter: bumped on unregister/destroy so that in-flight vsync
+    // callbacks from a previous registration are safely ignored.
+    uint64_t generation_ = 0;
+    // Back-pressure flag: true while a vsync tick is queued on the context thread
+    // but not yet consumed. Further ticks are dropped instead of piling up.
+    std::atomic<bool> tick_pending_{false};
+    OH_NativeVSync *native_vsync_ = nullptr;
+};
+
+}  // namespace module
+}  // namespace kuikly

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/module/VsyncModule.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/module/VsyncModule.kt
@@ -15,6 +15,8 @@
 
 package com.tencent.kuikly.core.module
 
+import com.tencent.kuikly.core.datetime.DateTime
+
 /**
  *  监听Vsync回调
  *  created by zhenhuachen on 2025/4/27.
@@ -25,14 +27,19 @@ class VsyncModule : Module() {
         return MODULE_NAME
     }
 
-    fun registerVsync(callback: () -> Unit) {
+    /**
+     * @param callback 每个 vsync 回调一次。frameTimeNanos 为本帧 vsync 时间戳(纳秒,开机单调时基,
+     * 与 [DateTime.nanoTime] 同源);native 侧未透传时间戳时回退为 [DateTime.nanoTime]。
+     */
+    fun registerVsync(callback: (frameTimeNanos: Long) -> Unit) {
         toNative(
             keepCallbackAlive = true,
             methodName = METHOD_REGISTER_VSYNC,
             syncCall = false,
             param = null,
-            callback = {
-                callback()
+            callback = { res ->
+                val frameTimeNanos = res?.optLong(PARAM_TIMESTAMP) ?: 0L
+                callback(if (frameTimeNanos > 0L) frameTimeNanos else DateTime.nanoTime())
             }
         )
     }
@@ -50,5 +57,6 @@ class VsyncModule : Module() {
         const val MODULE_NAME = ModuleConst.VSYNC
         const val METHOD_REGISTER_VSYNC = "registerVsync"
         const val METHOD_UNREGISTER_VSYNC = "unRegisterVsync"
+        private const val PARAM_TIMESTAMP = "timestamp"
     }
 }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
# feat(compose): 真实系统 Vsync 帧驱动（iOS CADisplayLink / 鸿蒙 OH_NativeVSync）+ 修复语义树全量遍历导致的 fling 白屏

## 背景 / 动机

Kuikly Compose 的帧驱动此前并非真实系统 vsync：

- **iOS**：`KRVsyncModule` 用 `dispatch_source_t` 定时器模拟 60Hz，与屏幕刷新不对齐，ProMotion（120Hz）设备上动画只有 60fps 且存在节拍差顿挫。
- **鸿蒙（OHOS）**：`ComposeContainer` 走的是 Kotlin 侧 12ms Timer 延时循环（约 83Hz，随负载漂移），同样与屏幕刷新率不对齐，高刷设备上滚动/动画有明显卡顿感。
- **帧时间戳**：Kotlin 侧 `VsyncModule` 回调不带时间戳，Compose 帧时钟只能自行取当前时间，无法与 vsync 对齐。

另外在验证过程中定位并修复了一个独立问题：**鸿蒙 LazyColumn 快速 fling 时白屏**。根因是 #1391 移除了 `RootNodeOwner.onSemanticsChange()` 的 `isSemanticsRunnnng` 门控后，每次语义失效都会同步全量遍历合并语义树（一次慢滚动事件内可触发 7~27 次，每次约 2~3.5ms），单个滚动事件处理耗时峰值达 92ms，context 线程排队滞后，视口滑入未组合区域出现白屏。

## 主要改动

### 1. iOS：CADisplayLink 真 vsync（`core-render-ios/Extension/Modules/KRVsyncModule.mm`）

- iOS 分支改为 `CADisplayLink` 驱动，挂主 RunLoop（`NSRunLoopCommonModes`），tick 派发到 context 线程回调 Kotlin。
- iOS 15+ 使用 `preferredFrameRateRange(min=60, max=屏幕最大刷新率)`，动画时跑满 120Hz、静止时允许系统降频省电。
- 通过内部 `_KRVsyncDisplayLink` 中介对象持有 CADisplayLink，避免 CADisplayLink 强引用 module 造成泄漏；`unRegisterVsync`/`dealloc` 时在主线程 invalidate。
- macOS（`TARGET_OS_OSX`）保留原 timer 实现不变。
- `iosApp/iosApp/Info.plist` 增加 `CADisableMinimumFrameDurationOnPhone=true`（iPhone 上不加会被系统钳制在 60Hz）。

### 2. 鸿蒙：新增 C++ `KRVsyncModule`（`OH_NativeVSync` 真 vsync）

新增 `core-render-ohos/src/main/cpp/libohos_render/expand/modules/vsync/KRVsyncModule.{h,cpp}`，并在 `ModulesRegisterEntry.h` / `CMakeLists.txt` 注册编译：

- 基于 `OH_NativeVSync_Create / RequestFrame`，每帧回调后重新 arm 下一帧。
- **生命周期安全**：请求上下文持 `weak_ptr<KRVsyncModule>` + generation 计数；unregister/destroy 后飞行中的 vsync 回调 lock 失败或 generation 不匹配即安全丢弃（无 UAF）。
- **背压**：原子 `tick_pending_` 标志——上一帧任务尚未被 context 线程消费时，后续 vsync tick 直接丢弃，避免慢帧后 tick 堆积；标志通过 `KRContextScheduler::ScheduleTask(0, ...)` 排在帧任务之后清除。

### 3. Kotlin：ohos 帧驱动切到 VsyncModule + vsync 时间戳透传

- `ComposeContainer.kt`：ohos 从 12ms Timer 分支移到与 iOS/Android 一致的 `VsyncModule.registerVsync` 路径；`stopFrameDispatcher` 补上对应的 `unRegisterVsync`。miniApp/Web 仍走原 Timer 分支不变。
- `VsyncModule.kt`（**API 变化**）：`registerVsync` 回调签名从 `() -> Unit` 改为 `(frameTimeNanos: Long) -> Unit`，从 native 回调参数解析 `"timestamp"`（纳秒），缺省回退 `DateTime.nanoTime()`。
- `core-render-android/.../KRVsyncModule.kt`：Choreographer 的 `frameTimeNanos` 透传给 Kotlin。
- `ComposeSceneMediator.renderFrame(frameTimeNanos)`：以 vsync 时间戳作为 Compose 帧时钟，并做单调递增钳制（防止跨时基/乱序时间戳打断动画）。

### 4. 修复：语义变更合帧，消除 fling 白屏（`RootNodeOwner.kt`）

`onSemanticsChange()` 不再同步执行全量语义树遍历，只置 `semanticsChangePending = true`；在 `draw()` 末尾每帧至多 flush 一次。

- 正确性：所有语义失效均源自重组/布局，它们必然调度渲染帧，而 `BaseComposeScene.render()` 无条件调用 `draw()`，故变更不会丢失，只是合并到帧尾。
- 保留 #1391 的 testTag / 无障碍功能（相比恢复旧 `isSemanticsRunnnng` 门控，不会在未开无障碍时丢 testTag）。

## 效果数据

同一鸿蒙真机、同一脚本化 fling（120Hz 屏）：

| 指标 | 修复前 | 修复后 |
| --- | --- | --- |
| 单滚动事件处理耗时 avg | 8.18 ms | **1.92 ms**（基线 1.86 ms） |
| 单滚动事件处理耗时 max | 92 ms | 28 ms |
| ≥10ms 的滚动事件数 | 30 | 4 |
| 语义树全量遍历次数（单次 fling） | 292 | **28**（-90%） |
| fling 过程连拍截图 | 出现白屏 | 无白屏 |

vsync 驱动：鸿蒙帧间隔 ≈ 屏幕刷新周期（120Hz ≈ 8.3ms），iOS ProMotion 设备动画跑满 120fps。

## 兼容性说明

- `VsyncModule.registerVsync` 回调签名变化（`() -> Unit` → `(frameTimeNanos: Long) -> Unit`），仓库内调用点已同步更新；外部若有直接调用需适配。
- Android：仅透传 Choreographer 时间戳，行为不变。
- 未注册 C++ `KRVsyncModule` 的旧鸿蒙宿主会走 ArkTS 转发兜底；本 PR 已在 native 层注册拦截。
- macOS / miniApp / Web 帧驱动路径不变。

## 验证

- [x] 鸿蒙真机（120Hz）：ComposeAllSample LazyColumn 快速 fling，fling 过程中连拍截图无白屏；滚动事件耗时回到基线水平。
- [x] 鸿蒙：`hilog` 帧间隔 ≈ 8.3ms，与屏幕刷新对齐；页面退出/重进无 crash（验证 pending vsync 回调的 weak_ptr + generation 路径）。
- [x] iOS ProMotion 设备：ModalBottomSheet 动画 120fps，帧间隔 ≈ 8.3ms。
- [x] Android / iOS / 鸿蒙编译通过；Android 行为回归不变。
