### PR TITLE
fix(android): pager will drag end not sync on android

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
@@ -230,6 +230,7 @@ fun SubcomposeLayout(
     val materialized = currentComposer.materialize(modifier)
     scrollableState.kuiklyInfo.orientation = orientation
     scrollableState.kuiklyInfo.pageData = LocalConfiguration.current.pageData
+    val isAndroid = LocalConfiguration.current.isAndroid
     val isPagerView = scrollableState is PagerState || scrollableState is DrawerInternalPagerState
     val isDrawerPager = scrollableState is DrawerInternalPagerState
     val coroutineScope = rememberCoroutineScope()
@@ -263,7 +264,7 @@ fun SubcomposeLayout(
             }
 
             if (scrollableState is PagerState || scrollableState is DrawerInternalPagerState) {
-                willDragEndBySync(isSync = scrollableState is PagerState, handler = {
+                willDragEndBySync(isSync = scrollableState is PagerState && !isAndroid, handler = {
                     val viewportSize = kuiklyInfo.viewportSize
                     val scaleParams = it.scaleWithDensity(kuiklyInfo.getDensity())
                     // 实现分页滑动


### PR DESCRIPTION
## Summary
- On Android, PagerState now uses a non-sync willDragEnd callback (isSync = false) for pager snapping, matching the original fix intent.
- Sync behavior is preserved on iOS; DrawerInternalPagerState is unchanged.

## Change
compose/.../ui/layout/SubcomposeLayout.kt:
- Add `val isAndroid = LocalConfiguration.current.isAndroid`
- `willDragEndBySync(isSync = scrollableState is PagerState && !isAndroid, ...)`