### PR TITLE
fix(pager): fix settledPage/isScrollInProgress spurious values (#1560)

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
@@ -419,7 +419,7 @@ abstract class PagerState internal constructor(
     }
 
     /** Native setContentOffset(animated=true) snap is in progress. */
-    internal var isSnapAnimating = false
+    internal var isSnapAnimating by mutableStateOf(false)
 
     /** Native content offset that the snap animation is settling to. */
     internal var snapTargetContentOffset = 0
@@ -1026,6 +1026,7 @@ abstract class PagerState internal constructor(
                 "pageCount=$pageCount snapTargetPage=$snapTargetRelocatedPage " +
                 "snapTargetKey=$snapTargetItemKey snapStartDesyncPages=$snapStartDesyncPages"
         }
+        settledPageState = currentPage
         isSnapAnimating = false
         snapTargetContentOffset = 0
         snapStartPageCount = 0
@@ -1166,7 +1167,7 @@ abstract class PagerState internal constructor(
      * @sample androidx.compose.foundation.samples.ObservingStateChangesInPagerStateSample
      */
     val settledPage by derivedStateOf(structuralEqualityPolicy()) {
-        if (isScrollInProgress) {
+        if (isScrollInProgress || isSnapAnimating) {
             settledPageState
         } else {
             this.currentPage

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
@@ -99,6 +99,13 @@ class KuiklyScrollInfo {
     var isDragging: Boolean by mutableStateOf(false)
 
     /**
+     * True while a real user gesture scroll is in progress (dragBegin→scrollEnd).
+     * Used to distinguish genuine gesture-driven scrolls from programmatic offset
+     * sync/correction events, preventing false isScrollInProgress=true on iOS.
+     */
+    var gestureScrollActive: Boolean = false
+
+    /**
      * List height cache
      */
     internal var itemMainSpaceCache = hashMapOf<Any, Int>()
@@ -190,6 +197,7 @@ class KuiklyScrollInfo {
         composeOffset = 0f
         contentOffset = 0
         isDragging = false
+        gestureScrollActive = false
         offsetDirty = false
 
         // Reset content size related (reinitialize based on current density)

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollableState.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollableState.kt
@@ -72,12 +72,16 @@ internal class KuiklyScrollableState(val onDelta: (Float) -> Float) : Scrollable
     }
 
     fun kuiklyOnScroll(pixels: Float): Float {
-        isScrollingState.value = true
         if (pixels.isNaN()) return 0f
         val delta = onDelta(pixels)
         isLastScrollForwardState.value = delta > 0
         isLastScrollBackwardState.value = delta < 0
         return delta
+    }
+
+    fun kuiklyOnGestureScroll(pixels: Float): Float {
+        isScrollingState.value = true
+        return kuiklyOnScroll(pixels)
     }
 
     fun kuiklyOnScrollEnd(params: ScrollParams) {

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ScrollableStateExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ScrollableStateExtensions.kt
@@ -44,7 +44,8 @@ internal val ScrollableState.kuiklyInfo: KuiklyScrollInfo
     }
 
 /**
- * Handle scroll events
+ * Handle scroll events (non-gesture: programmatic offset sync / correction).
+ * Does NOT set isScrollInProgress=true.
  * @param delta scroll offset
  * @return actual consumed offset
  */
@@ -56,6 +57,23 @@ internal fun ScrollableState.kuiklyOnScroll(delta: Float): Float = when (this) {
     is LazyStaggeredGridState -> scrollableState.kuiklyOnScroll(delta)
     is ScrollState -> scrollableState.kuiklyOnScroll(delta)
     is KuiklyScrollableState -> kuiklyOnScroll(delta)
+    else -> dispatchRawDelta(delta)
+}
+
+/**
+ * Handle real user gesture scroll events.
+ * Sets isScrollInProgress=true in addition to applying the delta.
+ * @param delta scroll offset
+ * @return actual consumed offset
+ */
+internal fun ScrollableState.kuiklyOnGestureScroll(delta: Float): Float = when (this) {
+    is LazyListState -> scrollableState.kuiklyOnGestureScroll(delta)
+    is PagerState -> scrollableState.kuiklyOnGestureScroll(delta)
+    is DrawerInternalPagerState -> scrollableState.kuiklyOnGestureScroll(delta)
+    is LazyGridState -> scrollableState.kuiklyOnGestureScroll(delta)
+    is LazyStaggeredGridState -> scrollableState.kuiklyOnGestureScroll(delta)
+    is ScrollState -> scrollableState.kuiklyOnGestureScroll(delta)
+    is KuiklyScrollableState -> kuiklyOnGestureScroll(delta)
     else -> dispatchRawDelta(delta)
 }
 

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
@@ -83,6 +83,7 @@ import com.tencent.kuikly.compose.scroller.isAtTop
 import com.tencent.kuikly.compose.scroller.lastItemVisible
 import com.tencent.kuikly.compose.scroller.kuiklyInfo
 import com.tencent.kuikly.compose.scroller.kuiklyOnScroll
+import com.tencent.kuikly.compose.scroller.kuiklyOnGestureScroll
 import com.tencent.kuikly.compose.scroller.kuiklyOnScrollEnd
 import com.tencent.kuikly.compose.scroller.kuiklyWillDragEnd
 import com.tencent.kuikly.compose.scroller.tryExpandStartSize
@@ -271,6 +272,7 @@ fun SubcomposeLayout(
             if (scrollableState is PagerState || scrollableState is DrawerInternalPagerState) {
                 dragBegin {
                     kuiklyInfo.ignoreScrollOffset = null
+                    kuiklyInfo.gestureScrollActive = true
                 }
                 willDragEndBySync(isSync = scrollableState is PagerState && !isAndroid, handler = {
                     val viewportSize = kuiklyInfo.viewportSize
@@ -309,6 +311,7 @@ fun SubcomposeLayout(
 
                 // 仅触摸滑动结束会回调，api调用和bounce回弹都不会触发
                 // / back是回滑,forward是前滑
+                kuiklyInfo.gestureScrollActive = false
                 scrollableState.kuiklyOnScrollEnd(scaleParams)
                 // Touch-active align jobs only reschedule while the finger is down; re-arm once
                 // the gesture settles so prepend desync can still be repaired.
@@ -384,7 +387,14 @@ fun SubcomposeLayout(
                 }
 
                 // 触发compose滑动，并重新布局
-                val comsumedDelta = scrollableState.kuiklyOnScroll(delta)
+                // 真实手势路径（dragBegin 已开启 gestureScrollActive 或 scaleParams 标记 isDragging）
+                // 会置 isScrollInProgress=true；程序化/对齐修正路径只做位移，不影响 isScrollInProgress
+                val isGestureScroll = kuiklyInfo.gestureScrollActive || scaleParams.isDragging
+                val comsumedDelta = if (isGestureScroll) {
+                    scrollableState.kuiklyOnGestureScroll(delta)
+                } else {
+                    scrollableState.kuiklyOnScroll(delta)
+                }
 
                 // 尝试扩容
                 scrollableState.tryExpandStartSize(offset, true)

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/debug/BugReproHorizontalPagerPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/debug/BugReproHorizontalPagerPage.kt
@@ -1,0 +1,255 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.demo.pages.debug
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import com.tencent.kuikly.compose.ComposeContainer
+import com.tencent.kuikly.compose.foundation.background
+import com.tencent.kuikly.compose.foundation.layout.Arrangement
+import com.tencent.kuikly.compose.foundation.layout.Box
+import com.tencent.kuikly.compose.foundation.layout.Column
+import com.tencent.kuikly.compose.foundation.layout.Row
+import com.tencent.kuikly.compose.foundation.layout.fillMaxSize
+import com.tencent.kuikly.compose.foundation.layout.fillMaxWidth
+import com.tencent.kuikly.compose.foundation.layout.height
+import com.tencent.kuikly.compose.foundation.layout.padding
+import com.tencent.kuikly.compose.foundation.layout.size
+import com.tencent.kuikly.compose.foundation.pager.HorizontalPager
+import com.tencent.kuikly.compose.foundation.pager.rememberPagerState
+import com.tencent.kuikly.compose.foundation.shape.RoundedCornerShape
+import com.tencent.kuikly.compose.material3.Text
+import com.tencent.kuikly.compose.setContent
+import com.tencent.kuikly.compose.ui.Alignment
+import com.tencent.kuikly.compose.ui.Modifier
+import com.tencent.kuikly.compose.ui.draw.clip
+import com.tencent.kuikly.compose.ui.graphics.Color
+import com.tencent.kuikly.compose.ui.text.font.FontWeight
+import com.tencent.kuikly.compose.ui.text.style.TextAlign
+import com.tencent.kuikly.compose.ui.unit.dp
+import com.tencent.kuikly.compose.ui.unit.sp
+import com.tencent.kuikly.core.annotations.Page
+
+@Page("BugReproHorizontalPagerPage")
+internal class BugReproHorizontalPagerPage : ComposeContainer() {
+
+    override fun willInit() {
+        super.willInit()
+        setContent {
+            HorizontalPagerReproScreen(
+                topInset = pagerData.safeAreaInsets.top,
+                bottomInset = pagerData.safeAreaInsets.bottom,
+            )
+        }
+    }
+}
+
+private data class PagerDemoItem(
+    val title: String,
+    val description: String,
+    val color: Color,
+)
+
+private val PagerDemoItems = listOf(
+    PagerDemoItem("Page 1", "从第一页开始滑动", Color(0xFF6750A4)),
+    PagerDemoItem("Page 2", "currentPage 会跟随最近页面变化", Color(0xFF006A6A)),
+    PagerDemoItem("Page 3", "settledPage 会等待滚动结束", Color(0xFF9C4146)),
+    PagerDemoItem("Page 4", "慢慢拖动，观察两者差异", Color(0xFF3F6374)),
+    PagerDemoItem("Page 5", "快速滑动，观察日志顺序", Color(0xFF795548)),
+    PagerDemoItem("Page 6", "最后一个演示页面", Color(0xFF386A20)),
+)
+
+@Composable
+private fun HorizontalPagerReproScreen(
+    topInset: Float,
+    bottomInset: Float,
+) {
+    val pagerState = rememberPagerState(pageCount = { PagerDemoItems.size })
+    val currentPage = pagerState.currentPage
+    val settledPage = pagerState.settledPage
+    val isScrollInProgress = pagerState.isScrollInProgress
+
+    LaunchedEffect(currentPage) {
+        logPageChange(
+            changedState = "currentPage",
+            changedValue = currentPage.toString(),
+            currentPage = pagerState.currentPage,
+            settledPage = pagerState.settledPage,
+            isScrollInProgress = pagerState.isScrollInProgress,
+        )
+    }
+    LaunchedEffect(settledPage) {
+        logPageChange(
+            changedState = "settledPage",
+            changedValue = settledPage.toString(),
+            currentPage = pagerState.currentPage,
+            settledPage = pagerState.settledPage,
+            isScrollInProgress = pagerState.isScrollInProgress,
+        )
+    }
+    LaunchedEffect(isScrollInProgress) {
+        logPageChange(
+            changedState = "isScrollInProgress",
+            changedValue = isScrollInProgress.toString(),
+            currentPage = pagerState.currentPage,
+            settledPage = pagerState.settledPage,
+            isScrollInProgress = pagerState.isScrollInProgress,
+        )
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFF7F7FA))
+            .padding(
+                top = topInset.dp + 20.dp,
+                bottom = bottomInset.dp + 20.dp,
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "HorizontalPager Bug #1560",
+            color = Color(0xFF1B1B1F),
+            fontSize = 24.sp,
+            fontWeight = FontWeight(600),
+        )
+        Text(
+            text = "左右滑动页面，查看控制台日志",
+            modifier = Modifier.padding(top = 8.dp),
+            color = Color(0xFF74747B),
+            fontSize = 14.sp,
+        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 20.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            PagerStateCard(
+                label = "currentPage",
+                value = currentPage.toString(),
+                modifier = Modifier.weight(1f),
+            )
+            PagerStateCard(
+                label = "settledPage",
+                value = settledPage.toString(),
+                modifier = Modifier.weight(1f),
+            )
+            PagerStateCard(
+                label = "isScrollInProgress",
+                value = isScrollInProgress.toString(),
+                modifier = Modifier.weight(1f),
+            )
+        }
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+        ) { page ->
+            val item = PagerDemoItems[page]
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 24.dp)
+                    .clip(RoundedCornerShape(24.dp))
+                    .background(item.color),
+                contentAlignment = Alignment.Center,
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = item.title,
+                        color = Color.White,
+                        fontSize = 34.sp,
+                        fontWeight = FontWeight(700),
+                    )
+                    Text(
+                        text = item.description,
+                        modifier = Modifier
+                            .padding(top = 12.dp)
+                            .padding(horizontal = 24.dp),
+                        color = Color(0xD9FFFFFF),
+                        fontSize = 15.sp,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+        Row(
+            modifier = Modifier
+                .height(36.dp)
+                .padding(top = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            PagerDemoItems.indices.forEach { page ->
+                Box(
+                    modifier = Modifier
+                        .size(if (page == currentPage) 10.dp else 8.dp)
+                        .clip(RoundedCornerShape(5.dp))
+                        .background(
+                            if (page == currentPage) Color(0xFF6750A4)
+                            else Color(0xFFD0CDD5),
+                        ),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PagerStateCard(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(16.dp))
+            .background(Color.White)
+            .padding(vertical = 14.dp, horizontal = 4.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = label,
+            color = Color(0xFF74747B),
+            fontSize = 11.sp,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = value,
+            modifier = Modifier.padding(top = 4.dp),
+            color = Color(0xFF1B1B1F),
+            fontSize = 18.sp,
+            fontWeight = FontWeight(600),
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+private fun logPageChange(
+    changedState: String,
+    changedValue: String,
+    currentPage: Int,
+    settledPage: Int,
+    isScrollInProgress: Boolean,
+) {
+    val message = "[BugReproPager] $changedState changed to $changedValue; " +
+        "currentPage=$currentPage, settledPage=$settledPage, isScrollInProgress=$isScrollInProgress"
+    println(message)
+}


### PR DESCRIPTION
## Summary

- `settledPage` spuriously jumps to 0 on Android and gets stuck on iOS during `HorizontalPager` swipe
- `isScrollInProgress` is incorrectly `true` at rest on iOS

## Root Causes

1. **`isScrollInProgress` guard bypass**: `kuiklyOnScroll` (native bridge path) sets `isScrollingState=true` before `PagerState.scroll()` can snapshot `settledPageState`, leaving it at its initial value (0)
2. **`isSnapAnimating` not observable**: was a plain `var`, so `settledPage`'s `derivedStateOf` couldn't react to snap completion
3. **iOS `scrollEnd` missing**: programmatic/correction scroll events were incorrectly setting `isScrollInProgress=true`

## Changes

- `PagerState.kt`: `isSnapAnimating` → `mutableStateOf`; `settledPage` guard extended to `isScrollInProgress || isSnapAnimating`; snapshot `settledPageState = currentPage` in `clearSnapTrackingAfterAlignment()`
- `KuiklyScrollInfo.kt`: add `gestureScrollActive` flag; reset in `resetForNewScrollView()`
- `KuiklyScrollableState.kt`: split `kuiklyOnScroll` (offset only) from `kuiklyOnGestureScroll` (also sets `isScrollInProgress=true`)
- `ScrollableStateExtensions.kt`: add `kuiklyOnGestureScroll` dispatch path
- `SubcomposeLayout.kt`: set `gestureScrollActive=true` on `dragBegin`, clear on `scrollEnd`; route `scroll` callback to gesture vs non-gesture path accordingly

## Test

Demo page `BugReproHorizontalPagerPage` added for manual verification. Swipe between pages and observe console logs — `settledPage` should stay at the start page during swipe and update only after snap completes; `isScrollInProgress` should be `false` at rest.

Fixes #1560