### PR TITLE
fix(compose): round viewportSize dp→px conversion to fix bottom overscroll bounce

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
@@ -26,6 +26,7 @@ import com.tencent.kuikly.core.pager.PageData
 import com.tencent.kuikly.core.views.ScrollerAttr
 import com.tencent.kuikly.core.views.ScrollerEvent
 import com.tencent.kuikly.core.views.ScrollerView
+import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 
@@ -233,7 +234,11 @@ class KuiklyScrollInfo {
             } else {
                 scrollView?.renderView?.currentFrame?.width ?: 0f
             }
-            return (size * getDensity()).toInt()
+            // Use roundToInt instead of toInt to avoid truncating the dp→px conversion.
+            // A non-integer density (e.g. 2.625) makes the truncated viewportSize lose ~1px,
+            // which keeps toButtomDelta at 1 instead of 0 and breaks the bottom overscroll
+            // bounce handling (lastScrolledBackward wrongly set to true).
+            return (size * getDensity()).roundToInt()
         }
 
     /**


### PR DESCRIPTION
## Summary
- Root-cause fix for bottom overscroll bounce wrongly setting \`lastScrolledBackward = true\`.
- \`KuiklyScrollInfo.viewportSize\` used \`.toInt()\` (truncation) for the dp→px conversion. On devices with a non-integer density (e.g. 2.625 = 420/160, OnePlus PHB110), the truncated viewport lost ~1px (1594.9999 → 1594), so \`toButtomDelta\` stayed at 1 instead of 0.
- That routed the bottom overscroll through BOTTOM_NORMAL (inflating \`composeOffset\`) instead of BOTTOM_EXPAND, and during bounce-back a negative delta reached \`kuiklyOnScroll\`, wrongly setting \`lastScrolledBackward = true\`.
- Switch to \`roundToInt()\` so the conversion matches Compose's floating-point layout positioning. On integer densities (e.g. 3.0, HUAWEI) the result is unchanged.

## Test plan
- [ ] OnePlus (Android 16, density 2.625): scroll to bottom, overscroll bounce, release → \`toButtomDelta = 0\`, \`BOTTOM_EXPAND\` triggers, \`lastScrolledBackward = false\`.
- [ ] HUAWEI (Android 12, density 3.0): behavior unchanged, \`lastScrolledBackward = false\`.