### PR TITLE
fix(ohos): reduce LazyColumn scroll white-screen and remeasure storms

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
@@ -83,6 +83,9 @@ class KuiklyScrollInfo {
      */
     var realContentSize: Int? = null
 
+    /** 上次 calc 时读到的 native contentView 主轴尺寸（px），用于滚动中节流 */
+    internal var lastSyncedNativeContentMainAxisPx: Int = -1
+
     /**
      * Whether the offset has deviation
      */
@@ -157,6 +160,11 @@ class KuiklyScrollInfo {
     var skipExpandStartSize: Boolean = false
 
     /**
+     * 滚动中触及底部边界（toButtomDelta<=0）时置位，scrollEnd 时统一扩容 contentSize。
+     */
+    var pendingBottomExpand: Boolean = false
+
+    /**
      * Sticky Header Position Cache Manager
      */
     val stickyHeaderCacheManager = StickyHeaderCacheManager()
@@ -171,7 +179,26 @@ class KuiklyScrollInfo {
     /**
      * Update content size to render view
      */
+    private var lastAppliedContentSize: Int = -1
+    /** 与 contentSize 一并参与去重，避免 Android 上 ScrollView 宽度晚于首次 setFrame 时 contentView 宽度卡在 0 */
+    private var lastAppliedViewportCrossSize: Float = -1f
+
     fun updateContentSizeToRender() {
+        val viewportCrossSize = if (isVertical()) {
+            scrollView?.renderView?.currentFrame?.width ?: 0f
+        } else {
+            scrollView?.renderView?.currentFrame?.height ?: 0f
+        }
+        if (viewportCrossSize <= 0f) {
+            return
+        }
+        if (currentContentSize == lastAppliedContentSize &&
+            viewportCrossSize == lastAppliedViewportCrossSize
+        ) {
+            return
+        }
+        lastAppliedContentSize = currentContentSize
+        lastAppliedViewportCrossSize = viewportCrossSize
         val frame = createContentFrame()
         scrollView?.contentView?.setFrameToRenderView(frame)
     }
@@ -201,6 +228,19 @@ class KuiklyScrollInfo {
         stickyItemKey = null
         cachedTotalItems = 0
         pullToRefreshTopInsetPx = 0
+        lastAppliedContentSize = -1
+        lastAppliedViewportCrossSize = -1f
+        lastSyncedNativeContentMainAxisPx = -1
+        pendingBottomExpand = false
+    }
+
+    internal fun nativeContentMainAxisDp(): Float {
+        val scrollView = scrollView ?: return -1f
+        return if (orientation == Orientation.Vertical) {
+            scrollView.contentView?.renderView?.currentFrame?.height ?: -1f
+        } else {
+            scrollView.contentView?.renderView?.currentFrame?.width ?: -1f
+        }
     }
 
     /**

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/layout/SubcomposeLayoutEx.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/layout/SubcomposeLayoutEx.kt
@@ -83,12 +83,12 @@ internal fun KNode<*>.hideOffsetScreenView() {
 internal fun KNode<*>.resetViewVisible() {
     when {
         isVirtual -> forEachChild { (it as? KNode<*>)?.resetViewVisible() }
+        viewVisible == null -> {
+            // visibility unchanged — skip restore
+        }
         else -> {
-            // 恢复到原始的Visible属性
-            viewVisible?.let {
-                view.getViewAttr().visibility(it)
-                viewVisible = null
-            }
+            view.getViewAttr().visibility(viewVisible!!)
+            viewVisible = null
         }
     }
 }

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ContentSizeExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ContentSizeExtensions.kt
@@ -94,6 +94,48 @@ internal fun ScrollableState.calculateAndUpdateContentSize() {
     kuiklyInfo.updateContentSizeToRender()
 }
 
+/**
+ * 滚动过程中仅在接近底部或尚未得到真实 contentSize 时更新 native contentSize。
+ * [force] 用于 scrollEnd 等必须同步的时机。
+ */
+internal fun ScrollableState.calculateAndUpdateContentSizeIfNeeded(force: Boolean = false) {
+    if (force) {
+        calculateAndUpdateContentSize()
+        return
+    }
+    if (kuiklyInfo.nearScrollBottom()) {
+        calculateAndUpdateContentSize()
+        return
+    }
+    if (kuiklyInfo.realContentSize == null) {
+        // LazyList 每次 remeasure 都会把 realContentSize 置回 null，
+        // 此时必须重算，否则 currentContentSize(滚动边界) 会卡在偏大的旧值，导致滑到底还能继续滑。
+        calculateAndUpdateContentSize()
+        return
+    }
+    val nativeDp = kuiklyInfo.nativeContentMainAxisDp()
+    if (nativeDp < 0f) {
+        calculateAndUpdateContentSize()
+        return
+    }
+    val nativePx = (nativeDp * kuiklyInfo.getDensity()).toInt()
+    if (nativePx != kuiklyInfo.lastSyncedNativeContentMainAxisPx) {
+        kuiklyInfo.lastSyncedNativeContentMainAxisPx = nativePx
+        calculateAndUpdateContentSize()
+    }
+}
+
+/**
+ * 一次手势结束后的 native 滚动同步：contentSize + offset 校正 + 底部扩容。
+ */
+internal fun ScrollableState.finalizeNativeScrollSync(offset: Int) {
+    calculateAndUpdateContentSize()
+    if (kuiklyInfo.pendingBottomExpand) {
+        kuiklyInfo.pendingBottomExpand = false
+    }
+    tryExpandStartSize(offset, isScrolling = false)
+}
+
 internal fun PaddingValues.totalPadding(orientation: Orientation): Dp {
     return if (orientation == Orientation.Vertical) {
         calculateTopPadding() + calculateBottomPadding()
@@ -267,9 +309,16 @@ internal fun ScrollableState.tryExpandStartSize(offset: Int, isScrolling: Boolea
     if (kuiklyInfo.skipExpandStartSize) return
     if (this is PagerState) return
 
+    val atTopSync = isComposeAtTopForScrollSync()
+    val needsTopExpand = offset <= 0 && !atTopSync && kuiklyInfo.offsetDirty
+    val needsScrollViewPullBack = offset > 0 && atTopSync
+    if (!needsTopExpand && !needsScrollViewPullBack) {
+        return
+    }
+
     val density = kuiklyInfo.getDensity()
     // scrollview 到顶了，但是compose没到顶
-    if (offset <= 0 && !isComposeAtTopForScrollSync() && kuiklyInfo.offsetDirty) {
+    if (needsTopExpand) {
         var delta = calculateBackExpandSize(offset)
         val minDelta = (ScrollableStateConstants.DEFAULT_CONTENT_SIZE * density).toInt()
         delta = max(delta ?: minDelta, minDelta)
@@ -289,7 +338,7 @@ internal fun ScrollableState.tryExpandStartSize(offset: Int, isScrolling: Boolea
         }
         kuiklyInfo.offsetDirty = true
         applyScrollViewOffsetDelta(delta)
-    } else if (offset > 0 && isComposeAtTopForScrollSync()) {
+    } else if (needsScrollViewPullBack) {
         // compose 到顶了，但是scrollview没到顶
         applyScrollViewOffsetDelta(-offset)
         kuiklyInfo.offsetDirty = false
@@ -301,7 +350,8 @@ internal fun ScrollableState.tryExpandStartSizeNoScroll(forceExpand: Boolean = f
     kuiklyInfo.run {
         appleScrollViewOffsetJob?.cancel(ScrollViewOffsetAlignmentCancellation)
         appleScrollViewOffsetJob = scope?.launch {
-            delay(150)
+            val settleDelay = if (pageData?.isOhOs == true) 80 else 150
+            delay(settleDelay.toLong())
             val minDelta = (DEFAULT_CONTENT_SIZE * getDensity()).toInt()
             val epsilon = 0.5 * getDensity()  // 使用 0.5dp 作为误差值
             val reachBtm = contentOffset + viewportSize - currentContentSize >= -epsilon
@@ -317,7 +367,7 @@ internal fun ScrollableState.tryExpandStartSizeNoScroll(forceExpand: Boolean = f
                     updateContentSizeToRender()
                 }
                 if (pageData?.isOhOs == true) {
-                    delay(25)   // 鸿蒙扩容后，不会立刻刷新，也没有刷新api，华为建议添加一个delay来处理
+                    delay(16)
                 }
                 applyScrollViewOffsetDelta(delta)
                 offsetDirty = true

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
@@ -65,6 +65,7 @@ import com.tencent.kuikly.compose.ui.platform.createSubcomposition
 import com.tencent.kuikly.compose.ui.unit.Constraints
 import com.tencent.kuikly.compose.ui.unit.LayoutDirection
 import com.tencent.kuikly.compose.ui.util.fastForEach
+import com.tencent.kuikly.compose.ui.util.fastRoundToInt
 import com.tencent.kuikly.compose.gestures.KuiklyScrollInfo
 import com.tencent.kuikly.compose.views.KuiklyInfoKey
 import com.tencent.kuikly.compose.views.VirtualNodeView
@@ -74,7 +75,6 @@ import com.tencent.kuikly.compose.layout.hideOffsetScreenView
 import com.tencent.kuikly.compose.layout.restoreScrollerViewOnReuse
 import com.tencent.kuikly.compose.layout.transferScrollToTopCallback
 import com.tencent.kuikly.compose.scroller.handleScrollToTopCallback
-import com.tencent.kuikly.compose.scroller.isAtTop
 import com.tencent.kuikly.compose.scroller.lastItemVisible
 import com.tencent.kuikly.compose.scroller.kuiklyInfo
 import com.tencent.kuikly.compose.scroller.kuiklyOnScroll
@@ -93,6 +93,9 @@ import com.tencent.kuikly.compose.scroller.animateScrollToTop
 import com.tencent.kuikly.compose.scroller.applyScrollViewOffsetDelta
 import com.tencent.kuikly.compose.scroller.shouldRejectNativeScrollOffset
 import com.tencent.kuikly.compose.scroller.calculateAndUpdateContentSize
+import com.tencent.kuikly.compose.scroller.calculateAndUpdateContentSizeIfNeeded
+import com.tencent.kuikly.compose.scroller.finalizeNativeScrollSync
+import com.tencent.kuikly.compose.scroller.isAtTop
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.max
@@ -295,23 +298,31 @@ fun SubcomposeLayout(
             scrollEnd {
                 val scaleParams = it.scaleWithDensity(kuiklyInfo.getDensity())
                 val offset = if (isVertical) scaleParams.offsetY.toInt() else scaleParams.offsetX.toInt()
-                kuiklyInfo.contentOffset = offset
+                if (kuiklyInfo.contentOffset != offset) {
+                    kuiklyInfo.contentOffset = offset
+                }
                 (scrollableState as? PagerState)?.onNativeContentOffsetChanged(offset)
                 (scrollableState as? DrawerInternalPagerState)?.onNativeContentOffsetChanged(offset)
 
                 // 仅触摸滑动结束会回调，api调用和bounce回弹都不会触发
-                // / back是回滑,forward是前滑
+                scrollableState.finalizeNativeScrollSync(offset)
                 scrollableState.kuiklyOnScrollEnd(scaleParams)
             }
             dragEnd {
                 val scaleParams = it.scaleWithDensity(kuiklyInfo.getDensity())
                 val offset = if (isVertical) scaleParams.offsetY.toInt() else scaleParams.offsetX.toInt()
-                kuiklyInfo.contentOffset = offset
-                kuiklyInfo.isDragging = kuiklyInfo.scrollView?.isDragging ?: false
+                if (kuiklyInfo.contentOffset != offset) {
+                    kuiklyInfo.contentOffset = offset
+                }
+                val dragging = kuiklyInfo.scrollView?.isDragging ?: false
+                if (kuiklyInfo.isDragging != dragging) {
+                    kuiklyInfo.isDragging = dragging
+                }
             }
             scroll {
                 val scaleParams = it.scaleWithDensity(kuiklyInfo.getDensity())
-                val offset = if (isVertical) scaleParams.offsetY.toInt() else scaleParams.offsetX.toInt()
+                val nativeOffset = if (isVertical) scaleParams.offsetY else scaleParams.offsetX
+                val offset = nativeOffset.fastRoundToInt()
 
                 // Reject unexpected native offset jumps (e.g. HarmonyOS HandleCrashTop).
                 // Correct the native side back and skip this event entirely to prevent
@@ -328,11 +339,15 @@ fun SubcomposeLayout(
                     return@scroll
                 }
 
-                val prevOffset = kuiklyInfo.contentOffset
-                kuiklyInfo.contentOffset = offset
+                if (kuiklyInfo.contentOffset != offset) {
+                    kuiklyInfo.contentOffset = offset
+                }
                 (scrollableState as? PagerState)?.onNativeContentOffsetChanged(offset)
                 (scrollableState as? DrawerInternalPagerState)?.onNativeContentOffsetChanged(offset)
-                kuiklyInfo.isDragging = kuiklyInfo.scrollView?.isDragging ?: false
+                val dragging = kuiklyInfo.scrollView?.isDragging ?: false
+                if (kuiklyInfo.isDragging != dragging) {
+                    kuiklyInfo.isDragging = dragging
+                }
 
                 if (kuiklyInfo.ignoreScrollOffset != null) {
                     val ignoreOffset = kuiklyInfo.ignoreScrollOffset!!
@@ -345,14 +360,15 @@ fun SubcomposeLayout(
                     return@scroll
                 }
 
-                // 忽略较小的滑动
-                val delta = offset - kuiklyInfo.composeOffset
-                if (delta.toInt() == 0) {
+                // 与 LazyListState 一致：不足 0.5px 的位移先累积，避免鸿蒙高频 sub-pixel onScroll 触发 remeasure
+                val delta = nativeOffset - kuiklyInfo.composeOffset
+                if (abs(delta) < 0.5f) {
                     return@scroll
                 }
-
-                // 更新当前的contentSize大小
-                scrollableState.calculateAndUpdateContentSize()
+                val scrollDelta = delta.fastRoundToInt()
+                if (scrollDelta == 0) {
+                    return@scroll
+                }
 
                 val toButtomDelta = if (kuiklyInfo.realContentSize == null) {
                     null
@@ -362,20 +378,19 @@ fun SubcomposeLayout(
                 // 判断是否滑出边界
                 if (offset < 0 && scrollableState.isAtTop()) {
                     return@scroll
-                } else if (toButtomDelta != null && delta > toButtomDelta) {
+                } else if (toButtomDelta != null && scrollDelta > toButtomDelta) {
                     if (toButtomDelta.toInt() <= 0) {
-                        scrollableState.tryExpandStartSize(offset, true)
+                        kuiklyInfo.pendingBottomExpand = true
                         return@scroll
                     }
-                    kuiklyInfo.composeOffset += min(delta, toButtomDelta)
+                    kuiklyInfo.composeOffset += min(scrollDelta.toFloat(), toButtomDelta)
                 } else {
-                    kuiklyInfo.composeOffset = max(0f, kuiklyInfo.composeOffset + delta)
+                    kuiklyInfo.composeOffset = max(0f, kuiklyInfo.composeOffset + scrollDelta)
                 }
 
-                // 触发compose滑动，并重新布局
-                val comsumedDelta = scrollableState.kuiklyOnScroll(delta)
-
-                // 尝试扩容
+                // 仅在实际驱动 LazyList 滚动后同步 contentSize / offset 校正
+                scrollableState.kuiklyOnScroll(scrollDelta.toFloat())
+                scrollableState.calculateAndUpdateContentSizeIfNeeded()
                 scrollableState.tryExpandStartSize(offset, true)
             }
 


### PR DESCRIPTION
## Summary
- Throttle Compose↔Native scroll sync on HarmonyOS (contentSize/expand deferral, contentSize dedup, scrollEnd finalize) to reduce LazyColumn white-screen during fast fling.
- Quantize ArkUI `onScroll` in fling and flush the final offset on scroll stop; skip redundant `contentOffset`/`isDragging` writes and unchanged visibility restores.
- Keep only behavioral fixes—no `KuiklyScrollTrace`, stress-test demo, or debug launch harness.

## Test plan
- [ ] OHOS: open a LazyColumn-heavy page, fast fling up/down — no prolonged bottom white-screen
- [ ] OHOS: nested scroll at bottom boundary — outer scroller can take over without Compose remeasure storm
- [ ] Android/iOS smoke: LazyColumn scroll still works (shared Compose gates)
- [ ] Confirm PR contains no `KuiklyScrollTrace` / `ScrollPerfGates` / stress demo changes


Made with [Cursor](https://cursor.com)