### PR TITLE
fix(android): add animationDuration parameter to smoothScrollBy for pager scroll accuracy

### DIFF
--- a/core-render-android/build.1.3.10.gradle
+++ b/core-render-android/build.1.3.10.gradle
@@ -91,7 +91,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.10")
     compileOnly(project(":core"))
 
-    implementation("androidx.recyclerview:recyclerview:1.0.0")
+    implementation("androidx.recyclerview:recyclerview:1.2.1")
     implementation("androidx.appcompat:appcompat:1.0.0")
     implementation("androidx.dynamicanimation:dynamicanimation:1.0.0")
 }

--- a/core-render-android/build.1.4.20.gradle
+++ b/core-render-android/build.1.4.20.gradle
@@ -91,7 +91,7 @@ android {
 dependencies {
     compileOnly(project(":core"))
 
-    implementation("androidx.recyclerview:recyclerview:1.1.0")
+    implementation("androidx.recyclerview:recyclerview:1.2.1")
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.dynamicanimation:dynamicanimation:1.0.0")
 }

--- a/core-render-android/build.1.5.31.gradle.kts
+++ b/core-render-android/build.1.5.31.gradle.kts
@@ -69,7 +69,7 @@ android {
 
 dependencies {
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31")
-    implementation("androidx.recyclerview:recyclerview:1.1.0")
+    implementation("androidx.recyclerview:recyclerview:1.2.1")
     compileOnly(project(":core"))
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.dynamicanimation:dynamicanimation:1.0.0")

--- a/core-render-android/build.1.6.21.gradle.kts
+++ b/core-render-android/build.1.6.21.gradle.kts
@@ -68,7 +68,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.recyclerview:recyclerview:1.1.0")
+    implementation("androidx.recyclerview:recyclerview:1.2.1")
     compileOnly(project(":core"))
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.dynamicanimation:dynamicanimation:1.0.0")

--- a/core-render-android/build.1.7.20.gradle.kts
+++ b/core-render-android/build.1.7.20.gradle.kts
@@ -68,7 +68,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.recyclerview:recyclerview:1.1.0")
+    implementation("androidx.recyclerview:recyclerview:1.2.1")
     compileOnly(project(":core"))
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.dynamicanimation:dynamicanimation:1.0.0")

--- a/core-render-android/build.1.8.21.gradle.kts
+++ b/core-render-android/build.1.8.21.gradle.kts
@@ -68,7 +68,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.recyclerview:recyclerview:1.1.0")
+    implementation("androidx.recyclerview:recyclerview:1.2.1")
     compileOnly(project(":core"))
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.dynamicanimation:dynamicanimation:1.0.0")

--- a/core-render-android/build.1.9.22.gradle.kts
+++ b/core-render-android/build.1.9.22.gradle.kts
@@ -68,7 +68,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.recyclerview:recyclerview:1.1.0")
+    implementation("androidx.recyclerview:recyclerview:1.2.1")
     compileOnly(project(":core"))
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.dynamicanimation:dynamicanimation:1.0.0")

--- a/core-render-android/build.2.0.21.gradle.kts
+++ b/core-render-android/build.2.0.21.gradle.kts
@@ -75,7 +75,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.recyclerview:recyclerview:1.1.0")
+    implementation("androidx.recyclerview:recyclerview:1.2.1")
     compileOnly(project(":core"))
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.dynamicanimation:dynamicanimation:1.0.0")

--- a/core-render-android/build.2.0.ohos.gradle.kts
+++ b/core-render-android/build.2.0.ohos.gradle.kts
@@ -68,7 +68,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.recyclerview:recyclerview:1.1.0")
+    implementation("androidx.recyclerview:recyclerview:1.2.1")
     compileOnly(project(":core"))
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.dynamicanimation:dynamicanimation:1.0.0")

--- a/core-render-android/build.2.1.21.gradle.kts
+++ b/core-render-android/build.2.1.21.gradle.kts
@@ -75,7 +75,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.recyclerview:recyclerview:1.1.0")
+    implementation("androidx.recyclerview:recyclerview:1.2.1")
     compileOnly(project(":core"))
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.dynamicanimation:dynamicanimation:1.0.0")

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/list/KRRecyclerView.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/component/list/KRRecyclerView.kt
@@ -1126,7 +1126,7 @@ class KRRecyclerView : RecyclerView, IKuiklyRenderViewExport, NestedScrollingChi
                             if (animationDamping == 1f) {
                                 // 无需弹簧效果时使用默认方案，目前startSpringScroll会存在快速滑动无法准确停靠问题
                                 // 待后续优化后移除这段代码
-                                smoothScrollBy(dx, dy)
+                                smoothScrollBy(dx, dy, null, animationDuration)
                             } else {
                                 startSpringScroll(dx, dy, animationDuration, animationDamping, animationVelocity, isVertical)
                             }


### PR DESCRIPTION
## Summary
- Rebase of #1123 onto latest `main`: pass `animationDuration` into `RecyclerView.smoothScrollBy` when spring damping is `1f` (no spring path).
- Fixes nested horizontal/vertical pager scroll snap accuracy on Android by honoring the configured animation duration instead of the default scroller duration.
- Bump `androidx.recyclerview:recyclerview` to `1.2.1` across all Kotlin version build files so the 4-arg `smoothScrollBy(dx, dy, interpolator, duration)` API is available (Kotlin 1.3.10 previously depended on `1.0.0`, which lacks this overload).

## Context
Original PR: https://github.com/Tencent-TDS/KuiklyUI/pull/1123

## Test plan
- [ ] `./gradlew :core-render-android:compileDebugKotlin` succeeds
- [ ] Android: nested horizontal + vertical pager — fling/settle lands on the expected page
- [ ] Android: `contentOffset` animate with `animationDamping == 1` uses the configured duration
- [ ] Android: spring path (`animationDamping != 1`) still uses `startSpringScroll` unchanged