### PR TITLE
chore(ohos): bump compose runtime deps to 1.7.3-kuikly2

### DIFF
--- a/compose/build.2.0.ohos.gradle.kts
+++ b/compose/build.2.0.ohos.gradle.kts
@@ -57,10 +57,10 @@ kotlin {
         }
         commonMain.dependencies {
             implementation(project(":core"))
-            api("com.tencent.kuikly-open.compose.runtime:runtime:1.7.3-kuikly1")
-            api("com.tencent.kuikly-open.compose.runtime:runtime-saveable:1.7.3-kuikly1")
-            api("com.tencent.kuikly-open.compose.annotation-internal:annotation:1.7.3-kuikly1")
-            api("com.tencent.kuikly-open.compose.collection-internal:collection:1.7.3-kuikly1")
+            api("com.tencent.kuikly-open.compose.runtime:runtime:1.7.3-kuikly2")
+            api("com.tencent.kuikly-open.compose.runtime:runtime-saveable:1.7.3-kuikly2")
+            api("com.tencent.kuikly-open.compose.annotation-internal:annotation:1.7.3-kuikly2")
+            api("com.tencent.kuikly-open.compose.collection-internal:collection:1.7.3-kuikly2")
             api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0-KBA-001")
             api("org.jetbrains.kotlinx:atomicfu:0.23.2-KBA-001")
         }


### PR DESCRIPTION
## Summary
- 将 OHOS 构建使用的 4 个 `kuikly-open` Compose 依赖从 `1.7.3-kuikly1` 升级到 `1.7.3-kuikly2`
- 仅修改 `compose/build.2.0.ohos.gradle.kts` 中的版本号

## Test plan
- [x] `./gradlew -c settings.2.0.ohos.gradle.kts :demo:linkDebugSharedOhosArm64` 编译通过
- [x] 确认从 `maven-tencent` 拉取到 `1.7.3-kuikly2` 的 metadata 与 `*-ohosarm64` klib


Made with [Cursor](https://cursor.com)