### PR TITLE
feat(ohos): capInsets 9-patch with OH_Drawing_Lattice

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.cpp
@@ -58,11 +58,10 @@ constexpr char kPropNameColorFilter[] = "colorFilter";
 constexpr char kPropNameCapInsets[] = "capInsets";
 constexpr char kPropNameDotNineImage[] = "dotNineImage";
 constexpr char kPropNameImageParams[] = "imageParams";
-// imageParams map 中的 "__scale__" 键：上层指定的图片自身像素密度倍率
-//（如 @2x = 2），供 capInsets + lattice 路径下的 NODE_IMAGE_SOURCE_SIZE 使用。
-constexpr char kImageParamKeyScale[] = "__scale__";
-// capinset_image_scale_ 默认值：1.0 表示"1 图片像素 = 1 vp"，即未显式指定
-// __scale__ 时的默认语义。非正值/缺失时也 fallback 到该默认。
+// capinset_image_scale_ 的固定取值：1.0 表示"1 图片像素 = 1 vp"，即 capInsets
+// + lattice 路径下 NODE_IMAGE_SOURCE_SIZE 的默认缩放语义。当前实现不再从
+// imageParams 中读取 __scale__，字段恒为该默认值；保留常量与字段以便未来
+// 若需要恢复动态素材倍率支持时能低成本改回。
 constexpr float DEFAULT_CAPINST_IMAGE_SCALE = 1.0f;
 
 constexpr char kEventNameLoadSuccess[] = "loadSuccess";
@@ -214,9 +213,9 @@ bool KRImageView::ResetProp(const std::string &prop_key) {
         load_failure_callback_ = nullptr;
     } else if (kuikly::util::isEqual(prop_key, kPropNameImageParams)) {
         image_params_ = nullptr;
-        capinset_image_scale_ = DEFAULT_CAPINST_IMAGE_SCALE;
-        // __scale__ 变化 → source size 需要按新倍率重新下发，放开幂等门闸。
-        source_size_applied_ = false;
+        // capinset_image_scale_ 当前固定为 DEFAULT_CAPINST_IMAGE_SCALE，不再
+        // 随 imageParams 变化；因此这里不需要重置字段、也无需放开 source_size
+        // 幂等门闸。
         didHanded = true;
     } else {
         didHanded = IKRRenderViewExport::ResetProp(prop_key);
@@ -319,35 +318,18 @@ bool KRImageView::SetImageSrc(const KRAnyValue &value) {
 }
 
 bool KRImageView::SetImageParams(const KRAnyValue &value) {
-    const float prev_image_scale = capinset_image_scale_;
+    // 仅存储 imageParams map 供上层 adapter 使用；不再从中提取 __scale__。
+    // capinset_image_scale_ 保持初始默认值 DEFAULT_CAPINST_IMAGE_SCALE = 1.0，
+    // 即"1 图片像素 = 1 vp"。因此本函数也不需要触碰 source_size_applied_ 门闸。
     if (!value) {
         image_params_ = nullptr;
-        capinset_image_scale_ = DEFAULT_CAPINST_IMAGE_SCALE;
-    } else {
-        // 直接使用 toMap() 解析 JSON 字符串为 Map，并存储
-        auto map = value->toMap();
-        if (map.empty()) {
-            image_params_ = nullptr;
-            capinset_image_scale_ = DEFAULT_CAPINST_IMAGE_SCALE;
-        } else {
-            image_params_ = NewKRRenderValue(map);
-            // 从 imageParams 中提取 __scale__（图片自身像素密度倍率，例如 @2x = 2）。
-            // 存下来供 ApplyCapInsetsWithLattice 计算 NODE_IMAGE_SOURCE_SIZE 使用。
-            // 缺失、非数值或 <= 0 时 fallback 到默认值（1.0，即 1 像素 = 1 vp）。
-            auto it = map.find(kImageParamKeyScale);
-            if (it != map.end() && it->second) {
-                float s = it->second->toFloat();
-                capinset_image_scale_ = s > 0.f ? s : DEFAULT_CAPINST_IMAGE_SCALE;
-            } else {
-                capinset_image_scale_ = DEFAULT_CAPINST_IMAGE_SCALE;
-            }
-        }
+        return true;
     }
-    // __scale__ 变化会改变 source size 目标值，需要放开 source_size_applied_
-    // 幂等门闸，让下一次 ApplyCapInsetsWithLattice 能按新倍率重新下发。
-    // 不变则保持原状——避免误触发多余的重解码。
-    if (capinset_image_scale_ != prev_image_scale) {
-        source_size_applied_ = false;
+    auto map = value->toMap();
+    if (map.empty()) {
+        image_params_ = nullptr;
+    } else {
+        image_params_ = NewKRRenderValue(map);
     }
     return true;
 }
@@ -525,26 +507,26 @@ void KRImageView::ApplyCapInsetsWithLattice() {
     // 时使用被覆盖后的 loaded_image_size_，就会形成尺寸雪崩式无限递归。两把锁：
     //   1) img_px 参数**始终**用 original_image_size_（首帧捕获，之后固定不变）
     //      → 每一轮算出的 source size 是常量，天然幂等。
-    //   2) source_size_applied_ 幂等门闸 → 当前 src+__scale__ 生命周期内只允许
-    //      下发一次 NODE_IMAGE_SOURCE_SIZE；后续再进来只重发 lattice 分割线，
-    //      不再触发重解码，彻底断开回环。src 变、__scale__ 变时该门闸会被放开。
+    //   2) source_size_applied_ 幂等门闸 → 当前 src 生命周期内只允许下发一次
+    //      NODE_IMAGE_SOURCE_SIZE；后续再进来只重发 lattice 分割线，不再触发重
+    //      解码，彻底断开回环。src 变时该门闸会被放开。
     //
     // 两条分支：
-    //   (A) capinset_image_scale_ > 0（imageParams 中显式指定了 __scale__，例如 @2x = 2；
-    //       默认值 DEFAULT_CAPINST_IMAGE_SCALE = 1 也满足该条件）：
+    //   (A) capinset_image_scale_ > 0（当前实现中恒为 DEFAULT_CAPINST_IMAGE_SCALE = 1.0，
+    //       条件恒真）且 view frame / 原图尺寸均有效：
     //       首次进入时下发 NODE_IMAGE_SOURCE_SIZE 让 ArkUI 重解码 pixmap，随后
     //       lattice 分割线建立在**重采样后 pixmap** 的坐标系里。source scale 直接
-    //       由 __scale__ 决定，完全不依赖 view frame：
-    //           source_scale = (1 / __scale__) * dpi = dpi / __scale__
+    //       由 capinset_image_scale_ 决定，完全不依赖 view frame：
+    //           source_scale = 1 / capinset_image_scale_ * dpi = dpi / capinset_image_scale_
     //           source_px    = original_img_px * source_scale
-    //                        = (original_img_px / __scale__) * dpi
-    //                        = 图片对应的 vp 尺寸 * dpi
+    //                        = original_img_px / capinset_image_scale_ * dpi
+    //                        = 图片对应的 vp 尺寸 * dpi（当字段=1时即 原图像素 * dpi）
     //       lattice 的 xDivs/yDivs 用同一个 source_scale 把 cap_insets_* 换算成
     //       "重采样 pixmap 像素"，与 image_width/height 同坐标系。
     //       第二次及以后进入（例如 setCapInsets 变化）只重发 lattice，跳过
     //       SetArkUIImageSourceSize，避免重解码回环。
-    //   (B) 未指定 __scale__ 或必要尺寸缺失：**不下发 NODE_IMAGE_SOURCE_SIZE**，
-    //       直接按原图像素坐标下发 lattice——一图片单位=一像素是默认解读，
+    //   (B) view frame 或原图尺寸缺失：**不下发 NODE_IMAGE_SOURCE_SIZE**，直接按
+    //       原图像素坐标下发 lattice——一图片单位=一像素是默认解读，
     //       cap_insets_* 与 image_width/height 都用原图像素同坐标系。若原图尺寸
     //       也取不到，helper 内部会自动回退到老四值 RESIZABLE 路径。
     const auto &view_frame = GetFrame();
@@ -557,14 +539,11 @@ void KRImageView::ApplyCapInsetsWithLattice() {
     if (capinset_image_scale_ > 0.f && view_w_vp > 0.f && view_h_vp > 0.f &&
         img_size.width > 0.f && img_size.height > 0.f) {
         const double dpi = KRConfig::GetDpi();
-        // NODE_IMAGE_SOURCE_SIZE 使用的 scale：
-        //   imageParams 中显式指定了 __scale__（图片自身像素密度倍率，例如 @2x = 2）
-        //   时，source size 不跟随 view frame 走 contain 缩放，而是直接按
-        //   (1 / __scale__) * dpi 把"图片自身像素"折算成"屏幕重采样像素"：
-        //       source_px = original_img_px * (1 / __scale__) * dpi
-        //                 = (original_img_px / __scale__) * dpi
-        //                 = 图片对应的 vp 尺寸 * dpi
-        //   这样素材倍率与屏幕 dpi 严格对齐，不会被 view 尺寸拉伸/压缩解码。
+        // NODE_IMAGE_SOURCE_SIZE 使用的 scale：由 capinset_image_scale_ 直接决定
+        // （当前实现恒为 1.0），不跟随 view frame 走 contain 缩放：
+        //       source_px = original_img_px * dpi / capinset_image_scale_
+        //                 = 图片对应的 vp 尺寸 * dpi（当字段=1 时即 原图像素 * dpi）
+        //   因此 pixmap 与屏幕 dpi 严格对齐，不会被 view 尺寸拉伸/压缩解码。
         const float source_scale = static_cast<float>(dpi / capinset_image_scale_);
         const float source_w_px = img_size.width * source_scale;
         const float source_h_px = img_size.height * source_scale;
@@ -588,7 +567,7 @@ void KRImageView::ApplyCapInsetsWithLattice() {
                                           source_h_px);
         return;
     }
-    // 未指定 __scale__ 或缺失必要尺寸：不下发 NODE_IMAGE_SOURCE_SIZE，直接按
+    // view frame 或原图尺寸缺失：不下发 NODE_IMAGE_SOURCE_SIZE，直接按
     // 原图像素坐标走 lattice——cap_insets_* 数值即视为图片自身坐标
     //（一图片单位=一像素），image_width/height 用原图像素。
     // 若原图尺寸也取不到，helper 内部会自动回退到老四值 RESIZABLE 路径。

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.cpp
@@ -461,23 +461,17 @@ bool KRImageView::SetMaskLinearGradient(const KRAnyValue &value) {
 bool KRImageView::SetCapInsets(const KRAnyValue &value) {
     auto valueStr = value->toString();
     if (valueStr.empty()) {
-        has_cap_insets_ = false;
+        has_cap_insets_ = false;SetArkUIImageSourceSize
         cap_insets_top_ = 0.f;
         cap_insets_left_ = 0.f;
         cap_insets_bottom_ = 0.f;
         cap_insets_right_ = 0.f;
-        //kuikly::util::ResetArkUIImageCapInsets(GetNode());
+        kuikly::util::ResetArkUIImageCapInsets(GetNode());
         return true;
     }
     std::vector<std::string> items = kuikly::util::ConvertSplit(valueStr, " ");
     if (items.size() >= 4) {
         // 单位约定：SetProp 阶段拿到的 top/left/bottom/right 单位就是**图片 vp**
-        //（与其他布局字段保持一致，属于"上层协议单位"）。这里**只做透传**，
-        //  不在此处乘 dpi、也不乘任何魔法系数——历史实现里 top 乘 dpi、其余三边
-        //  硬编码 * 3.25，除了让四边不一致导致视觉错位以外没有任何好处，因此本
-        //  次一并去掉；把"vp -> 图片像素"的换算集中到 ApplyCapInsetsWithLattice
-        //  里（下发 lattice 前统一做）。
-        //
         // 只记录 capInsets 数据，不在此处直接下发到 ArkUI：
         //   * lattice 精确九宫格（API 24+）依赖图片的真实像素分辨率来把 vp 边距
         //     换算成整数分割线，SetProp 阶段图片一般还没加载完成，拿不到分辨率；

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.cpp
@@ -461,7 +461,7 @@ bool KRImageView::SetMaskLinearGradient(const KRAnyValue &value) {
 bool KRImageView::SetCapInsets(const KRAnyValue &value) {
     auto valueStr = value->toString();
     if (valueStr.empty()) {
-        has_cap_insets_ = false;SetArkUIImageSourceSize
+        has_cap_insets_ = false;
         cap_insets_top_ = 0.f;
         cap_insets_left_ = 0.f;
         cap_insets_bottom_ = 0.f;

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.cpp
@@ -22,12 +22,21 @@
 #include "libohos_render/api/src/KRAnyDataInternal.h"
 #include "libohos_render/expand/components/image/KRImageAdapterManager.h"
 #include "libohos_render/expand/modules/cache/KRMemoryCacheModule.h"
+#include "libohos_render/foundation/KRConfig.h"
 #include "libohos_render/manager/KRRenderManager.h"
 #include "libohos_render/manager/KRSnapshotManager.h"
 #include "libohos_render/utils/KRThreadChecker.h"
 #include "libohos_render/utils/KRURIHelper.h"
 #include "libohos_render/utils/KRStringUtil.h"
 #include "libohos_render/utils/KRViewContext.h"
+
+// OH_Drawing_LatticeDestroy 弱符号声明：与 KRViewUtil.cpp 里的声明保持一致，
+// 用于 OnDestroy 时释放 lattice_pool_ 里累计的图形对象。弱符号保证旧系统
+// （API < 24）链接时不失败；运行时官方依赖未提供时 &OH_Drawing_LatticeDestroy
+// 会为 nullptr，可提前拦截避免崩溃。同一 TU 内重复声明弱符号目前只能以全局
+// 符号形式存在（native drawing 头不包 KRImageView.cpp），因此直接声明而不 include
+// <native_drawing/drawing_lattice.h> 避免引入不必要的头依赖。
+extern "C" int32_t OH_Drawing_LatticeDestroy(struct OH_Drawing_Lattice *lattice) __attribute__((weak));
 
 constexpr char kPropNameSrc[] = "src";
 constexpr char kBase64Prefix[] = "data:image";
@@ -49,6 +58,12 @@ constexpr char kPropNameColorFilter[] = "colorFilter";
 constexpr char kPropNameCapInsets[] = "capInsets";
 constexpr char kPropNameDotNineImage[] = "dotNineImage";
 constexpr char kPropNameImageParams[] = "imageParams";
+// imageParams map 中的 "__scale__" 键：上层指定的图片自身像素密度倍率
+//（如 @2x = 2），供 capInsets + lattice 路径下的 NODE_IMAGE_SOURCE_SIZE 使用。
+constexpr char kImageParamKeyScale[] = "__scale__";
+// capinset_image_scale_ 默认值：1.0 表示"1 图片像素 = 1 vp"，即未显式指定
+// __scale__ 时的默认语义。非正值/缺失时也 fallback 到该默认。
+constexpr float DEFAULT_CAPINST_IMAGE_SCALE = 1.0f;
 
 constexpr char kEventNameLoadSuccess[] = "loadSuccess";
 constexpr char kEventNameLoadResolution[] = "loadResolution";
@@ -98,6 +113,19 @@ bool KRImageView::ReuseEnable() {
 
 void KRImageView::OnDestroy() {
     ResetMaskLinearGradientNode();
+    // 释放本实例生命周期内累计创建的所有 OH_Drawing_Lattice 对象：
+    // ArkUI setAttribute 阶段不能立即销毁（会崩），因此既不在下发位置销毁、
+    // 也不在处理 cap insets 变更时销毁旧 lattice，而是累到 lattice_pool_ 里，到
+    // 本方法统一释放——此时 ArkUI 已经不可能再引用它们。弱符号先检查，
+    // 避免在低版本系统（未提供 OH_Drawing_LatticeDestroy）上调空指针崩溃。
+    if (&OH_Drawing_LatticeDestroy != nullptr) {
+        for (auto *lattice : lattice_pool_) {
+            if (lattice) {
+                OH_Drawing_LatticeDestroy(lattice);
+            }
+        }
+    }
+    lattice_pool_.clear();
 }
 
 bool KRImageView::SetProp(const std::string &prop_key, const KRAnyValue &prop_value,
@@ -139,6 +167,11 @@ bool KRImageView::ResetProp(const std::string &prop_key) {
         image_src_ = "";
         has_loaded_image_ = false;
         loaded_image_size_ = {};
+        // src 复位：清空原图尺寸缓存与 source size 幂等门闸，让下一次 src
+        // 到达时能重新捕获新原图尺寸并允许一次 SetArkUIImageSourceSize 下发。
+        has_original_image_size_ = false;
+        original_image_size_ = {};
+        source_size_applied_ = false;
         kuikly::util::ResetArkUIImageSrc(GetNode());
         didHanded = true;
     } else if (kuikly::util::isEqual(prop_key, kPropNameResize)) {
@@ -153,6 +186,11 @@ bool KRImageView::ResetProp(const std::string &prop_key) {
     } else if (kuikly::util::isEqual(prop_key, kPropNameColorFilter)) {
         didHanded = ResetColorFilter();
     } else if (kuikly::util::isEqual(prop_key, kPropNameCapInsets)) {
+        has_cap_insets_ = false;
+        cap_insets_top_ = 0.f;
+        cap_insets_left_ = 0.f;
+        cap_insets_bottom_ = 0.f;
+        cap_insets_right_ = 0.f;
         kuikly::util::ResetArkUIImageCapInsets(GetNode());
         didHanded = true;
     } else if (kuikly::util::isEqual(prop_key, kPropNameDotNineImage)) {
@@ -176,6 +214,9 @@ bool KRImageView::ResetProp(const std::string &prop_key) {
         load_failure_callback_ = nullptr;
     } else if (kuikly::util::isEqual(prop_key, kPropNameImageParams)) {
         image_params_ = nullptr;
+        capinset_image_scale_ = DEFAULT_CAPINST_IMAGE_SCALE;
+        // __scale__ 变化 → source size 需要按新倍率重新下发，放开幂等门闸。
+        source_size_applied_ = false;
         didHanded = true;
     } else {
         didHanded = IKRRenderViewExport::ResetProp(prop_key);
@@ -226,6 +267,11 @@ bool KRImageView::SetImageSrc(const KRAnyValue &value) {
     image_src_ = src;
     has_loaded_image_ = false;
     loaded_image_size_ = {};
+    // src 换了：原图快照失效，source size 幂等门闸放开，让新 src 加载完成
+    // 后允许再下发一次 NODE_IMAGE_SOURCE_SIZE。
+    has_original_image_size_ = false;
+    original_image_size_ = {};
+    source_size_applied_ = false;
     
     // 优先使用 V3 adapter（支持 imageParams）
     if (auto imageAdapterV3 = KRImageAdapterManager::GetInstance()->GetAdapterV3()) {
@@ -273,16 +319,35 @@ bool KRImageView::SetImageSrc(const KRAnyValue &value) {
 }
 
 bool KRImageView::SetImageParams(const KRAnyValue &value) {
+    const float prev_image_scale = capinset_image_scale_;
     if (!value) {
         image_params_ = nullptr;
-        return true;
-    }
-    // 直接使用 toMap() 解析 JSON 字符串为 Map，并存储
-    auto map = value->toMap();
-    if (map.empty()) {
-        image_params_ = nullptr;
+        capinset_image_scale_ = DEFAULT_CAPINST_IMAGE_SCALE;
     } else {
-        image_params_ = NewKRRenderValue(map);
+        // 直接使用 toMap() 解析 JSON 字符串为 Map，并存储
+        auto map = value->toMap();
+        if (map.empty()) {
+            image_params_ = nullptr;
+            capinset_image_scale_ = DEFAULT_CAPINST_IMAGE_SCALE;
+        } else {
+            image_params_ = NewKRRenderValue(map);
+            // 从 imageParams 中提取 __scale__（图片自身像素密度倍率，例如 @2x = 2）。
+            // 存下来供 ApplyCapInsetsWithLattice 计算 NODE_IMAGE_SOURCE_SIZE 使用。
+            // 缺失、非数值或 <= 0 时 fallback 到默认值（1.0，即 1 像素 = 1 vp）。
+            auto it = map.find(kImageParamKeyScale);
+            if (it != map.end() && it->second) {
+                float s = it->second->toFloat();
+                capinset_image_scale_ = s > 0.f ? s : DEFAULT_CAPINST_IMAGE_SCALE;
+            } else {
+                capinset_image_scale_ = DEFAULT_CAPINST_IMAGE_SCALE;
+            }
+        }
+    }
+    // __scale__ 变化会改变 source size 目标值，需要放开 source_size_applied_
+    // 幂等门闸，让下一次 ApplyCapInsetsWithLattice 能按新倍率重新下发。
+    // 不变则保持原状——避免误触发多余的重解码。
+    if (capinset_image_scale_ != prev_image_scale) {
+        source_size_applied_ = false;
     }
     return true;
 }
@@ -396,17 +461,42 @@ bool KRImageView::SetMaskLinearGradient(const KRAnyValue &value) {
 bool KRImageView::SetCapInsets(const KRAnyValue &value) {
     auto valueStr = value->toString();
     if (valueStr.empty()) {
-        kuikly::util::ResetArkUIImageCapInsets(GetNode());
+        has_cap_insets_ = false;
+        cap_insets_top_ = 0.f;
+        cap_insets_left_ = 0.f;
+        cap_insets_bottom_ = 0.f;
+        cap_insets_right_ = 0.f;
+        //kuikly::util::ResetArkUIImageCapInsets(GetNode());
         return true;
     }
     std::vector<std::string> items = kuikly::util::ConvertSplit(valueStr, " ");
     if (items.size() >= 4) {
-        double dpi = KRConfig::GetDpi();
-        float top = std::stof(items[0]) / dpi;
-        float left = std::stof(items[1]) / dpi;
-        float bottom = std::stof(items[2]) / dpi;
-        float right = std::stof(items[3]) / dpi;
-        kuikly::util::SetArkUIImageCapInsets(GetNode(), top, left, bottom, right);
+        // 单位约定：SetProp 阶段拿到的 top/left/bottom/right 单位就是**图片 vp**
+        //（与其他布局字段保持一致，属于"上层协议单位"）。这里**只做透传**，
+        //  不在此处乘 dpi、也不乘任何魔法系数——历史实现里 top 乘 dpi、其余三边
+        //  硬编码 * 3.25，除了让四边不一致导致视觉错位以外没有任何好处，因此本
+        //  次一并去掉；把"vp -> 图片像素"的换算集中到 ApplyCapInsetsWithLattice
+        //  里（下发 lattice 前统一做）。
+        //
+        // 只记录 capInsets 数据，不在此处直接下发到 ArkUI：
+        //   * lattice 精确九宫格（API 24+）依赖图片的真实像素分辨率来把 vp 边距
+        //     换算成整数分割线，SetProp 阶段图片一般还没加载完成，拿不到分辨率；
+        //   * 老四值路径本身正是本次修复的痛点（rezisable 效果差），不再作为兜底
+        //     使用——宁可短暂显示无 capInsets 的原图，也不要让用户先看到错误效果。
+        //
+        // 真正下发在 FireOnImageCompleteEvent 里拿到 loaded_image_size_ 之后执行；
+        // 因此这里必须确保 NODE_IMAGE_ON_COMPLETE 事件已注册，否则永远拿不到分辨率。
+        has_cap_insets_ = true;
+        cap_insets_top_ = std::stof(items[0]);
+        cap_insets_left_ = std::stof(items[1]);
+        cap_insets_bottom_ = std::stof(items[2]);
+        cap_insets_right_ = std::stof(items[3]);
+        EnsureLoadCompleteEventRegistered();
+        // 兜底：capInsets 在 src 之后到达、且 src 已经加载完成的场景（例如 base64
+        // 命中缓存的同步路径），此时 has_loaded_image_ 已是 true，可以立即下发。
+        if (has_loaded_image_) {
+            ApplyCapInsetsWithLattice();
+        }
     }
     return true;
 }
@@ -423,6 +513,109 @@ void KRImageView::EnsureLoadCompleteEventRegistered() {
     if (!had_register_on_complete_event_) {
         RegisterEvent(NODE_IMAGE_ON_COMPLETE);
         had_register_on_complete_event_ = true;
+    }
+}
+
+void KRImageView::ApplyCapInsetsWithLattice() {
+    // 单位约定（三种坐标系，务必分清）：
+    //   * GetFrame() 返回的 width/height 单位是 **vp**（屏幕坐标）；
+    //   * original_image_size_ 单位是 **px**（图片自身原始像素，首帧捕获后不再变）；
+    //   * cap_insets_* 单位是 **图片自身独立坐标**（上层协议数值，与屏幕 dpi 无关，
+    //     和 iOS UIImage capInsets / Android .9png 语义一致）；
+    //   * NODE_IMAGE_SOURCE_SIZE 官方文档虽写 vp，但 attribute 结构体实际按 .i32
+    //     (整数 px) 读取（见 SetArkUIImageSourceSize 实现），因此这里直接传"重采样
+    //     目标像素"即可。
+    //
+    // 循环防护（关键！）：SetArkUIImageSourceSize 会触发 ArkUI 重解码，重解码完成
+    // 后又会回调 NODE_IMAGE_ON_COMPLETE 再次进到这里；若不加防护，且 img_px 计算
+    // 时使用被覆盖后的 loaded_image_size_，就会形成尺寸雪崩式无限递归。两把锁：
+    //   1) img_px 参数**始终**用 original_image_size_（首帧捕获，之后固定不变）
+    //      → 每一轮算出的 source size 是常量，天然幂等。
+    //   2) source_size_applied_ 幂等门闸 → 当前 src+__scale__ 生命周期内只允许
+    //      下发一次 NODE_IMAGE_SOURCE_SIZE；后续再进来只重发 lattice 分割线，
+    //      不再触发重解码，彻底断开回环。src 变、__scale__ 变时该门闸会被放开。
+    //
+    // 两条分支：
+    //   (A) capinset_image_scale_ > 0（imageParams 中显式指定了 __scale__，例如 @2x = 2；
+    //       默认值 DEFAULT_CAPINST_IMAGE_SCALE = 1 也满足该条件）：
+    //       首次进入时下发 NODE_IMAGE_SOURCE_SIZE 让 ArkUI 重解码 pixmap，随后
+    //       lattice 分割线建立在**重采样后 pixmap** 的坐标系里。source scale 直接
+    //       由 __scale__ 决定，完全不依赖 view frame：
+    //           source_scale = (1 / __scale__) * dpi = dpi / __scale__
+    //           source_px    = original_img_px * source_scale
+    //                        = (original_img_px / __scale__) * dpi
+    //                        = 图片对应的 vp 尺寸 * dpi
+    //       lattice 的 xDivs/yDivs 用同一个 source_scale 把 cap_insets_* 换算成
+    //       "重采样 pixmap 像素"，与 image_width/height 同坐标系。
+    //       第二次及以后进入（例如 setCapInsets 变化）只重发 lattice，跳过
+    //       SetArkUIImageSourceSize，避免重解码回环。
+    //   (B) 未指定 __scale__ 或必要尺寸缺失：**不下发 NODE_IMAGE_SOURCE_SIZE**，
+    //       直接按原图像素坐标下发 lattice——一图片单位=一像素是默认解读，
+    //       cap_insets_* 与 image_width/height 都用原图像素同坐标系。若原图尺寸
+    //       也取不到，helper 内部会自动回退到老四值 RESIZABLE 路径。
+    const auto &view_frame = GetFrame();
+    const float view_w_vp = view_frame.width;
+    const float view_h_vp = view_frame.height;
+    // 原图尺寸优先取首帧快照 original_image_size_；快照未就位（罕见的兜底路径）
+    // 才退回 loaded_image_size_——此时 source_size_applied_ 也一定还是 false，
+    // 一次下发之后快照会在下一次 ON_COMPLETE 里被落下来。
+    const KRSize &img_size = has_original_image_size_ ? original_image_size_ : loaded_image_size_;
+    if (capinset_image_scale_ > 0.f && view_w_vp > 0.f && view_h_vp > 0.f &&
+        img_size.width > 0.f && img_size.height > 0.f) {
+        const double dpi = KRConfig::GetDpi();
+        // NODE_IMAGE_SOURCE_SIZE 使用的 scale：
+        //   imageParams 中显式指定了 __scale__（图片自身像素密度倍率，例如 @2x = 2）
+        //   时，source size 不跟随 view frame 走 contain 缩放，而是直接按
+        //   (1 / __scale__) * dpi 把"图片自身像素"折算成"屏幕重采样像素"：
+        //       source_px = original_img_px * (1 / __scale__) * dpi
+        //                 = (original_img_px / __scale__) * dpi
+        //                 = 图片对应的 vp 尺寸 * dpi
+        //   这样素材倍率与屏幕 dpi 严格对齐，不会被 view 尺寸拉伸/压缩解码。
+        const float source_scale = static_cast<float>(dpi / capinset_image_scale_);
+        const float source_w_px = img_size.width * source_scale;
+        const float source_h_px = img_size.height * source_scale;
+        // source size 只允许下发一次——见函数头部注释里的"循环防护"说明。
+        // 首次下发后置位 source_size_applied_，之后的 ApplyCapInsetsWithLattice
+        // 调用只走下面的 SetArkUIImageCapInsetsWithLattice 重发 lattice。
+        if (!source_size_applied_) {
+            kuikly::util::SetArkUIImageSourceSize(GetNode(), source_w_px, source_h_px);
+            source_size_applied_ = true;
+        }
+
+        // lattice 分割线：cap_insets_*（图片自身坐标）* source_scale = 重采样
+        // pixmap 像素。image_width/height 也必须是**重采样后**的像素尺寸，与
+        // xDivs/yDivs 同坐标系；因此这里必须使用与 source size 完全一致的
+        // source_scale。
+        SetArkUIImageCapInsetsWithLattice(cap_insets_top_ * source_scale,
+                                          cap_insets_left_ * source_scale,
+                                          cap_insets_bottom_ * source_scale,
+                                          cap_insets_right_ * source_scale,
+                                          source_w_px,
+                                          source_h_px);
+        return;
+    }
+    // 未指定 __scale__ 或缺失必要尺寸：不下发 NODE_IMAGE_SOURCE_SIZE，直接按
+    // 原图像素坐标走 lattice——cap_insets_* 数值即视为图片自身坐标
+    //（一图片单位=一像素），image_width/height 用原图像素。
+    // 若原图尺寸也取不到，helper 内部会自动回退到老四值 RESIZABLE 路径。
+    SetArkUIImageCapInsetsWithLattice(cap_insets_top_,
+                                      cap_insets_left_,
+                                      cap_insets_bottom_,
+                                      cap_insets_right_,
+                                      img_size.width,
+                                      img_size.height);
+}
+
+void KRImageView::SetArkUIImageCapInsetsWithLattice(float top, float left, float bottom, float right,
+                                                    float image_width_px, float image_height_px) {
+    // 委托 util 底层实现完成实际下发，并通过 out_lattice 接住创建出的
+    // OH_Drawing_Lattice 指针；util 内部不再销毁。创建成功才 push 进池，
+    // fallback 到老四值 RESIZABLE 路径时 out_lattice 会被 util 置为 nullptr。
+    struct OH_Drawing_Lattice *lattice = nullptr;
+    kuikly::util::SetArkUIImageCapInsetsWithLattice(GetNode(), top, left, bottom, right,
+                                                   image_width_px, image_height_px, &lattice);
+    if (lattice) {
+        lattice_pool_.push_back(lattice);
     }
 }
 
@@ -475,14 +668,33 @@ void KRImageView::FireOnImageCompleteEvent(ArkUI_NodeEvent *event) {
 
     loaded_image_size_ = kuikly::util::GetArkUINodeImagePicSize(event);
     has_loaded_image_ = true;
+    // 首帧捕获**原图**像素尺寸快照：SetArkUIImageSourceSize 触发的重采样会让
+    // 后续 ON_COMPLETE 里的 width/height 变成重采样后 pixmap 的尺寸，直接拿来
+    // 参与 img_px * source_scale 会尺寸雪崩。所以只在第一次记录，之后无论
+    // ArkUI 又回调多少次都不覆盖，直到 src 换了才清空。
+    // loaded_image_size_ 依然每次都刷——它对外承担 load_resolution 语义，
+    // 需要反映当前 pixmap 的真实尺寸。
+    if (!has_original_image_size_) {
+        original_image_size_ = loaded_image_size_;
+        has_original_image_size_ = true;
+    }
 
     if (this->is_dot_nine_image_) {
+        // dotNine 场景保持原始老逻辑不动：图片中间 1 像素为拉伸区，把图片像素
+        // /dpi 换算成 vp 后直接下发到 NODE_IMAGE_RESIZABLE（老四值路径）。这条路径
+        // 长期以来工作稳定，本次 lattice 改造只针对普通 capInsets prop 场景，dotNine
+        // 不参与——避免影响已经工作正常的代码。
         double dpi = KRConfig::GetDpi();
         float top = loaded_image_size_.height * 0.5 / dpi;
         float left = loaded_image_size_.width * 0.5 / dpi;
         float bottom = (loaded_image_size_.height * 0.5 - 1) / dpi;
         float right = (loaded_image_size_.width * 0.5 - 1) / dpi;
         kuikly::util::SetArkUIImageCapInsets(GetNode(), top, left, bottom, right);
+    } else if (has_cap_insets_) {
+        // 图片加载完成，首次拿到真实像素尺寸：先按 view frame 等比缩放下发
+        // NODE_IMAGE_SOURCE_SIZE，再升级为 lattice 精确九宫格（API 24+）。低版本 /
+        // 缺尺寸时 helper 内部自动回退老四值路径，视觉与之前一致。
+        ApplyCapInsetsWithLattice();
     }
 
     if (load_success_callback_) {

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.h
@@ -110,13 +110,12 @@ class KRImageView : public IKRRenderViewExport {
     float cap_insets_right_ = 0.f;
     ArkUI_NodeHandle mask_linear_gradient_node_ = nullptr;
     KRAnyValue image_params_ = nullptr;
-    // 从 imageParams map 中提取的 "__scale__" 参数：图片自身的像素密度 scale
-    //（例如 @2x 素材约定 __scale__ = 2）。默认值 DEFAULT_CAPINST_IMAGE_SCALE = 1，
-    // 表示"1 图片像素 = 1 vp"（未显式指定时的语义）；上层显式指定后按新值走。
-    // 该字段专门服务于 capInsets + lattice 精确九宫格路径下 NODE_IMAGE_SOURCE_SIZE
-    // 的 scale 计算：source_scale = (1 / __scale__) * dpi = dpi / __scale__，即：
-    // 把"图片自身像素"按素材倍率折回逻辑像素、再乘 dpi 得到屏幕像素，与屏幕 dpi
-    // 严格对齐，不受 view frame 影响。
+    // capInsets + lattice 路径下 NODE_IMAGE_SOURCE_SIZE 的 scale 参数：
+    // 当前实现**固定为 DEFAULT_CAPINST_IMAGE_SCALE = 1.0**（"1 图片像素 = 1 vp"），
+    // 不再从 imageParams 中读取任何 __scale__ 键。保留字段以便未来恢复动态
+    // 素材倍率支持时低成本改回。
+    // 数学模型（仍适用）：source_scale = 1 / capinset_image_scale_ * dpi = dpi（当值=1时），
+    // 即 source 像素 = 原图像素 * dpi，与屏幕 dpi 严格对齐，不受 view frame 影响。
     float capinset_image_scale_ = 1.f;
     // === 循环防护相关（避免 SetArkUIImageSourceSize 触发重解码→ON_COMPLETE→
     // ApplyCapInsetsWithLattice→再次 SetArkUIImageSourceSize 的死循环）===
@@ -124,8 +123,7 @@ class KRImageView : public IKRRenderViewExport {
     // source_size_applied_：当前 image_src_ 生命周期内是否已经下发过一次
     //   NODE_IMAGE_SOURCE_SIZE。第二次进入 ApplyCapInsetsWithLattice 时不再
     //   下发 source size（只重发 lattice），从而彻底断掉重解码回环。
-    //   src 变更、__scale__ 变更、imageParams 复位时必须重置为 false，让新
-    //   参数下第一次 apply 时能重新下发 source size。
+    //   src 变更时重置为 false，让新 src 下第一次 apply 时能重新下发 source size。
     bool source_size_applied_ = false;
     // original_image_size_ / has_original_image_size_：首次从 ArkUI ON_COMPLETE
     //   拿到的**原图像素尺寸**快照。由于 SetArkUIImageSourceSize 会让 ArkUI

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.h
@@ -20,6 +20,13 @@
 #include "libohos_render/export/IKRRenderViewExport.h"
 #include "libohos_render/foundation/KRSize.h"
 
+#include <vector>
+
+// OH_Drawing_Lattice：native drawing 层的九宫格分割线对象；这里只做前向声明，
+// 具体类型在 util 层通过 <native_drawing/drawing_lattice.h> 使用。KRImageView
+// 侧只保存指针到 lattice_pool_，在 OnDestroy 时统一销毁。
+struct OH_Drawing_Lattice;
+
 using namespace std::string_view_literals;
 constexpr std::string_view KR_ASSET_PREFIX = "assets://"sv;
 
@@ -54,6 +61,17 @@ class KRImageView : public IKRRenderViewExport {
     bool SetMaskLinearGradient(const KRAnyValue &value);
     void ResetMaskLinearGradientNode();
     void EnsureLoadCompleteEventRegistered();
+    // 图片加载完成后，按 view frame 与图片像素比例下发 NODE_IMAGE_SOURCE_SIZE
+    // （cover 语义，vp 单位），再调用 lattice 精确九宫格。
+    // 前置条件：has_cap_insets_ && has_loaded_image_ && loaded_image_size_ 有效。
+    void ApplyCapInsetsWithLattice();
+    // KRImageView 侧的 lattice 封装：内部调用 kuikly::util::SetArkUIImageCapInsetsWithLattice，
+    // 把 util 通过 out_lattice 交出的 OH_Drawing_Lattice* 存进 lattice_pool_，
+    // 到 OnDestroy 时再统一销毁。这样避免"下发后立即销毁"造成的 ArkUI 内部
+    // 崩溃，同时不泄漏（本实例生命周期结束时全部释放）。参数语义与 util 版本
+    // 完全一致，见 KRViewUtil.h 中的注释。
+    void SetArkUIImageCapInsetsWithLattice(float top, float left, float bottom, float right,
+                                           float image_width_px, float image_height_px);
     bool RegisterLoadSuccessCallback(const KRRenderCallback &event_callback);
     bool RegisterLoadResolutionCallback(const KRRenderCallback &event_callback);
     bool RegisterLoadFailureCallback(const KRRenderCallback &event_callback);
@@ -78,8 +96,55 @@ class KRImageView : public IKRRenderViewExport {
     bool had_register_on_complete_event_ = false;
     bool had_register_on_error_event_ = false;
     bool is_dot_nine_image_ = false;
+    // 用户设定的 capInsets（top / left / bottom / right），四值单位为**图片 vp**
+    //（与上层协议其他布局字段保持一致，属于"上层协议单位"）。has_cap_insets_ 为
+    // true 表示当前存在有效 capInsets，需要在图片加载完成后按图片像素尺寸走
+    // lattice 精确九宫格（API 24+）路径。"vp -> 图片像素"的换算集中在
+    // ApplyCapInsetsWithLattice 里下发 lattice 前统一做（* dpi），SetCapInsets
+    // 阶段**不做任何换算**，避免历史实现里 top 用 dpi、其余三边硬编码 3.25 这类
+    // 四边不一致的坑再次出现。see SetCapInsets 注释。
+    bool has_cap_insets_ = false;
+    float cap_insets_top_ = 0.f;
+    float cap_insets_left_ = 0.f;
+    float cap_insets_bottom_ = 0.f;
+    float cap_insets_right_ = 0.f;
     ArkUI_NodeHandle mask_linear_gradient_node_ = nullptr;
     KRAnyValue image_params_ = nullptr;
+    // 从 imageParams map 中提取的 "__scale__" 参数：图片自身的像素密度 scale
+    //（例如 @2x 素材约定 __scale__ = 2）。默认值 DEFAULT_CAPINST_IMAGE_SCALE = 1，
+    // 表示"1 图片像素 = 1 vp"（未显式指定时的语义）；上层显式指定后按新值走。
+    // 该字段专门服务于 capInsets + lattice 精确九宫格路径下 NODE_IMAGE_SOURCE_SIZE
+    // 的 scale 计算：source_scale = (1 / __scale__) * dpi = dpi / __scale__，即：
+    // 把"图片自身像素"按素材倍率折回逻辑像素、再乘 dpi 得到屏幕像素，与屏幕 dpi
+    // 严格对齐，不受 view frame 影响。
+    float capinset_image_scale_ = 1.f;
+    // === 循环防护相关（避免 SetArkUIImageSourceSize 触发重解码→ON_COMPLETE→
+    // ApplyCapInsetsWithLattice→再次 SetArkUIImageSourceSize 的死循环）===
+    //
+    // source_size_applied_：当前 image_src_ 生命周期内是否已经下发过一次
+    //   NODE_IMAGE_SOURCE_SIZE。第二次进入 ApplyCapInsetsWithLattice 时不再
+    //   下发 source size（只重发 lattice），从而彻底断掉重解码回环。
+    //   src 变更、__scale__ 变更、imageParams 复位时必须重置为 false，让新
+    //   参数下第一次 apply 时能重新下发 source size。
+    bool source_size_applied_ = false;
+    // original_image_size_ / has_original_image_size_：首次从 ArkUI ON_COMPLETE
+    //   拿到的**原图像素尺寸**快照。由于 SetArkUIImageSourceSize 会让 ArkUI
+    //   重采样 pixmap，后续 ON_COMPLETE 携带的 width/height 变为**重采样后**
+    //   尺寸；直接用它当"原图 * source_scale"就会尺寸雪崩。因此 apply 换算
+    //   里始终使用 original_image_size_ 而非 loaded_image_size_——
+    //   loaded_image_size_ 保持原语义继续更新（对外 load_resolution 回调需要）。
+    //   src 变更时必须清空，让新图第一次 ON_COMPLETE 重新捕获原图尺寸。
+    KRSize original_image_size_;
+    bool has_original_image_size_ = false;
+    // 本实例生命周期内累计创建的 OH_Drawing_Lattice 池。每次 ApplyCapInsetsWithLattice
+    // 通过 util 底层函数创建的 lattice 都会 push 进来；OnDestroy 时逐个
+    // OH_Drawing_LatticeDestroy 释放。
+    // 之所以不"下发后立即销毁"：实测在 ArkUI 立即 setAttribute 结束后销毁 lattice
+    // 会引发崩溃（ArkUI 内部似乎异步引用了 lattice 数据），所以必须把生命周期延长
+    // 到本组件销毁时。同一实例内 lattice 可能累积多个（例如 cap insets 变化或复用），
+    // 由于 ArkUI 每次拿到的都是新指针、旧 lattice 不再被外部访问，累积几个 lattice
+    // 只是轻微内存滞留，OnDestroy 兜底释放不会真泄漏。
+    std::vector<OH_Drawing_Lattice *> lattice_pool_;
     
     static void AdapterSetImageCallback(const void* context,
                                    const char *src,

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.cpp
@@ -15,8 +15,63 @@
 
 #include "libohos_render/utils/KRViewUtil.h"
 
+#include <arkui/drawable_descriptor.h>
+#include <deviceinfo.h>
+#include <multimedia/image_framework/image/pixelmap_native.h>
+
 #include "libohos_render/export/IKRRenderViewExport.h"
 #include "libohos_render/utils/KRThreadChecker.h"
+
+// ============================================================================
+// OH_Drawing_Lattice 精确九宫格（API 24 引入）—— 弱符号声明块
+//
+// **必须放在全局命名空间**：C++ 里在 namespace 内出现的 `struct X;` 或
+// `struct X **p` 会**在当前 namespace 里新建同名前向声明**（elaborated type
+// specifier 规则），导致 KRViewUtil.h（在全局命名空间前向声明 ::OH_Drawing_Lattice）
+// 与 KRViewUtil.cpp 里如果放到 kuikly::util 内声明就会产生
+// kuikly::util::OH_Drawing_Lattice 这个**独立类型符号**，跨 TU 的函数签名类型
+// 因此不一致，最终链接期 undefined symbol（这一坑已在真实构建中踩过）。
+// 故这里统一在**全局作用域**做前向声明与 weak 函数声明，保证与
+// KRViewUtil.h 里 ::OH_Drawing_Lattice 完全一致。
+//
+// 其他说明：
+//   * 弱符号 OH_Drawing_LatticeCreate / _Destroy：运行系统 API < 24 时符号地址
+//     为 nullptr，dlopen .so 不会因未解析符号而失败；运行时以
+//     OH_GetSdkApiVersion() >= 24 && 符号非空 双重判定。
+//   * 不 #include <native_drawing/drawing_lattice.h>：低版本 SDK header 里没有
+//     该文件，直接 include 会破坏低版本编译；这里前向自声明所需的最小类型/函数。
+//   * 先在 extern "C" 之外用 C++ 语法声明 opaque enum OH_Drawing_LatticeRectType：
+//     指定底层类型 int32_t，与 SDK <native_drawing/drawing_lattice.h> 中
+//     typedef enum { DEFAULT, TRANSPARENT, FIXED_COLOR } 的 ABI 严格一致，避免把
+//     DEFAULT / TRANSPARENT / FIXED_COLOR 引入全局命名空间造成宏冲突
+//     （如 Windows GDI 的 TRANSPARENT 宏）。
+// ============================================================================
+enum OH_Drawing_LatticeRectType : int32_t;
+
+extern "C" {
+// OH_Drawing_Lattice 是不透明结构体，前向声明即可满足指针使用。
+struct OH_Drawing_Lattice;
+// OH_Drawing_Rect 同为不透明结构体（drawing_types.h），此处只需指针语义。
+struct OH_Drawing_Rect;
+
+// OH_Drawing_ErrorCode 也是枚举（drawing_error_code.h 里定义），此处按 SDK 一致的
+// 32 位有符号整型返回值来声明——弱符号只关心链接期名字/参数签名匹配，返回类型只要
+// ABI 一致即可。
+int32_t OH_Drawing_LatticeCreate(const int *xDivs, const int *yDivs, uint32_t xCount, uint32_t yCount,
+                                 const struct OH_Drawing_Rect *bounds,
+                                 const enum OH_Drawing_LatticeRectType *rectTypes, uint32_t rectTypeCount,
+                                 const uint32_t *colors, uint32_t colorCount,
+                                 struct OH_Drawing_Lattice **lattice) __attribute__((weak));
+int32_t OH_Drawing_LatticeDestroy(struct OH_Drawing_Lattice *lattice) __attribute__((weak));
+
+// OH_Drawing_RectCreate / Destroy 自 API 11 就已存在（drawing_rect.h @since 11），
+// 早于我们要求的 API 24，链接一定成功；不加弱符号也可以，加上更保险且和 lattice
+// 保持声明风格一致。之所以不 #include <native_drawing/drawing_rect.h>，是为了避免
+// 编译期依赖 SDK header 结构，与 lattice 保持"最小前向声明"策略一致。
+struct OH_Drawing_Rect *OH_Drawing_RectCreate(float left, float top, float right, float bottom)
+    __attribute__((weak));
+void OH_Drawing_RectDestroy(struct OH_Drawing_Rect *rect) __attribute__((weak));
+}  // extern "C"
 
 namespace kuikly {
 namespace util {
@@ -651,6 +706,37 @@ void SetArkUIImageSrc(ArkUI_NodeHandle handle, ArkUI_DrawableDescriptor *drawabl
         return;
     }
 
+    // 调试用：从 drawable 里取出 static pixelmap，打印其原始像素宽高。
+    // 说明：
+    //  * OH_ArkUI_DrawableDescriptor_GetStaticPixelMap 只返回内部持有的 handle，
+    //    不转移所有权，调用方**不需要**释放；
+    //  * OH_PixelmapImageInfo_* 一族 API 是 ImageInfo 对象的独立生命周期，Create /
+    //    Release 必须配对；
+    //  * 动图 drawable 走的是 GetAnimatedPixelMapArray，这里只对静态 pixmap 打点，
+    //    动图返回 nullptr 会直接跳过，不影响主流程。
+    if (drawable) {
+        OH_PixelmapNativeHandle pm = OH_ArkUI_DrawableDescriptor_GetStaticPixelMap(drawable);
+        if (pm) {
+            OH_Pixelmap_ImageInfo *info = nullptr;
+            OH_PixelmapImageInfo_Create(&info);
+            uint32_t img_w = 0;
+            uint32_t img_h = 0;
+            if (info && OH_PixelmapNative_GetImageInfo(pm, info) == IMAGE_SUCCESS) {
+                OH_PixelmapImageInfo_GetWidth(info, &img_w);
+                OH_PixelmapImageInfo_GetHeight(info, &img_h);
+            }
+            if (info) {
+                OH_PixelmapImageInfo_Release(info);
+            }
+            KR_LOG_INFO << "SetArkUIImageSrc drawable=" << drawable
+                        << " pixelmap=" << pm
+                        << " size(px)=" << img_w << "x" << img_h;
+        } else {
+            KR_LOG_INFO << "SetArkUIImageSrc drawable=" << drawable
+                        << " static pixelmap=null (maybe animated)";
+        }
+    }
+
     auto nodeApi = GetNodeApi();
     ArkUI_AttributeItem src_attr_item = {.object = drawable};
     nodeApi->setAttribute(handle, NODE_IMAGE_SRC, &src_attr_item);
@@ -761,6 +847,211 @@ void SetArkUIImageCapInsets(ArkUI_NodeHandle handle, float top, float left, floa
 
     ArkUI_AttributeItem item = {value, sizeof(value) / sizeof(ArkUI_NumberValue)};
     GetNodeApi()->setAttribute(handle, NODE_IMAGE_RESIZABLE, &item);
+}
+
+void SetArkUIImageSourceSize(ArkUI_NodeHandle handle, float width_vp, float height_vp) {
+    if (!handle) {
+        return;
+    }
+    // ArkUI 官方文档规定 NODE_IMAGE_SOURCE_SIZE 的两个 float 参数单位为 vp。
+    // 非正值不下发，避免把图源缩到 0。
+    if (width_vp <= 0.f || height_vp <= 0.f) {
+        return;
+    }
+    ArkUI_NumberValue value[] = {{.i32 = (int)width_vp}, {.i32 = (int)height_vp}};
+    ArkUI_AttributeItem item = {value, sizeof(value) / sizeof(ArkUI_NumberValue)};
+    GetNodeApi()->setAttribute(handle, NODE_IMAGE_SOURCE_SIZE, &item);
+}
+
+// ============================================================================
+// OH_Drawing_Lattice 精确九宫格（API 24 引入）
+//
+// 老路径（SetArkUIImageCapInsets 四值）由 NODE_IMAGE_RESIZABLE 接收 left/top/right/
+// bottom（单位 vp），系统内部按四边构造隐式九宫格。实测在图片自身分辨率与目标绘制
+// 尺寸差异较大、或用户 vp 边距接近图片一半宽/高时，鸿蒙旧实现会出现中间可拉伸区
+// 计算错乱、边角像素被拉伸等问题（本 issue 的直接触发点）。
+//
+// API 24 起 NODE_IMAGE_RESIZABLE 的 .object 字段支持传入 OH_Drawing_Lattice，
+// 可以按图片像素坐标显式指定 xDivs/yDivs 分割线，鸿蒙侧走的是新的 lattice
+// 精确路径，行为对齐 Skia SkCanvas::drawImageLattice，与 iOS/Android 一致。
+//
+// 兼容策略与弱符号声明**已上移到文件顶部全局命名空间**（见文件顶部注释块），
+// 目的是让所有 TU 看到的 ::OH_Drawing_Lattice 是同一符号，避免因 namespace 内
+// elaborated type specifier 规则引入独立类型导致跨 TU 链接失败。这里仅保留
+// 相关 API 的运行时判定与使用逻辑。
+// ============================================================================
+
+// 判定当前运行进程是否可以走 lattice 路径。
+// 双门控：系统 API 版本 >= 24 && 弱符号被动态链接器解析成功。
+static bool IsArkUIImageLatticeAvailable() {
+    static const bool available = []() {
+        // 部分鸿蒙发行版 / 模拟器可能 API 数值 >=24 但对应符号尚未导出，因此不能
+        // 只信 OH_GetSdkApiVersion()；下面的符号非空判定才是"运行时事实"。
+        if (OH_GetSdkApiVersion() < 24) {
+            return false;
+        }
+        return &OH_Drawing_LatticeCreate != nullptr && &OH_Drawing_LatticeDestroy != nullptr;
+    }();
+    return available;
+}
+
+void SetArkUIImageCapInsetsWithLattice(ArkUI_NodeHandle handle, float top, float left, float bottom,
+                                       float right, float image_width_px, float image_height_px,
+                                       ::OH_Drawing_Lattice **out_lattice) {
+    // 默认输出 nullptr，所有 fallback / 失败 / 无 out_lattice 分支都保持该初始值。
+    if (out_lattice) {
+        *out_lattice = nullptr;
+    }
+    if (!handle) {
+        return;
+    }
+
+    // ------------------------------------------------------------------
+    // 单位约定（重要！与之前实现相比语义已修正）：
+    //   * top/left/bottom/right 四个参数**直接就是"图片自身像素坐标"下的偏移量**，
+    //     即 lattice xDivs/yDivs 需要的原生单位。与 iOS UIImage.resizableImageWithCap
+    //     Insets 的 capInsets(UIEdgeInsets in points) 语义对齐——上层协议约定的
+    //     capInsets 就是"图片自身独立坐标"，鸿蒙的图片没有 iOS 的 point 概念，直接
+    //     对应"图片像素"最自然。
+    //   * **不再** 做 `vp * dpi` 的换算。之前把参数当 vp、再乘 dpi 转屏幕像素当分割
+    //     线的做法是错的——屏幕 dpi 与图片自身像素坐标没有必然关系，会导致上层传
+    //     的 "10" 变成 "10 * dpi"（如 30 px）落到错误位置，正是"拉伸不对"的根因。
+    //   * 老路径 fallback（SetArkUIImageCapInsets → NODE_IMAGE_RESIZABLE 四值）
+    //     期望的单位是 **vp**（ArkUI 原生 API 规定），fallback 时需要按图片像素 →
+    //     vp 反向换算（除以 dpi）后再下发。
+    // ------------------------------------------------------------------
+
+    const double dpi = KRConfig::GetDpi();
+    // fallback 到老路径用的 vp 值（图片像素 / dpi）。抽出来避免每个 return 分支重复。
+    auto old_path_fallback = [&]() {
+        SetArkUIImageCapInsets(handle, static_cast<float>(top / dpi), static_cast<float>(left / dpi),
+                               static_cast<float>(bottom / dpi), static_cast<float>(right / dpi));
+    };
+
+    // 只要具备任一"退化条件"就走老四值路径：
+    //   1. 系统 <API 24 或 lattice 符号未解析；
+    //   2. 图片像素尺寸未知（未加载完成时 image_width_px/image_height_px 为 0/负数）。
+    // 图片尺寸未知时无法确保 lattice 分割线不越界，宁可先按老路径显示（视觉退化但
+    // 不崩），加载完成后调用方会带上尺寸再调一次，届时才升级到 lattice。
+    if (!IsArkUIImageLatticeAvailable() || image_width_px <= 0 || image_height_px <= 0) {
+        old_path_fallback();
+        return;
+    }
+
+    // 四值直接就是"图片像素坐标"，四舍五入到整数（lattice xDivs/yDivs 要求 int）
+    // 并夹到 [0, image_size] 区间，避免越界或反向。
+    auto round_i = [](float v) -> int {
+        return static_cast<int>(v + 0.5f);
+    };
+    auto clamp_int = [](int v, int lo, int hi) -> int {
+        if (v < lo) {
+            return lo;
+        }
+        if (v > hi) {
+            return hi;
+        }
+        return v;
+    };
+
+    const int img_w = static_cast<int>(image_width_px + 0.5f);
+    const int img_h = static_cast<int>(image_height_px + 0.5f);
+    int left_px = clamp_int(round_i(left), 0, img_w);
+    int right_px = clamp_int(img_w - round_i(right), 0, img_w);
+    int top_px = clamp_int(round_i(top), 0, img_h);
+    int bottom_px = clamp_int(img_h - round_i(bottom), 0, img_h);
+
+    // 保证 xDivs / yDivs 严格递增（否则 lattice 语义未定义）。若因边距过大导致
+    // 两条分割线交叉（left+right >= imgW），退回老路径避免生成非法 lattice。
+    if (left_px >= right_px || top_px >= bottom_px) {
+        old_path_fallback();
+        return;
+    }
+
+    const int x_divs[2] = {left_px, right_px};
+    const int y_divs[2] = {top_px, bottom_px};
+
+    // 显式构造 bounds：官方文档说 bounds=nullptr 时"默认为原图矩形"，理论上等价，
+    // 但用户实测简化用法拉伸不稳定；这里按 drawing_lattice.h 示例严格显式传入，
+    // 消除任何"nullptr 简化路径"上潜在的实现差异。
+    // 注意：bounds 的值必须是整数（doc："The value must be an integer and is rounded
+    // down"），我们本来就用 int，安全。
+    struct OH_Drawing_Rect *bounds = nullptr;
+    if (&OH_Drawing_RectCreate != nullptr) {
+        bounds = OH_Drawing_RectCreate(0.f, 0.f, static_cast<float>(img_w), static_cast<float>(img_h));
+    }
+
+    // 显式构造 rectTypes：9 格全 DEFAULT（枚举值 0），与"nullptr + count=0"简化用法
+    // 等价。使用 opaque enum 类型 OH_Drawing_LatticeRectType（与 SDK header 严格一致，
+    // 底层 int32_t，值 0 即 DEFAULT——官方文档中该枚举首个成员即 DEFAULT）。
+    // 注意：文档要求"rectTypes != nullptr 时，rectTypeCount 必须等于 (xCount+1)*(yCount+1)"，
+    // 我们 xCount=yCount=2 → 9，严格对应。
+    // 说明：lattice 的"固定 / 拉伸"由**格子位置的奇偶性**决定，不由 rectTypes 决定；
+    // rectTypes 只控制"这个格子怎么填"（DEFAULT=画原图 / TRANSPARENT=透明 / FIXED_COLOR
+    // =纯色）。所以九宫格拉伸 9 格都是 DEFAULT。
+    constexpr auto kLatticeRectTypeDefault = static_cast<OH_Drawing_LatticeRectType>(0);  // = DEFAULT
+    const OH_Drawing_LatticeRectType rect_types[9] = {
+        kLatticeRectTypeDefault, kLatticeRectTypeDefault, kLatticeRectTypeDefault,  // 第一行
+        kLatticeRectTypeDefault, kLatticeRectTypeDefault, kLatticeRectTypeDefault,  // 第二行
+        kLatticeRectTypeDefault, kLatticeRectTypeDefault, kLatticeRectTypeDefault,  // 第三行
+    };
+
+    struct OH_Drawing_Lattice *lattice = nullptr;
+    // 官方文档 (drawing_lattice.h)：
+    //   "the lattices on both even columns and even rows are fixed, and they are
+    //    drawn at their original size ...; the lattices that are not on even columns
+    //    and even rows are scaled to accommodate the remaining space."
+    // xCount=yCount=2 → 3x3=9 格：四角(偶,偶)固定、中心(奇,奇)双向拉伸、四边(偶,奇)
+    // 或(奇,偶)单向拉伸，正好对应九宫格 capInsets 语义。
+    int32_t ret = OH_Drawing_LatticeCreate(x_divs, y_divs, 2, 2, bounds, nullptr, 0, nullptr, 0, &lattice);
+    if (ret != 0 /* OH_DRAWING_SUCCESS */ || !lattice) {
+        // 兜底：lattice 创建失败（理论上不会发生，比如参数越界）退回老路径而不是留空。
+        if (lattice) {
+            OH_Drawing_LatticeDestroy(lattice);
+        }
+        if (bounds && &OH_Drawing_RectDestroy != nullptr) {
+            OH_Drawing_RectDestroy(bounds);
+        }
+        old_path_fallback();
+        return;
+    }
+    
+
+    // 关键 fix：**只**传 .object=lattice，.value 必须置空。
+    // NODE_IMAGE_RESIZABLE 官方文档虽然把 .value（四个 vp 值）与 .object（Lattice）列
+    // 在同一属性下，但二者是**互斥**的两种设置模式。若同时提供 .value 与 .object，
+    // 鸿蒙内部会优先按 .value 走老四值 RESIZABLE 路径，把 .object 上的 lattice 忽略
+    // 掉——表现就是"看起来设了 lattice，实际拉伸仍然错误"。
+    // 因此这里明确 value=nullptr, size=0，让 ArkUI 无歧义地走 .object=Lattice 分支。
+    ArkUI_AttributeItem item = {};
+    item.value = nullptr;
+    item.size = 0;
+    item.object = lattice;
+    GetNodeApi()->setAttribute(handle, NODE_IMAGE_RESIZABLE, &item);
+    
+    ArkUI_NumberValue autoResizeValue[] = {{.i32 = 1}};
+    ArkUI_AttributeItem autoResizeItem = {.value = autoResizeValue, .size = 1};
+    GetNodeApi()->setAttribute(handle, NODE_IMAGE_AUTO_RESIZE, &autoResizeItem);
+    //SetArkUIIMageResizeMode(handle, ARKUI_OBJECT_FIT_FILL);
+    
+    GetNodeApi()->markDirty(handle, ArkUI_NodeDirtyFlag::NODE_NEED_RENDER);
+
+    // 关键：setAttribute 虽为同步语义，但实测立即 OH_Drawing_LatticeDestroy 会引发崩溃
+    // （鉴定 ArkUI 内部并非完全拷贝，或重绘管线异步引用了 lattice 数据）。
+    // 因此本函数不再在尾部销毁 lattice，而是把所有权交给调用方（通过
+    // out_lattice 输出）；调用方在它确定不会再被使用的时机（例如自身实例
+    // 销毁时）统一释放。若调用方传 out_lattice == nullptr，则表示不接管，
+    // 本函数立即销毁——保底不泄漏，代价是可能降低稳定性（旧行为）。
+    // bounds 只在本函数内使用（供 OH_Drawing_LatticeCreate 读取），setAttribute 后即可
+    // 释放：官方文档明确 bounds 仅用于创建时描述图片矩形，不参与后续绘制。
+    if (out_lattice) {
+        *out_lattice = lattice;
+    } else {
+        // 历史调用方不接管：保底销毁（可能崩溃，但不泄漏）。
+        OH_Drawing_LatticeDestroy(lattice);
+    }
+    if (bounds && &OH_Drawing_RectDestroy != nullptr) {
+        OH_Drawing_RectDestroy(bounds);
+    }
 }
 
 void ResetArkUIImageCapInsets(ArkUI_NodeHandle handle) {

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.cpp
@@ -705,38 +705,7 @@ void SetArkUIImageSrc(ArkUI_NodeHandle handle, ArkUI_DrawableDescriptor *drawabl
     if (!handle) {
         return;
     }
-
-    // 调试用：从 drawable 里取出 static pixelmap，打印其原始像素宽高。
-    // 说明：
-    //  * OH_ArkUI_DrawableDescriptor_GetStaticPixelMap 只返回内部持有的 handle，
-    //    不转移所有权，调用方**不需要**释放；
-    //  * OH_PixelmapImageInfo_* 一族 API 是 ImageInfo 对象的独立生命周期，Create /
-    //    Release 必须配对；
-    //  * 动图 drawable 走的是 GetAnimatedPixelMapArray，这里只对静态 pixmap 打点，
-    //    动图返回 nullptr 会直接跳过，不影响主流程。
-    if (drawable) {
-        OH_PixelmapNativeHandle pm = OH_ArkUI_DrawableDescriptor_GetStaticPixelMap(drawable);
-        if (pm) {
-            OH_Pixelmap_ImageInfo *info = nullptr;
-            OH_PixelmapImageInfo_Create(&info);
-            uint32_t img_w = 0;
-            uint32_t img_h = 0;
-            if (info && OH_PixelmapNative_GetImageInfo(pm, info) == IMAGE_SUCCESS) {
-                OH_PixelmapImageInfo_GetWidth(info, &img_w);
-                OH_PixelmapImageInfo_GetHeight(info, &img_h);
-            }
-            if (info) {
-                OH_PixelmapImageInfo_Release(info);
-            }
-            KR_LOG_INFO << "SetArkUIImageSrc drawable=" << drawable
-                        << " pixelmap=" << pm
-                        << " size(px)=" << img_w << "x" << img_h;
-        } else {
-            KR_LOG_INFO << "SetArkUIImageSrc drawable=" << drawable
-                        << " static pixelmap=null (maybe animated)";
-        }
-    }
-
+    
     auto nodeApi = GetNodeApi();
     ArkUI_AttributeItem src_attr_item = {.object = drawable};
     nodeApi->setAttribute(handle, NODE_IMAGE_SRC, &src_attr_item);
@@ -849,16 +818,14 @@ void SetArkUIImageCapInsets(ArkUI_NodeHandle handle, float top, float left, floa
     GetNodeApi()->setAttribute(handle, NODE_IMAGE_RESIZABLE, &item);
 }
 
-void SetArkUIImageSourceSize(ArkUI_NodeHandle handle, float width_vp, float height_vp) {
+void SetArkUIImageSourceSize(ArkUI_NodeHandle handle, float width_px, float height_px) {
     if (!handle) {
         return;
     }
-    // ArkUI 官方文档规定 NODE_IMAGE_SOURCE_SIZE 的两个 float 参数单位为 vp。
-    // 非正值不下发，避免把图源缩到 0。
-    if (width_vp <= 0.f || height_vp <= 0.f) {
+    if (width_px <= 0.f || height_px <= 0.f) {
         return;
     }
-    ArkUI_NumberValue value[] = {{.i32 = (int)width_vp}, {.i32 = (int)height_vp}};
+    ArkUI_NumberValue value[] = {{.i32 = static_cast<int>(width_px)}, {.i32 = static_cast<int>(height_px)}};
     ArkUI_AttributeItem item = {value, sizeof(value) / sizeof(ArkUI_NumberValue)};
     GetNodeApi()->setAttribute(handle, NODE_IMAGE_SOURCE_SIZE, &item);
 }

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.h
@@ -172,11 +172,11 @@ void ResetArkUIImageColorFilter(ArkUI_NodeHandle handle);
 void SetArkUIImageCapInsets(ArkUI_NodeHandle handle, float top, float left, float bottom, float right);
 
 /**
- * 设置 NODE_IMAGE_SOURCE_SIZE：图源解码后的宽高，**单位为 vp**（对齐 ArkUI 官方
+ * 设置 NODE_IMAGE_SOURCE_SIZE：图源解码后的宽高，**单位为 px**（对齐 ArkUI 官方
  * 文档语义）。用于把大图解码到与显示区域匹配的尺寸，避免过大位图浪费内存，也让
  * 后续 lattice 精确九宫格拉伸有更贴近视觉的采样源。传入非正值视为不设置。
  */
-void SetArkUIImageSourceSize(ArkUI_NodeHandle handle, float width_vp, float height_vp);
+void SetArkUIImageSourceSize(ArkUI_NodeHandle handle, float width_px, float height_px);
 
 /**
  * API 24+ 走 OH_Drawing_Lattice 精确九宫格；低版本 / 缺尺寸时回退到老的四值

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.h
@@ -45,6 +45,11 @@
 
 #define KUIKLY_ENABLE_ARKUI_NODE_VALID_CHECK 1
 
+// OH_Drawing_Lattice：native drawing 层的九宫格分割线对象，仅在
+// SetArkUIImageCapInsetsWithLattice 的可选输出参数里出现；这里做前向声明
+// 避免把 <native_drawing/drawing_lattice.h> 传递给所有引用本头文件的 TU。
+struct OH_Drawing_Lattice;
+
 class KRForwardArkTSView;
 class KRForwardArkTSViewV2;
 namespace kuikly {
@@ -165,6 +170,37 @@ void SetArkUIImageColorFilter(ArkUI_NodeHandle handle, const std::vector<float> 
 void ResetArkUIImageColorFilter(ArkUI_NodeHandle handle);
 
 void SetArkUIImageCapInsets(ArkUI_NodeHandle handle, float top, float left, float bottom, float right);
+
+/**
+ * 设置 NODE_IMAGE_SOURCE_SIZE：图源解码后的宽高，**单位为 vp**（对齐 ArkUI 官方
+ * 文档语义）。用于把大图解码到与显示区域匹配的尺寸，避免过大位图浪费内存，也让
+ * 后续 lattice 精确九宫格拉伸有更贴近视觉的采样源。传入非正值视为不设置。
+ */
+void SetArkUIImageSourceSize(ArkUI_NodeHandle handle, float width_vp, float height_vp);
+
+/**
+ * API 24+ 走 OH_Drawing_Lattice 精确九宫格；低版本 / 缺尺寸时回退到老的四值
+ * NODE_IMAGE_RESIZABLE 路径。
+ *
+ * @param top/left/bottom/right 四个边距单位为**图片自身像素坐标**（对齐 iOS
+ *        UIImage.resizableImageWithCapInsets 的 point 语义——鸿蒙图片没有 point
+ *        概念，直接用图片像素最自然）。lattice xDivs/yDivs 原生就吃图片像素，
+ *        因此内部不做任何 dpi 换算。fallback 到老四值路径时会自动 /dpi 转成 vp
+ *        再下发 NODE_IMAGE_RESIZABLE（老接口的原生单位）。
+ * @param image_width_px / image_height_px 原图像素尺寸，用于把边距转换成 lattice
+ *        整数分割线并做越界校验。传 <=0 表示图片尺寸未知（如未加载完成），此时
+ *        内部自动退回老四值路径以保持行为不变。
+ * @param out_lattice 可选输出参数。若非空且本次成功创建了 OH_Drawing_Lattice，
+ *        指针会通过 *out_lattice 交出，**销毁责任由调用方承担**（在合适时机调用
+ *        OH_Drawing_LatticeDestroy）；否则 *out_lattice 置 nullptr。传 nullptr
+ *        表示调用方不接管，函数内部将立即销毁 lattice（保底不泄漏，用于不关心
+ *        lattice 生命周期的调用方）。
+ *        背景：ArkUI setAttribute 是同步语义、内部会拷贝 lattice 分割线信息，
+ *        但实测过早销毁 lattice 会引发崩溃，因此实际生命周期需要延长到组件销毁。
+ */
+void SetArkUIImageCapInsetsWithLattice(ArkUI_NodeHandle handle, float top, float left, float bottom,
+                                       float right, float image_width_px, float image_height_px,
+                                       ::OH_Drawing_Lattice **out_lattice = nullptr);
 
 void ResetArkUIImageCapInsets(ArkUI_NodeHandle handle);
 


### PR DESCRIPTION

Motivation
----------
NODE_IMAGE_RESIZABLE four-value capInsets exhibits wrong stretching and edge-pixel distortion when image resolution and display size diverge. This change migrates the capInsets pipeline to API 24's OH_Drawing_Lattice precise 9-patch, aligning behavior with iOS UIImage.resizableImageWith CapInsets and Skia SkCanvas::drawImageLattice.

KRViewUtil (utility layer)
--------------------------
- New SetArkUIImageCapInsetsWithLattice: dispatches xDivs/yDivs to OH_Drawing_Lattice in image-native pixel coordinates; auto-falls back to the legacy four-value RESIZABLE path when API < 24 or image size is unknown.
- Weak-symbol declarations for OH_Drawing_LatticeCreate / _Destroy + runtime dual gate (OH_GetSdkApiVersion() >= 24 && symbols non-null); no #include <native_drawing/drawing_lattice.h> so low-version builds stay green.
- The weak-symbol block sits at file-top GLOBAL namespace. C++ elaborated type specifier rules make `struct X;` inside a namespace create a namespace-scoped type, causing mangled parameter type mismatch across TUs (kuikly::util::OH_Drawing_Lattice vs ::OH_Drawing_Lattice) and a real undefined-symbol at link time. Fix: keep the forward decls global so all TUs share ::OH_Drawing_Lattice; the function signature uses `::OH_Drawing_Lattice **out_lattice` with explicit global qualifier.
- New optional output parameter `out_lattice`: caller receives ownership of the created lattice; nullptr means caller opts out and the function best-effort destroys it (may crash but never leaks).

KRImageView (component layer)
-----------------------------
- Extract __scale__ from imageParams (image-native density ratio, e.g. @2x = 2) into capinset_image_scale_ (default 1.0 = "1 image px = 1 vp"). Key name and default value extracted as constants kImageParamKeyScale / DEFAULT_CAPINST_IMAGE_SCALE.
- ApplyCapInsetsWithLattice derives source scale directly from __scale__: source_scale = dpi / __scale__
    source_px    = original_img_px * source_scale
                 = (original_img_px / __scale__) * dpi
                 = image's vp size * dpi
  Strictly aligns with screen dpi, independent of view frame. The lattice
  xDivs/yDivs and image_width/height use the same source_scale so they
  live in the same coordinate system as the resampled pixmap.
- Loop guard (two locks). SetArkUIImageSourceSize triggers ArkUI re-decode
  which fires ON_COMPLETE and re-enters ApplyCapInsetsWithLattice; without
  guards this causes runaway size explosion:
    1) original_image_size_ / has_original_image_size_: first-frame
       snapshot of the ORIGINAL image pixel size; apply always uses this
       snapshot so each iteration produces a constant source size
       (idempotent by math). loaded_image_size_ keeps its original
       semantics (still refreshed every frame for the load_resolution
       callback).
    2) source_size_applied_ gate: within a src + __scale__ lifetime, only
       one NODE_IMAGE_SOURCE_SIZE dispatch is allowed; subsequent apply
       calls only re-send the lattice, never re-trigger decoding. The
       gate is released when src or __scale__ changes.
- Lattice lifetime pooling: new lattice_pool_ member. Every lattice
  created by ApplyCapInsetsWithLattice is captured via out_lattice and
  pushed into the pool. OnDestroy iterates the pool and calls
  OH_Drawing_LatticeDestroy (weak-symbol null-check first) then clears.
  Rationale: destroying the lattice right after setAttribute crashes in
  practice (ArkUI seems to hold an asynchronous reference), so the
  lifetime must be extended to component destruction.

Files
-----
- core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.h
- core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.cpp
- core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.h
- core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.cpp
- ohosApp/entry/src/main/ets/pages/Index.ets