### PR TITLE
fix(ios): enable edge anti-aliasing for rotated views

### DIFF
--- a/core-render-ios/Extension/Category/UIView+CSS.m
+++ b/core-render-ios/Extension/Category/UIView+CSS.m
@@ -1988,15 +1988,14 @@ typedef NS_OPTIONS(NSUInteger, CSSAnimationType) {
 #pragma mark - Transform Application
 
 - (void)applyTransformToView:(UIView *)view {
+    // Always use CATransform3D so that allowsEdgeAntialiasing takes effect for all rotations
+    view.transform = CGAffineTransformIdentity;
     if (self.is3D) {
-        // Clear 2D transform before applying 3D
-        view.transform = CGAffineTransformIdentity;
         view.layer.transform = self.transform3D;
     } else {
-        // Clear 3D transform before applying 2D
-        view.layer.transform = CATransform3DIdentity;
-        view.transform = self.affineTransform;
+        view.layer.transform = CATransform3DMakeAffineTransform(self.affineTransform);
     }
+    view.layer.allowsEdgeAntialiasing = YES;
 }
 
 @end

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/RotateAntiAliasingPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/RotateAntiAliasingPage.kt
@@ -1,0 +1,179 @@
+package com.tencent.kuikly.demo.pages
+
+import com.tencent.kuikly.core.annotations.Page
+import com.tencent.kuikly.core.base.*
+import com.tencent.kuikly.core.pager.Pager
+import com.tencent.kuikly.core.views.*
+import com.tencent.kuikly.demo.pages.demo.base.NavBar
+
+@Page("RotateAntiAliasingPage")
+internal class RotateAntiAliasingPage : Pager() {
+
+    override fun body(): ViewBuilder {
+        return {
+            View {
+                attr {
+                    size(pagerData.pageViewWidth, pagerData.pageViewHeight)
+                    backgroundColor(Color.WHITE)
+                }
+                NavBar { attr { title = "旋转抗锯齿测试" } }
+
+                // 说明文字
+                Text {
+                    attr {
+                        marginTop(10f)
+                        marginLeft(16f)
+                        marginRight(16f)
+                        text("以下旋转视图应显示平滑边缘（无锯齿）：")
+                        fontSize(14f)
+                        color(Color(0xFF666666.toInt()))
+                    }
+                }
+
+                // 不同角度旋转对比
+                View {
+                    attr {
+                        marginTop(20f)
+                        flexDirectionRow()
+                        justifyContentSpaceEvenly()
+                        alignItemsCenter()
+                        size(pagerData.pageViewWidth, 180f)
+                    }
+                    View {
+                        attr {
+                            size(60f, 60f)
+                            backgroundColor(Color.RED)
+                            transform(rotate = Rotate(15f))
+                        }
+                        Text { attr { text("15°"); fontSize(12f); color(Color.WHITE); marginTop(22f); alignSelfCenter() } }
+                    }
+                    View {
+                        attr {
+                            size(60f, 60f)
+                            backgroundColor(Color.BLUE)
+                            transform(rotate = Rotate(30f))
+                        }
+                        Text { attr { text("30°"); fontSize(12f); color(Color.WHITE); marginTop(22f); alignSelfCenter() } }
+                    }
+                    View {
+                        attr {
+                            size(60f, 60f)
+                            backgroundColor(Color(0xFF00AA00.toInt()))
+                            transform(rotate = Rotate(45f))
+                        }
+                        Text { attr { text("45°"); fontSize(12f); color(Color.WHITE); marginTop(22f); alignSelfCenter() } }
+                    }
+                    View {
+                        attr {
+                            size(60f, 60f)
+                            backgroundColor(Color(0xFFFF8800.toInt()))
+                            transform(rotate = Rotate(60f))
+                        }
+                        Text { attr { text("60°"); fontSize(12f); color(Color.WHITE); marginTop(22f); alignSelfCenter() } }
+                    }
+                }
+
+                // 大尺寸旋转 - 更容易观察边缘
+                Text {
+                    attr {
+                        marginTop(30f)
+                        marginLeft(16f)
+                        text("大尺寸旋转（更易观察边缘质量）：")
+                        fontSize(14f)
+                        color(Color(0xFF666666.toInt()))
+                    }
+                }
+                View {
+                    attr {
+                        marginTop(20f)
+                        flexDirectionRow()
+                        justifyContentSpaceEvenly()
+                        alignItemsCenter()
+                        size(pagerData.pageViewWidth, 200f)
+                    }
+                    // 大方块旋转
+                    View {
+                        attr {
+                            size(120f, 120f)
+                            backgroundColor(Color.RED)
+                            borderRadius(4f)
+                            transform(rotate = Rotate(30f))
+                        }
+                        Text {
+                            attr {
+                                text("旋转30°")
+                                fontSize(16f)
+                                color(Color.WHITE)
+                                marginTop(50f)
+                                alignSelfCenter()
+                            }
+                        }
+                    }
+                    View {
+                        attr {
+                            size(120f, 120f)
+                            backgroundColor(Color.BLUE)
+                            borderRadius(4f)
+                            transform(rotate = Rotate(45f))
+                        }
+                        Text {
+                            attr {
+                                text("旋转45°")
+                                fontSize(16f)
+                                color(Color.WHITE)
+                                marginTop(50f)
+                                alignSelfCenter()
+                            }
+                        }
+                    }
+                }
+
+                // 圆角 + 旋转
+                Text {
+                    attr {
+                        marginTop(30f)
+                        marginLeft(16f)
+                        text("圆角 + 旋转（锯齿最明显的场景）：")
+                        fontSize(14f)
+                        color(Color(0xFF666666.toInt()))
+                    }
+                }
+                View {
+                    attr {
+                        marginTop(20f)
+                        flexDirectionRow()
+                        justifyContentSpaceEvenly()
+                        alignItemsCenter()
+                        size(pagerData.pageViewWidth, 160f)
+                    }
+                    View {
+                        attr {
+                            size(100f, 100f)
+                            backgroundColor(Color(0xFFFF5500.toInt()))
+                            borderRadius(16f)
+                            transform(rotate = Rotate(20f))
+                        }
+                    }
+                    View {
+                        attr {
+                            size(100f, 100f)
+                            backgroundColor(Color(0xFF9900CC.toInt()))
+                            borderRadius(50f)
+                            transform(rotate = Rotate(45f))
+                        }
+                    }
+                    View {
+                        attr {
+                            size(100f, 100f)
+                            backgroundColor(Color(0xFF009999.toInt()))
+                            borderRadius(16f)
+                            border(Border(2f, BorderStyle.SOLID, Color.BLACK))
+                            transform(rotate = Rotate(33f))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

- **问题**：iOS 上旋转 View 时边缘出现明显锯齿
- **根因**：2D 旋转走 `CGAffineTransform`（不支持 `allowsEdgeAntialiasing`），3D 旋转虽走 `CATransform3D` 但也未启用该属性
- **修复**：统一所有旋转走 `CATransform3D` 路径 + 开启 `layer.allowsEdgeAntialiasing = YES`

## 修改内容

| 文件 | 变更 |
|------|------|
| `core-render-ios/Extension/Category/UIView+CSS.m` | `applyTransformToView:` 统一使用 `CATransform3DMakeAffineTransform` + `allowsEdgeAntialiasing` |
| `demo/.../RotateAntiAliasingPage.kt` | 新增 demo 页面，包含多种旋转角度 + 圆角组合，方便验证抗锯齿效果 |

## 性能影响

- `allowsEdgeAntialiasing` 仅在绘制旋转边缘时做采样，**无额外 GPU 内存开销**
- `CATransform3DMakeAffineTransform` 是零开销的矩阵格式转换
- 相比 `shouldRasterize`（需要位图缓存、动画时每帧重绘），本方案性能更优

## Test plan

- [ ] 在 iOS 设备上打开 `RotateAntiAliasingPage`，验证各角度旋转视图边缘平滑无锯齿
- [ ] 对比修复前后截图
- [ ] 验证旋转动画场景下无性能回退

🤖 Generated with [Claude Code](https://claude.com/claude-code)