### PR TITLE
fix(demo): 横竖屏黑底仅作用于 orientation demos

### DIFF
--- a/androidApp/src/main/java/com/tencent/kuikly/android/demo/KuiklyRenderActivity.kt
+++ b/androidApp/src/main/java/com/tencent/kuikly/android/demo/KuiklyRenderActivity.kt
@@ -84,6 +84,11 @@ class KuiklyRenderActivity : AppCompatActivity() {
         hrContainerView = findViewById(R.id.hr_container)
         loadingView = findViewById(R.id.hr_loading)
         errorView = findViewById(R.id.hr_error)
+        // 横竖屏 Demo 转屏间隙需要宿主容器黑底兜底；其他页面保持默认，避免全局变黑。
+        if (pageName == "ComposeVideoOrientationDemo" || pageName == "ComposeOrientationOverlayDemo") {
+            findViewById<View>(android.R.id.content).setBackgroundColor(Color.BLACK)
+            hrContainerView.setBackgroundColor(Color.BLACK)
+        }
         // 4. 触发Kuikly View实例化
         // hrContainerView：承载Kuikly的容器View
         // contextCode: jvm模式下传递""

--- a/androidApp/src/main/res/layout/activity_hr.xml
+++ b/androidApp/src/main/res/layout/activity_hr.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="#000000">
+    android:layout_height="match_parent">
 
     <FrameLayout
         android:id="@+id/backgroundBtn"
@@ -37,8 +36,7 @@
     <FrameLayout
         android:id="@+id/hr_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="#000000"/>
+        android:layout_height="match_parent"/>
 
     <View
         android:id="@+id/hr_loading"

--- a/ohosApp/entry/src/main/ets/pages/Index.ets
+++ b/ohosApp/entry/src/main/ets/pages/Index.ets
@@ -73,6 +73,14 @@ struct Index {
     this.kuiklyViewDelegate.pageDidDisappear();
   }
 
+  /**
+   * 横竖屏 Demo 转屏间隙需要宿主 Stack 黑底兜底；其他页面保持默认，避免全局变黑。
+   */
+  private shouldUseBlackBackground(): boolean {
+    const name = this.pageName ?? 'router';
+    return name === 'ComposeVideoOrientationDemo' || name === 'ComposeOrientationOverlayDemo';
+  }
+
   build() {
     Stack({ alignContent: Alignment.TopStart }) {
       if (this.showKuikly) {
@@ -100,7 +108,7 @@ struct Index {
     }
     .width('100%')
     .height('100%')
-    .backgroundColor(Color.Black)
+    .backgroundColor(this.shouldUseBlackBackground() ? Color.Black : Color.Transparent)
     .expandSafeArea([SafeAreaType.KEYBOARD]);
   }
 


### PR DESCRIPTION
## Summary
- OHOS `Index` Stack 黑底改为仅 `ComposeVideoOrientationDemo` / `ComposeOrientationOverlayDemo` 生效，其他页面恢复透明默认底
- Android 去掉 `activity_hr.xml` 全局黑底，改为 Activity 按 pageName 仅对上述两个 Demo 设置宿主容器黑底
- 转屏间隙仍走宿主 Stack/容器黑底兜底，避免影响其他 Demo 页面

## Test plan
- [ ] OHOS：打开普通 Demo（如 router / ComposeAllSample），确认背景不再是全局黑
- [ ] OHOS：打开两个横竖屏 Demo，确认转屏间隙仍是黑底
- [ ] Android：同上两组场景验证


Made with [Cursor](https://cursor.com)