### PR TITLE
fix(ios): avoid pager snap end hard-jump from spring flush miss

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
@@ -453,6 +453,8 @@ abstract class PagerState internal constructor(
 
     private var snapStallAlignmentRetryRequested = false
 
+    private var snapLastObservedContentOffset = 0
+
     /** Called before native setContentOffset(animated=true). */
     internal fun markSnapAnimationStarted(
         targetContentOffset: Int,
@@ -469,6 +471,7 @@ abstract class PagerState internal constructor(
         kuiklyInfo.snapAnchorOffsetCorrection = 0
         snapTargetReachedAlignmentRequested = false
         snapStallAlignmentRetryRequested = false
+        snapLastObservedContentOffset = kuiklyInfo.contentOffset
         scrollPosition.clearSnapAnchorPageDuringDrag()
         pagerSnapDebugLog {
             "snapStarted: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
@@ -488,7 +491,15 @@ abstract class PagerState internal constructor(
             return
         }
 
+        val offsetChanged = contentOffset != snapLastObservedContentOffset
+        if (offsetChanged) {
+            snapLastObservedContentOffset = contentOffset
+            snapStallAlignmentRetryRequested = false
+        }
         if (!hasSnapReachedTarget(contentOffset)) {
+            if (offsetChanged) {
+                scheduleScrollViewOffsetAlignment(SNAP_MEASURE_JOB_INITIAL_DELAY_MS)
+            }
             return
         }
 
@@ -520,6 +531,7 @@ abstract class PagerState internal constructor(
         snapStartDesyncPages = 0
         snapTargetReachedAlignmentRequested = false
         snapStallAlignmentRetryRequested = false
+        snapLastObservedContentOffset = 0
         kuiklyInfo.snapAnchorOffsetCorrection = 0
         kuiklyInfo.appleScrollViewOffsetJob?.cancel(ScrollViewOffsetAlignmentCancellation)
     }
@@ -959,6 +971,7 @@ abstract class PagerState internal constructor(
         snapStartDesyncPages = 0
         snapTargetReachedAlignmentRequested = false
         snapStallAlignmentRetryRequested = false
+        snapLastObservedContentOffset = 0
         kuiklyInfo.snapAnchorOffsetCorrection = 0
     }
 

--- a/core-render-ios/Extension/Components/KRScrollView.m
+++ b/core-render-ios/Extension/Components/KRScrollView.m
@@ -849,6 +849,11 @@ KUIKLY_NESTEDSCROLL_PROTOCOL_PROPERTY_IMP
                                             [self setContentOffset:contentOffset];
                                         }
                              completion:^(BOOL finished) {
+                                            // OffsetAnimator samples presentationLayer via DisplayLink and is cancelled here
+                                            // without a final callback. Flush model contentOffset so Compose/Kotlin reaches target.
+                                            if (finished) {
+                                                [self dispatchScrollEventWithCurOffset:self.contentOffset];
+                                            }
                                             [animator cancel];
                                         }];
         }
@@ -867,6 +872,11 @@ KUIKLY_NESTEDSCROLL_PROTOCOL_PROPERTY_IMP
                     }
                     [self setContentOffset:contentOffset];
             } completion:^(BOOL finished) {
+                // OffsetAnimator samples presentationLayer via DisplayLink and is cancelled here
+                // without a final callback. Flush model contentOffset so Compose/Kotlin reaches target.
+                if (finished) {
+                    [self dispatchScrollEventWithCurOffset:self.contentOffset];
+                }
                 [animator cancel];
             }];
         }


### PR DESCRIPTION
## Summary
- On iOS, Pager snap uses a custom UIView spring/linear animation plus `KRScrollViewOffsetAnimator` (DisplayLink + `presentationLayer`). When the animation completes, the animator is cancelled without flushing the final model `contentOffset` to Kotlin, leaving Kotlin ~1pt short of the exact target.
- With `SNAP_TARGET_OFFSET_TOLERANCE = 1`, that residual triggers stall recovery → `fixInterruptedSnap` hard jump (visible 3–4px flicker at page settle).
- Fix: flush model `contentOffset` via `dispatchScrollEventWithCurOffset` in both linear and spring completion handlers when `finished`.
- Also clear `snapStallAlignmentRetryRequested` when native offset keeps changing mid-snap, so a mid-animation false stall does not escalate into a hard jump at the end.

## Test plan
- [ ] HorizontalPager / VerticalPager: swipe pages repeatedly; confirm no end-of-snap flicker/hard jump
- [ ] Fast consecutive swipes that interrupt an in-flight spring still settle to the correct page
- [ ] Non-Pager scroll views with spring/linear `css_contentOffset` still animate normally


Made with [Cursor](https://cursor.com)