### PR TITLE
fix(compose): coalesce semantics updates per frame to prevent fling white screen

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/RootNodeOwner.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/node/RootNodeOwner.kt
@@ -162,6 +162,7 @@ internal class RootNodeOwner(
     }
 
     private var needClearObservations = false
+    private var semanticsChangePending = false
 
     private fun clearInvalidObservations() {
         if (needClearObservations) {
@@ -207,6 +208,10 @@ internal class RootNodeOwner(
 //            graphicsLayer = null // the root node will provide the root graphics layer
         )
         clearInvalidObservations()
+        if (semanticsChangePending) {
+            semanticsChangePending = false
+            semanticsKuiklyHandler.onSemanticsChange(semanticsOwner)
+        }
     }
 
     fun setRootModifier(modifier: Modifier) {
@@ -400,7 +405,10 @@ internal class RootNodeOwner(
 
         override fun onSemanticsChange() {
 //            platformContext.semanticsOwnerListener?.onSemanticsChange(semanticsOwner)
-            semanticsKuiklyHandler.onSemanticsChange(semanticsOwner)
+            // Coalesce to at most once per frame: this fires per semantics invalidation
+            // (dozens of times during a single fling remeasure), and each handler pass
+            // walks the whole merged semantics tree.
+            semanticsChangePending = true
         }
 
         override fun onZIndexChange(layoutNode: LayoutNode) {


### PR DESCRIPTION
## Summary

- Fix HarmonyOS LazyColumn fast fling white screen caused by synchronous full semantics tree traversal on every invalidation
- `onSemanticsChange()` now only sets `semanticsChangePending = true`; `draw()` flushes at most once per frame
- Preserves #1391 behavior: `testTag` and accessibility attributes still update when system accessibility is off (unlike restoring the old `isSemanticsRunnnng` gate)

## Background

#1391 removed the `isSemanticsRunnnng` gate so `testTag` works without accessibility enabled. After that, each semantics invalidation during fling triggered `KuiklySemantisHandler.onSemanticsChange()` (full tree walk). A single fling could fire dozens of traversals, blocking the context thread and causing white frames in the viewport.

This change coalesces semantics work to frame end. All semantics invalidations originate from recomposition/layout, which already schedule render frames; `BaseComposeScene.render()` always calls `draw()`, so updates are not lost.

## Test plan

- [x] HarmonyOS real device (120Hz): `ComposeAllSample` LazyColumn fast fling — white screen reproduced on baseline, fixed with this change
- [ ] Android / iOS regression: accessibility and `testTag` still work
- [ ] Toggle/Switch stateDescription announcements (edge case: same-frame intermediate states)


Made with [Cursor](https://cursor.com)