### PR TITLE
fix(compose): sync pager snap edge align and touch-defer

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/container/SuperTouchManager.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/container/SuperTouchManager.kt
@@ -28,6 +28,7 @@ import com.tencent.kuikly.compose.ui.node.KNode
 import com.tencent.kuikly.compose.ui.platform.InteractionView
 import com.tencent.kuikly.compose.ui.scene.ComposeScene
 import com.tencent.kuikly.compose.ui.scene.ComposeScenePointer
+import com.tencent.kuikly.compose.scroller.TouchActivityTracker
 import com.tencent.kuikly.core.base.Attr.StyleConst
 import com.tencent.kuikly.core.base.event.Touch
 import com.tencent.kuikly.core.views.DivEvent
@@ -40,6 +41,7 @@ class SuperTouchManager {
     private lateinit var scene: ComposeScene
 
     private var layoutNode: KNode<*>? = null
+    private val touchActivityOwner = Any()
 
     private var _useSyncMove: Boolean? = null
     private val DivEvent.useSyncMove
@@ -61,6 +63,7 @@ class SuperTouchManager {
 
     fun DivEvent.setTouchDown(isSync: Boolean) {
         touchDown(isSync) {
+            TouchActivityTracker.onTouchDown(container.getPager().pageData, touchActivityOwner)
             val result = touchesDelegate.onTouchesEvent(it.touches, PointerEventType.Press, it.timestamp)
             if (result.dispatchedToAPointerInputModifier) {
                 getView()?.getViewAttr()?.forceUpdate = true
@@ -72,6 +75,7 @@ class SuperTouchManager {
     internal fun DivEvent.setTouchUp(isSync: Boolean) {
         touchUp(isSync) {
             touchesDelegate.onTouchesEvent(it.touches, PointerEventType.Release, it.timestamp, it.consumed)
+            TouchActivityTracker.onTouchEnd(container.getPager().pageData, touchActivityOwner)
             if (container.getViewAttr().getProp(StyleConst.PREVENT_TOUCH) == true) {
                 container.getViewAttr().preventTouch(false)
                 if (useSyncMove) {
@@ -98,6 +102,7 @@ class SuperTouchManager {
     internal fun DivEvent.setTouchCancel(isSync: Boolean) {
         touchCancel(isSync) {
             touchesDelegate.onTouchesEvent(it.touches, PointerEventType.Release, it.timestamp, true)
+            TouchActivityTracker.onTouchEnd(container.getPager().pageData, touchActivityOwner)
             if (container.getViewAttr().getProp(StyleConst.PREVENT_TOUCH) == true) {
                 container.getViewAttr().preventTouch(false)
                 if (useSyncMove) {

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
@@ -61,6 +61,7 @@ import com.tencent.kuikly.compose.ui.unit.dp
 import com.tencent.kuikly.compose.scroller.applyScrollViewOffsetDelta
 import com.tencent.kuikly.compose.scroller.convertAnimationSpecToSpringAnimation
 import com.tencent.kuikly.compose.scroller.kuiklyInfo
+import com.tencent.kuikly.compose.scroller.TouchActivityTracker
 import com.tencent.kuikly.compose.profiler.RecompositionProfiler
 import com.tencent.kuikly.compose.material3.internal.identityHashCode
 import com.tencent.kuikly.core.collection.fastMutableMapOf
@@ -480,6 +481,23 @@ abstract class PagerState internal constructor(
                 "targetPage=$targetPage targetKey=$targetKey pageCount=$pageCount " +
                 "desyncPages=$desyncPages anchorCorrection=${kuiklyInfo.snapAnchorOffsetCorrection}"
         }
+        if (hasSnapReachedTarget(kuiklyInfo.contentOffset)) {
+            snapTargetReachedAlignmentRequested = true
+            // Native will not emit scroll callbacks for a no-op setContentOffset. If compose and
+            // native are already desynced at that edge, rebase onto the current page instead of
+            // teleporting to the intended neighbor; the next gesture can animate normally.
+            if (desyncPages != 0) {
+                val rebasePage = currentPage.coerceInPageRange()
+                pagerSnapDebugLog {
+                    "snapAlreadyAtTargetRebaseCurrent: stateId=$debugPagerStateId " +
+                        "fromTargetPage=$snapTargetRelocatedPage toCurrentPage=$rebasePage " +
+                        "contentOffset=${kuiklyInfo.contentOffset} desyncPages=$desyncPages"
+                }
+                snapTargetRelocatedPage = rebasePage
+                snapTargetItemKey = null
+            }
+            scheduleScrollViewOffsetAlignment(SNAP_MEASURE_JOB_INITIAL_DELAY_MS)
+        }
     }
 
     internal fun hasSnapReachedTarget(contentOffset: Int): Boolean {
@@ -534,6 +552,15 @@ abstract class PagerState internal constructor(
         snapLastObservedContentOffset = 0
         kuiklyInfo.snapAnchorOffsetCorrection = 0
         kuiklyInfo.appleScrollViewOffsetJob?.cancel(ScrollViewOffsetAlignmentCancellation)
+    }
+
+    /**
+     * Re-schedule idle compose/native offset alignment after a native gesture settles.
+     * Align jobs defer while touch is active; scrollEnd re-arms so prepend desync can still
+     * be repaired once the finger is up.
+     */
+    internal fun requestScrollViewOffsetAlignmentAfterGesture() {
+        scheduleScrollViewOffsetAlignment(SNAP_MEASURE_JOB_INITIAL_DELAY_MS)
     }
 
     private fun scheduleScrollViewOffsetAlignment(
@@ -628,6 +655,19 @@ abstract class PagerState internal constructor(
         scheduledLayoutGeneration: Int,
         scheduledPageCount: Int
     ) {
+        if (TouchActivityTracker.isTouchActive(kuiklyInfo.pageData)) {
+            pagerSnapDebugLog {
+                "deferAlignDuringActiveTouch: stateId=$debugPagerStateId " +
+                    "orientation=${layoutInfo.orientation} pageCount=$pageCount " +
+                    "currentPage=$currentPage isScrollInProgress=$isScrollInProgress " +
+                    "isDragging=${kuiklyInfo.scrollView?.isDragging} " +
+                    "composeOffset=${currentAbsoluteScrollOffset().toInt()} " +
+                    "contentOffset=${kuiklyInfo.contentOffset}"
+            }
+            scheduleScrollViewOffsetAlignment(SNAP_MEASURE_JOB_INITIAL_DELAY_MS, layoutSize)
+            return
+        }
+
         val contentOffsetInt = scrollableState.kuiklyInfo.contentOffset
 
         if (scheduledLayoutGeneration != alignmentLayoutGeneration) {
@@ -811,6 +851,29 @@ abstract class PagerState internal constructor(
         if (isSnapAnimating) {
             clearSnapTrackingAfterAlignment()
         }
+    }
+
+    /**
+     * Expand the native content bounds as soon as a new pager measure result is applied.
+     *
+     * Shrinking remains in [updateScrollViewContentSize], which runs with the delayed offset
+     * alignment. This prevents a data removal or layout change from clamping the native offset
+     * while a gesture or snap is still settling.
+     */
+    private fun expandScrollViewContentSize(layoutSize: Int) {
+        val requiredContentSize = (maxScrollOffset + layoutSize).toInt()
+        if (kuiklyInfo.currentContentSize >= requiredContentSize) {
+            return
+        }
+        pagerSnapDebugLog {
+            "pagerExpandContentSize: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
+                "maxScrollOffset=$maxScrollOffset layoutSize=$layoutSize " +
+                "requiredContentSize=$requiredContentSize oldContentSize=${kuiklyInfo.currentContentSize} " +
+                "pageCount=$pageCount pageSize=$pageSize pageSpacing=$pageSpacing " +
+                "composeOffset=${kuiklyInfo.composeOffset.toInt()} contentOffset=${kuiklyInfo.contentOffset}"
+        }
+        kuiklyInfo.currentContentSize = requiredContentSize
+        kuiklyInfo.updateContentSizeToRender()
     }
 
     private fun updateScrollViewContentSize(layoutSize: Int) {
@@ -1434,6 +1497,7 @@ abstract class PagerState internal constructor(
         minScrollOffset = result.calculateNewMinScrollOffset(pageCount)
         val layoutSize = if (result.orientation == Orientation.Horizontal)
             result.viewportSize.width else result.viewportSize.height
+        expandScrollViewContentSize(layoutSize)
         if (isSnapAnimating && snapStartDesyncPages != 0) {
             logSnapFrameSnapshot(
                 stage = "measureDuringDesyncedSnap",

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/TouchActivityTracker.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/TouchActivityTracker.kt
@@ -1,0 +1,45 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.compose.scroller
+
+import com.tencent.kuikly.core.pager.PageData
+
+/**
+ * Tracks the raw pointer lifetime for each Kuikly page.
+ *
+ * Native RecyclerView does not enter DRAGGING until MOVE crosses touch slop. Pager offset
+ * alignment must also be blocked between DOWN and that transition, otherwise it can move child
+ * frames while the pending gesture still owns the old native offset.
+ */
+internal object TouchActivityTracker {
+    private val activeOwnersByPage = mutableMapOf<PageData, MutableSet<Any>>()
+
+    fun onTouchDown(pageData: PageData, owner: Any) {
+        activeOwnersByPage.getOrPut(pageData) { mutableSetOf() }.add(owner)
+    }
+
+    fun onTouchEnd(pageData: PageData, owner: Any) {
+        val activeOwners = activeOwnersByPage[pageData] ?: return
+        activeOwners.remove(owner)
+        if (activeOwners.isEmpty()) {
+            activeOwnersByPage.remove(pageData)
+        }
+    }
+
+    fun isTouchActive(pageData: PageData?): Boolean {
+        return pageData != null && activeOwnersByPage[pageData]?.isNotEmpty() == true
+    }
+}

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/TouchActivityTracker.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/TouchActivityTracker.kt
@@ -15,6 +15,8 @@
 
 package com.tencent.kuikly.compose.scroller
 
+import com.tencent.kuikly.core.collection.fastHashMapOf
+import com.tencent.kuikly.core.collection.fastMutableSetOf
 import com.tencent.kuikly.core.pager.PageData
 
 /**
@@ -25,10 +27,10 @@ import com.tencent.kuikly.core.pager.PageData
  * frames while the pending gesture still owns the old native offset.
  */
 internal object TouchActivityTracker {
-    private val activeOwnersByPage = mutableMapOf<PageData, MutableSet<Any>>()
+    private val activeOwnersByPage = fastHashMapOf<PageData, MutableSet<Any>>()
 
     fun onTouchDown(pageData: PageData, owner: Any) {
-        activeOwnersByPage.getOrPut(pageData) { mutableSetOf() }.add(owner)
+        activeOwnersByPage.getOrPut(pageData) { fastMutableSetOf() }.add(owner)
     }
 
     fun onTouchEnd(pageData: PageData, owner: Any) {

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
@@ -269,10 +269,8 @@ fun SubcomposeLayout(
             }
 
             if (scrollableState is PagerState || scrollableState is DrawerInternalPagerState) {
-                if (scrollableState is PagerState) {
-                    dragBegin {
-                        kuiklyInfo.ignoreScrollOffset = null
-                    }
+                dragBegin {
+                    kuiklyInfo.ignoreScrollOffset = null
                 }
                 willDragEndBySync(isSync = scrollableState is PagerState && !isAndroid, handler = {
                     val viewportSize = kuiklyInfo.viewportSize

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
@@ -269,6 +269,11 @@ fun SubcomposeLayout(
             }
 
             if (scrollableState is PagerState || scrollableState is DrawerInternalPagerState) {
+                if (scrollableState is PagerState) {
+                    dragBegin {
+                        kuiklyInfo.ignoreScrollOffset = null
+                    }
+                }
                 willDragEndBySync(isSync = scrollableState is PagerState && !isAndroid, handler = {
                     val viewportSize = kuiklyInfo.viewportSize
                     val scaleParams = it.scaleWithDensity(kuiklyInfo.getDensity())
@@ -307,6 +312,9 @@ fun SubcomposeLayout(
                 // 仅触摸滑动结束会回调，api调用和bounce回弹都不会触发
                 // / back是回滑,forward是前滑
                 scrollableState.kuiklyOnScrollEnd(scaleParams)
+                // Touch-active align jobs only reschedule while the finger is down; re-arm once
+                // the gesture settles so prepend desync can still be repaired.
+                (scrollableState as? PagerState)?.requestScrollViewOffsetAlignmentAfterGesture()
             }
             dragEnd {
                 val scaleParams = it.scaleWithDensity(kuiklyInfo.getDensity())


### PR DESCRIPTION
## Summary
- Clear stale `ignoreScrollOffset` on `dragBegin` so a following settle is not blocked by a leftover ignore guard
- When native is already at the snap target, schedule alignment immediately; if compose/native are desynced, rebase to the **current** page instead of teleporting to the neighbor
- Defer compose/native offset alignment while SuperTouch is active, and re-arm alignment on `scrollEnd`
- Expand native content size on measure growth so newly appended pages remain scrollable

Synced from ComposeOnKuikly `feature/compose` pager settle fixes that were still missing on public `main` (MR !113 / !115 equivalents). Base is public `main` only; no internal-only files.

## Test plan
- [ ] VerticalPager: swipe many pages with prepend; release past 50% with near-zero velocity still settles forward
- [ ] After prepend desync at top edge: brief no-op settle may keep current page; next swipe animates normally (no teleport jump)
- [ ] No black-screen / wrong-page jump while finger is still down during prepend align
- [ ] Append near last page still allows scrolling to the new last item


Made with [Cursor](https://cursor.com)