### PR TITLE
fix(android): prevent KRNotifyModule from re-registering receiver after onDestroy

### DIFF
--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/module/KRNotifyModule.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/module/KRNotifyModule.kt
@@ -35,6 +35,7 @@ open class KRNotifyModule : KuiklyRenderBaseModule() {
 
     private val toHRMap: MutableMap<String, MutableList<HRCallbackWrapper>> = mutableMapOf()
     private var notifyBroadcastReceiver: HRNotifyModuleReceiver? = null
+    private var isDestroyed = false
 
     override fun call(method: String, params: String?, callback: KuiklyRenderCallback?): Any? {
         return when (method) {
@@ -47,6 +48,7 @@ open class KRNotifyModule : KuiklyRenderBaseModule() {
 
     override fun onDestroy() {
         super.onDestroy()
+        isDestroyed = true
         unregisterNotifyModuleReceiver()
     }
 
@@ -112,6 +114,7 @@ open class KRNotifyModule : KuiklyRenderBaseModule() {
     }
 
     protected open fun registerNotifyModuleReceiver(event: String, params: JSONObject) {
+        if (isDestroyed) return
         if (notifyBroadcastReceiver == null) {
             notifyBroadcastReceiver = HRNotifyModuleReceiver {
                 val eventName = it.getStringExtra(KEY_EVENT_NAME) ?: ""


### PR DESCRIPTION
## 问题

KRNotifyModule 在页面退出时 onDestroy() 会调用 unregisterNotifyModuleReceiver()，将 notifyBroadcastReceiver 置为 null。

若 onDestroy 执行完后仍有异步的 addNotify 调用到达，registerNotifyModuleReceiver 检测到 notifyBroadcastReceiver == null，会重新 registerReceiver，导致 BroadcastReceiver 泄漏。

## 修复

在 onDestroy 时设置 isDestroyed = true 标志位，registerNotifyModuleReceiver 入口处检查该标志位，已销毁则直接返回，不再重新注册。

## 改动文件

- core-render-android/.../KRNotifyModule.kt：新增 isDestroyed 标志位，onDestroy 先置位再 unregister，registerNotifyModuleReceiver 入口加守卫