### PR TITLE
fix(ohos): use default pager spring for damping one

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerView.cpp
@@ -148,7 +148,8 @@ void KRScrollerView::SetRenderViewFrame(const KRRect &frame) {
     if (!is_set_frame_) {
         is_set_frame_ = true;
         if (is_need_set_content_offset_) {
-            kuikly::util::SetArkUIContentOffset(GetNode(), first_offset_x_, first_offset_y_, first_animate_, first_duration_, first_curve_);
+            kuikly::util::SetArkUIContentOffset(GetNode(), first_offset_x_, first_offset_y_, first_animate_,
+                                                first_duration_, first_curve_, first_damping_);
             is_need_set_content_offset_ = false;
         }
     }
@@ -432,6 +433,7 @@ void KRScrollerView::SetContentOffset(const KRAnyValue &value) {
     auto offset_y = content_offset_splits[1]->toFloat();
     auto animate = content_offset_splits[2]->toBool();
     auto duration = content_offset_splits.size() > 3 ? content_offset_splits[3]->toInt() : 0;
+    auto damping = content_offset_splits.size() > 4 ? content_offset_splits[4]->toFloat() : 0;
     auto curve = content_offset_splits.size() > 6 ? content_offset_splits[6]->toInt() : 0;
 
     if (!is_set_frame_) {
@@ -440,10 +442,11 @@ void KRScrollerView::SetContentOffset(const KRAnyValue &value) {
         first_animate_ = animate;
         first_duration_ = duration;
         first_curve_ = curve;
+        first_damping_ = damping;
         is_need_set_content_offset_ = true;
         return;
     }
-    kuikly::util::SetArkUIContentOffset(GetNode(), offset_x, offset_y, animate, duration, curve);
+    kuikly::util::SetArkUIContentOffset(GetNode(), offset_x, offset_y, animate, duration, curve, damping);
 }
 
 void KRScrollerView::SetContentInset(const KRAnyValue &value) {
@@ -472,7 +475,7 @@ void KRScrollerView::SetContentInset(const std::shared_ptr<KRScrollerContentInse
         auto current_offset = GetContentOffset();
         auto target_offset = MaxContentOffsetInContentInset(content_inset);
         if (target_offset.x != current_offset.x || target_offset.y != current_offset.y) {
-            kuikly::util::SetArkUIContentOffset(GetNode(), target_offset.x, target_offset.y, true, 0, 0);
+            kuikly::util::SetArkUIContentOffset(GetNode(), target_offset.x, target_offset.y, true, 0, 0, 0);
         }
         // 再用原有动画逻辑设置 margin
         auto root_view = GetRootView().lock();

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerView.h
@@ -157,6 +157,7 @@ class KRScrollerView : public IKRRenderViewExport {
     bool first_animate_ = false;
     int first_duration_ = 0;
     int first_curve_ = 0;
+    float first_damping_ = 0;
     ArkUI_ScrollState current_scroll_state_;
 
     std::shared_ptr<KRAnimation> content_inset_animate_;

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.cpp
@@ -859,7 +859,8 @@ KRPoint GetArkUIScrollContentOffset(ArkUI_NodeHandle handle) {
     return item ? KRPoint{item->value[0].f32, item->value[1].f32} : KRPoint();
 }
 
-void SetArkUIContentOffset(ArkUI_NodeHandle handle, float offset_x, float offset_y, bool animate, int duration, int curve) {
+void SetArkUIContentOffset(ArkUI_NodeHandle handle, float offset_x, float offset_y, bool animate, int duration, int curve,
+                           float damping) {
     if (!handle) {
         return;
     }
@@ -867,16 +868,23 @@ void SetArkUIContentOffset(ArkUI_NodeHandle handle, float offset_x, float offset
     if (duration < 0) {
         duration = 0;
     }
+    int durationForArkUI = duration;
     int enableDefaultSpringAnimation = animate ? 1 : 0;
     if (duration > 0 && animate) {
-        // Default spring animation should be disabled when custom animation duration is specified,
-        // otherwise custom animation duration will not take effect.
-        enableDefaultSpringAnimation = 0;
+        if (curve == 0 && damping == 1.0f) {
+            // Align with Android: use the platform default scroll animation when no extra spring effect is needed.
+            durationForArkUI = 0;
+            enableDefaultSpringAnimation = 1;
+        } else {
+            // Default spring animation should be disabled when custom animation duration is specified,
+            // otherwise custom animation duration will not take effect.
+            enableDefaultSpringAnimation = 0;
+        }
     }
     ArkUI_NumberValue value[] = {
         {.f32 = offset_x},
         {.f32 = offset_y},
-        {.i32 = duration},
+        {.i32 = durationForArkUI},
         {.i32 = curve == 0 ? ARKUI_CURVE_EASE : ARKUI_CURVE_LINEAR},
         {.i32 = enableDefaultSpringAnimation},  // whether to enable the default spring animation
         {.i32 = 1},                             // whether scrolling can cross the boundary

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.h
@@ -186,7 +186,8 @@ void SetArkUIScrollEnabled(ArkUI_NodeHandle handle, bool enable);
 
 KRPoint GetArkUIScrollContentOffset(ArkUI_NodeHandle handle);
 
-void SetArkUIContentOffset(ArkUI_NodeHandle handle, float offset_x, float offset_y, bool animate, int duration, int curve);
+void SetArkUIContentOffset(ArkUI_NodeHandle handle, float offset_x, float offset_y, bool animate, int duration, int curve,
+                           float damping);
 
 ArkUI_ScrollState GetArkUIScrollerState(ArkUI_NodeEvent *event, int scroll_state_index);
 


### PR DESCRIPTION
## Summary
- Align OHOS scroll offset animation with Android when spring damping is `1f` by using ArkUI's default scroll animation path.
- Preserve custom duration animation behavior for non-default spring and linear animation cases.
- Carry the parsed damping value through pending and immediate `SetContentOffset` paths.

## Test plan
- [x] `./gradlew :compose:compileDebugKotlinAndroid`
- [x] `./2.0_ohos_demo_build.sh`
- [x] `cd ohosApp && ohpm install && hvigorw assembleHap --mode module -p module=entry@default -p product=default -p buildMode=debug --no-daemon`
- [x] Installed and launched on HarmonyOS device for manual pager fling verification


Made with [Cursor](https://cursor.com)