### PR TITLE
fix(ohos): default damping arg for SetArkUIContentOffset

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.h
@@ -187,7 +187,7 @@ void SetArkUIScrollEnabled(ArkUI_NodeHandle handle, bool enable);
 KRPoint GetArkUIScrollContentOffset(ArkUI_NodeHandle handle);
 
 void SetArkUIContentOffset(ArkUI_NodeHandle handle, float offset_x, float offset_y, bool animate, int duration, int curve,
-                           float damping);
+                           float damping = 0);
 
 ArkUI_ScrollState GetArkUIScrollerState(ArkUI_NodeEvent *event, int scroll_state_index);
 


### PR DESCRIPTION
## Summary
- Add a default `damping = 0` argument to `SetArkUIContentOffset` so legacy 6-argument call sites remain compatible after #1528.
- Keeps the pager snap fix behavior unchanged when callers explicitly pass `damping = 1`.

## Test plan
- [x] `./2.0_ohos_demo_build.sh`
- [ ] Verify internal HAR build (`hvigorw assembleHar`) passes on branches with additional `KRScrollerView` call sites


Made with [Cursor](https://cursor.com)