### PR TITLE
feat(core): add cross-platform Chart component

### DIFF
--- a/core/build.1.4.20.gradle.kts
+++ b/core/build.1.4.20.gradle.kts
@@ -56,6 +56,12 @@ kotlin {
     }
 
     val commonMain by sourceSets.getting
+    val commonTest by sourceSets.getting {
+        dependencies {
+            implementation(kotlin("test-common"))
+            implementation(kotlin("test-annotations-common"))
+        }
+    }
 
 }
 

--- a/core/build.1.5.31.gradle.kts
+++ b/core/build.1.5.31.gradle.kts
@@ -56,6 +56,11 @@ kotlin {
             compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31")
         }
     }
+    val commonTest by sourceSets.getting {
+        dependencies {
+            implementation(kotlin("test"))
+        }
+    }
 
     val androidMain by sourceSets.getting {
         dependsOn(commonMain)

--- a/core/build.1.6.21.gradle.kts
+++ b/core/build.1.6.21.gradle.kts
@@ -57,6 +57,11 @@ kotlin {
                 compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21")
             }
         }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
 
         val androidMain by getting {
             dependsOn(commonMain)

--- a/core/build.1.7.20.gradle.kts
+++ b/core/build.1.7.20.gradle.kts
@@ -54,6 +54,11 @@ kotlin {
     // sourceSets
     sourceSets {
         val commonMain by getting
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
         val appleMain by sourceSets.creating {
             dependsOn(commonMain)
         }

--- a/core/build.1.8.21.gradle.kts
+++ b/core/build.1.8.21.gradle.kts
@@ -54,6 +54,11 @@ kotlin {
     // sourceSets
     sourceSets {
         val commonMain by getting
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
         val appleMain by sourceSets.creating {
             dependsOn(commonMain)
         }

--- a/core/build.1.9.22.gradle.kts
+++ b/core/build.1.9.22.gradle.kts
@@ -76,6 +76,11 @@ kotlin {
     // sourceSets
     sourceSets {
         val commonMain by getting
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
         val appleMain by sourceSets.creating {
             dependsOn(commonMain)
         }

--- a/core/build.2.0.21.gradle.kts
+++ b/core/build.2.0.21.gradle.kts
@@ -70,6 +70,11 @@ kotlin {
 
     sourceSets {
         val commonMain by getting
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
         val appleMain by sourceSets.creating {
             dependsOn(commonMain)
         }

--- a/core/build.2.0.ohos.gradle.kts
+++ b/core/build.2.0.ohos.gradle.kts
@@ -88,6 +88,11 @@ kotlin {
     // sourceSets
     sourceSets {
         val commonMain by getting
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
         val appleMain by sourceSets.creating {
             dependsOn(commonMain)
         }

--- a/core/build.2.1.21.gradle.kts
+++ b/core/build.2.1.21.gradle.kts
@@ -70,6 +70,11 @@ kotlin {
 
     sourceSets {
         val commonMain by getting
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
         val appleMain by sourceSets.creating {
             dependsOn(commonMain)
         }

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartLayoutEngine.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartLayoutEngine.kt
@@ -29,7 +29,7 @@ internal data class ChartRect(
     val left: Float,
     val top: Float,
     val right: Float,
-    val bottom: Float,
+    val bottom: Float
 ) {
     val width: Float get() = (right - left).coerceAtLeast(0f)
     val height: Float get() = (bottom - top).coerceAtLeast(0f)
@@ -40,14 +40,14 @@ internal data class ChartCoordinate(val x: Float, val y: Float)
 internal data class ChartScale(
     val minimum: Float,
     val maximum: Float,
-    val ticks: List<Float>,
+    val ticks: List<Float>
 )
 
 internal data class ChartLayout(
     val plot: ChartRect,
     val categoryCount: Int,
     val scale: ChartScale,
-    val barSeriesCount: Int,
+    val barSeriesCount: Int
 ) {
     val bandWidth: Float
         get() = if (categoryCount == 0) 0f else plot.width / categoryCount
@@ -91,7 +91,7 @@ internal data class ChartLayout(
             left = left,
             top = min(zeroY, valueY),
             right = left + width,
-            bottom = max(zeroY, valueY),
+            bottom = max(zeroY, valueY)
         )
     }
 }
@@ -105,7 +105,7 @@ internal object ChartLayoutEngine {
         requestedTickCount: Int,
         includeZero: Boolean,
         minimumOverride: Float,
-        maximumOverride: Float,
+        maximumOverride: Float
     ): ChartLayout {
         val safeWidth = width.coerceAtLeast(0f)
         val safeHeight = height.coerceAtLeast(0f)
@@ -115,7 +115,7 @@ internal object ChartLayoutEngine {
             left = plotLeft,
             top = plotTop,
             right = (safeWidth - insets.right).coerceIn(plotLeft, safeWidth),
-            bottom = (safeHeight - insets.bottom).coerceIn(plotTop, safeHeight),
+            bottom = (safeHeight - insets.bottom).coerceIn(plotTop, safeHeight)
         )
         val values = data.series
             .flatMap { it.values }
@@ -129,13 +129,13 @@ internal object ChartLayoutEngine {
             requestedTickCount = requestedTickCount,
             includeZero = shouldIncludeZero,
             minimumOverride = minimumOverride,
-            maximumOverride = maximumOverride,
+            maximumOverride = maximumOverride
         )
         return ChartLayout(
             plot = plot,
             categoryCount = data.categories.size,
             scale = scale,
-            barSeriesCount = data.series.count { it.type == ChartSeriesType.BAR },
+            barSeriesCount = data.series.count { it.type == ChartSeriesType.BAR }
         )
     }
 
@@ -144,11 +144,19 @@ internal object ChartLayoutEngine {
         requestedTickCount: Int,
         includeZero: Boolean,
         minimumOverride: Float,
-        maximumOverride: Float,
+        maximumOverride: Float
     ): ChartScale {
         val tickCount = requestedTickCount.coerceIn(2, 10)
-        var minimum = values.minOrNull() ?: 0f
-        var maximum = values.maxOrNull() ?: 1f
+        var minimum = 0f
+        var maximum = 1f
+        if (values.isNotEmpty()) {
+            minimum = values[0]
+            maximum = values[0]
+            values.forEach { value ->
+                minimum = min(minimum, value)
+                maximum = max(maximum, value)
+            }
+        }
 
         if (includeZero) {
             minimum = min(minimum, 0f)

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartLayoutEngine.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartLayoutEngine.kt
@@ -1,0 +1,242 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.core.views.chart
+
+import kotlin.math.abs
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.log10
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.round
+import kotlin.math.roundToInt
+
+internal data class ChartRect(
+    val left: Float,
+    val top: Float,
+    val right: Float,
+    val bottom: Float,
+) {
+    val width: Float get() = (right - left).coerceAtLeast(0f)
+    val height: Float get() = (bottom - top).coerceAtLeast(0f)
+}
+
+internal data class ChartCoordinate(val x: Float, val y: Float)
+
+internal data class ChartScale(
+    val minimum: Float,
+    val maximum: Float,
+    val ticks: List<Float>,
+)
+
+internal data class ChartLayout(
+    val plot: ChartRect,
+    val categoryCount: Int,
+    val scale: ChartScale,
+    val barSeriesCount: Int,
+) {
+    val bandWidth: Float
+        get() = if (categoryCount == 0) 0f else plot.width / categoryCount
+
+    fun xForCategory(index: Int): Float {
+        if (categoryCount == 0) return plot.left
+        return plot.left + bandWidth * (index.coerceIn(0, categoryCount - 1) + 0.5f)
+    }
+
+    fun yForValue(value: Float): Float {
+        val range = scale.maximum - scale.minimum
+        if (range <= 0f) return plot.bottom
+        val ratio = ((value - scale.minimum) / range).coerceIn(0f, 1f)
+        return plot.bottom - ratio * plot.height
+    }
+
+    fun point(index: Int, value: Float): ChartCoordinate {
+        return ChartCoordinate(xForCategory(index), yForValue(value))
+    }
+
+    fun categoryIndexAt(x: Float): Int {
+        if (categoryCount == 0 || x < plot.left || x > plot.right) return -1
+        return floor((x - plot.left) / bandWidth)
+            .toInt()
+            .coerceIn(0, categoryCount - 1)
+    }
+
+    fun barRect(categoryIndex: Int, barSeriesIndex: Int, value: Float): ChartRect {
+        if (barSeriesCount <= 0 || categoryCount <= 0) {
+            return ChartRect(plot.left, plot.bottom, plot.left, plot.bottom)
+        }
+        val groupWidth = bandWidth * 0.72f
+        val slotWidth = groupWidth / barSeriesCount
+        val gap = min(2f, slotWidth * 0.12f)
+        val width = (slotWidth - gap).coerceAtLeast(1f)
+        val groupLeft = xForCategory(categoryIndex) - groupWidth / 2f
+        val left = groupLeft + slotWidth * barSeriesIndex + gap / 2f
+        val zeroY = yForValue(0f.coerceIn(scale.minimum, scale.maximum))
+        val valueY = yForValue(value)
+        return ChartRect(
+            left = left,
+            top = min(zeroY, valueY),
+            right = left + width,
+            bottom = max(zeroY, valueY),
+        )
+    }
+}
+
+internal object ChartLayoutEngine {
+    fun layout(
+        data: ChartData,
+        width: Float,
+        height: Float,
+        insets: ChartInsets,
+        requestedTickCount: Int,
+        includeZero: Boolean,
+        minimumOverride: Float,
+        maximumOverride: Float,
+    ): ChartLayout {
+        val safeWidth = width.coerceAtLeast(0f)
+        val safeHeight = height.coerceAtLeast(0f)
+        val plotLeft = insets.left.coerceIn(0f, safeWidth)
+        val plotTop = insets.top.coerceIn(0f, safeHeight)
+        val plot = ChartRect(
+            left = plotLeft,
+            top = plotTop,
+            right = (safeWidth - insets.right).coerceIn(plotLeft, safeWidth),
+            bottom = (safeHeight - insets.bottom).coerceIn(plotTop, safeHeight),
+        )
+        val values = data.series
+            .flatMap { it.values }
+            .filterNotNull()
+            .filter { it.isFinite() }
+        val shouldIncludeZero = includeZero || data.series.any {
+            it.type == ChartSeriesType.BAR || it.type == ChartSeriesType.AREA
+        }
+        val scale = createScale(
+            values = values,
+            requestedTickCount = requestedTickCount,
+            includeZero = shouldIncludeZero,
+            minimumOverride = minimumOverride,
+            maximumOverride = maximumOverride,
+        )
+        return ChartLayout(
+            plot = plot,
+            categoryCount = data.categories.size,
+            scale = scale,
+            barSeriesCount = data.series.count { it.type == ChartSeriesType.BAR },
+        )
+    }
+
+    private fun createScale(
+        values: List<Float>,
+        requestedTickCount: Int,
+        includeZero: Boolean,
+        minimumOverride: Float,
+        maximumOverride: Float,
+    ): ChartScale {
+        val tickCount = requestedTickCount.coerceIn(2, 10)
+        var minimum = values.minOrNull() ?: 0f
+        var maximum = values.maxOrNull() ?: 1f
+
+        if (includeZero) {
+            minimum = min(minimum, 0f)
+            maximum = max(maximum, 0f)
+        }
+        if (minimumOverride.isFinite()) minimum = minimumOverride
+        if (maximumOverride.isFinite()) maximum = maximumOverride
+        if (minimum > maximum) {
+            val swap = minimum
+            minimum = maximum
+            maximum = swap
+        }
+        if (minimum == maximum) {
+            val padding = max(abs(minimum) * 0.1f, 1f)
+            minimum -= padding
+            maximum += padding
+        }
+
+        val rawRange = maximum - minimum
+        val step = niceNumber(rawRange / (tickCount - 1), true).coerceAtLeast(0.000001f)
+        val niceMinimum = if (minimumOverride.isFinite()) minimum else floor(minimum / step) * step
+        val niceMaximum = if (maximumOverride.isFinite()) maximum else ceil(maximum / step) * step
+        val ticks = mutableListOf<Float>()
+        var value = niceMinimum
+        val limit = niceMaximum + step * 0.5f
+        while (value <= limit && ticks.size <= 12) {
+            ticks.add(normalizeFloat(value))
+            value += step
+        }
+        if (ticks.size < 2) {
+            ticks.add(niceMaximum)
+        }
+        return ChartScale(niceMinimum, niceMaximum, ticks)
+    }
+
+    private fun niceNumber(value: Float, roundValue: Boolean): Float {
+        if (!value.isFinite() || value <= 0f) return 1f
+        val exponent = floor(log10(value.toDouble())).toInt()
+        val power = 10.0.pow(exponent).toFloat()
+        val fraction = value / power
+        val niceFraction = if (roundValue) {
+            when {
+                fraction < 1.5f -> 1f
+                fraction < 3f -> 2f
+                fraction < 7f -> 5f
+                else -> 10f
+            }
+        } else {
+            when {
+                fraction <= 1f -> 1f
+                fraction <= 2f -> 2f
+                fraction <= 5f -> 5f
+                else -> 10f
+            }
+        }
+        return niceFraction * power
+    }
+
+    private fun normalizeFloat(value: Float): Float {
+        if (abs(value) < 0.000001f) return 0f
+        return (value * 1_000_000f).roundToInt() / 1_000_000f
+    }
+}
+
+internal fun formatChartValue(value: Float): String {
+    val absolute = abs(value)
+    val suffix: String
+    val scaled: Float
+    when {
+        absolute >= 1_000_000f -> {
+            suffix = "M"
+            scaled = value / 1_000_000f
+        }
+        absolute >= 1_000f -> {
+            suffix = "K"
+            scaled = value / 1_000f
+        }
+        else -> {
+            suffix = ""
+            scaled = value
+        }
+    }
+    val rounded = round(scaled)
+    val text = if (abs(scaled - rounded) < 0.0001f) {
+        rounded.toInt().toString()
+    } else {
+        val hundredths = (scaled * 100f).roundToInt() / 100f
+        hundredths.toString().trimEnd('0').trimEnd('.')
+    }
+    return text + suffix
+}

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartLayoutEngine.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartLayoutEngine.kt
@@ -240,3 +240,19 @@ internal fun formatChartValue(value: Float): String {
     }
     return text + suffix
 }
+
+internal fun chartLegendLineCount(itemWidths: List<Float>, availableWidth: Float): Int {
+    if (itemWidths.isEmpty()) return 0
+    val safeWidth = availableWidth.coerceAtLeast(0f)
+    var lineCount = 1
+    var usedWidth = 0f
+    itemWidths.forEach { itemWidth ->
+        val safeItemWidth = itemWidth.coerceAtLeast(0f)
+        if (usedWidth > 0f && usedWidth + safeItemWidth > safeWidth) {
+            lineCount++
+            usedWidth = 0f
+        }
+        usedWidth += safeItemWidth
+    }
+    return lineCount
+}

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartModels.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartModels.kt
@@ -21,13 +21,13 @@ import com.tencent.kuikly.core.base.Color
 enum class ChartSeriesType {
     LINE,
     BAR,
-    AREA,
+    AREA
 }
 /** Position of the built-in legend. */
 enum class ChartLegendPosition {
     NONE,
     TOP,
-    BOTTOM,
+    BOTTOM
 }
 
 /** A single named data series. A null value is rendered as a gap. */
@@ -38,13 +38,13 @@ data class ChartSeries(
     val color: Color,
     val lineWidth: Float = 2f,
     val showPoints: Boolean = true,
-    val showValues: Boolean = false,
+    val showValues: Boolean = false
 )
 
 /** Immutable chart data shared by every Kuikly target. */
 data class ChartData(
     val categories: List<String>,
-    val series: List<ChartSeries>,
+    val series: List<ChartSeries>
 ) {
     companion object {
         val EMPTY = ChartData(emptyList(), emptyList())
@@ -56,20 +56,20 @@ data class ChartInsets(
     val left: Float = 48f,
     val top: Float = 18f,
     val right: Float = 16f,
-    val bottom: Float = 38f,
+    val bottom: Float = 38f
 )
 
 /** Value returned when the user taps or drags over a category. */
 data class ChartSelection(
     val index: Int,
     val category: String,
-    val values: List<ChartSelectionValue>,
+    val values: List<ChartSelectionValue>
 )
 
 data class ChartSelectionValue(
     val seriesName: String,
     val value: Float?,
-    val color: Color,
+    val color: Color
 )
 
 /**
@@ -98,7 +98,7 @@ class ChartSeriesBuilder internal constructor() {
             color = color,
             lineWidth = lineWidth.coerceAtLeast(0.5f),
             showPoints = showPoints,
-            showValues = showValues,
+            showValues = showValues
         )
     }
 }
@@ -117,7 +117,7 @@ class ChartDataBuilder {
     fun line(
         name: String,
         color: Color = nextColor(),
-        init: ChartSeriesBuilder.() -> Unit,
+        init: ChartSeriesBuilder.() -> Unit
     ) {
         addSeries(name, ChartSeriesType.LINE, color, init)
     }
@@ -125,7 +125,7 @@ class ChartDataBuilder {
     fun bar(
         name: String,
         color: Color = nextColor(),
-        init: ChartSeriesBuilder.() -> Unit,
+        init: ChartSeriesBuilder.() -> Unit
     ) {
         addSeries(name, ChartSeriesType.BAR, color, init)
     }
@@ -133,7 +133,7 @@ class ChartDataBuilder {
     fun area(
         name: String,
         color: Color = nextColor(),
-        init: ChartSeriesBuilder.() -> Unit,
+        init: ChartSeriesBuilder.() -> Unit
     ) {
         addSeries(name, ChartSeriesType.AREA, color, init)
     }
@@ -142,7 +142,7 @@ class ChartDataBuilder {
         name: String,
         type: ChartSeriesType,
         color: Color,
-        init: ChartSeriesBuilder.() -> Unit,
+        init: ChartSeriesBuilder.() -> Unit
     ) {
         val builder = ChartSeriesBuilder().apply(init)
         seriesItems.add(builder.build(name, type, color))
@@ -155,9 +155,13 @@ class ChartDataBuilder {
     }
 
     internal fun build(): ChartData {
+        var seriesValueCount = 0
+        seriesItems.forEach { series ->
+            seriesValueCount = maxOf(seriesValueCount, series.values.size)
+        }
         val itemCount = maxOf(
             categoryItems.size,
-            seriesItems.maxOfOrNull { it.values.size } ?: 0,
+            seriesValueCount
         )
         val normalizedCategories = List(itemCount) { index ->
             categoryItems.getOrNull(index) ?: (index + 1).toString()
@@ -172,7 +176,7 @@ class ChartDataBuilder {
             Color(0xFFED7B2FL),
             Color(0xFFE34D59L),
             Color(0xFF7B61FFL),
-            Color(0xFF00A6A6L),
+            Color(0xFF00A6A6L)
         )
     }
 }

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartModels.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartModels.kt
@@ -1,0 +1,178 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.core.views.chart
+
+import com.tencent.kuikly.core.base.Color
+
+/** Rendering style for a chart series. */
+enum class ChartSeriesType {
+    LINE,
+    BAR,
+    AREA,
+}
+/** Position of the built-in legend. */
+enum class ChartLegendPosition {
+    NONE,
+    TOP,
+    BOTTOM,
+}
+
+/** A single named data series. A null value is rendered as a gap. */
+data class ChartSeries(
+    val name: String,
+    val type: ChartSeriesType,
+    val values: List<Float?>,
+    val color: Color,
+    val lineWidth: Float = 2f,
+    val showPoints: Boolean = true,
+    val showValues: Boolean = false,
+)
+
+/** Immutable chart data shared by every Kuikly target. */
+data class ChartData(
+    val categories: List<String>,
+    val series: List<ChartSeries>,
+) {
+    companion object {
+        val EMPTY = ChartData(emptyList(), emptyList())
+    }
+}
+
+/** Insets reserved around the plot for labels and legends. */
+data class ChartInsets(
+    val left: Float = 48f,
+    val top: Float = 18f,
+    val right: Float = 16f,
+    val bottom: Float = 38f,
+)
+
+/** Value returned when the user taps or drags over a category. */
+data class ChartSelection(
+    val index: Int,
+    val category: String,
+    val values: List<ChartSelectionValue>,
+)
+
+data class ChartSelectionValue(
+    val seriesName: String,
+    val value: Float?,
+    val color: Color,
+)
+
+/**
+ * Builder used by [ChartDataBuilder.line], [ChartDataBuilder.bar], and
+ * [ChartDataBuilder.area].
+ */
+class ChartSeriesBuilder internal constructor() {
+    private val items = mutableListOf<Float?>()
+    var lineWidth: Float = 2f
+    var showPoints: Boolean = true
+    var showValues: Boolean = false
+
+    fun values(vararg values: Float?) {
+        items.addAll(values)
+    }
+
+    fun value(value: Float?) {
+        items.add(value)
+    }
+
+    internal fun build(name: String, type: ChartSeriesType, color: Color): ChartSeries {
+        return ChartSeries(
+            name = name,
+            type = type,
+            values = items.toList(),
+            color = color,
+            lineWidth = lineWidth.coerceAtLeast(0.5f),
+            showPoints = showPoints,
+            showValues = showValues,
+        )
+    }
+}
+
+/** Declarative data DSL consumed by [ChartAttr.data]. */
+class ChartDataBuilder {
+    private val categoryItems = mutableListOf<String>()
+    private val seriesItems = mutableListOf<ChartSeries>()
+    private var paletteIndex = 0
+
+    fun categories(vararg labels: String) {
+        categoryItems.clear()
+        categoryItems.addAll(labels)
+    }
+
+    fun line(
+        name: String,
+        color: Color = nextColor(),
+        init: ChartSeriesBuilder.() -> Unit,
+    ) {
+        addSeries(name, ChartSeriesType.LINE, color, init)
+    }
+
+    fun bar(
+        name: String,
+        color: Color = nextColor(),
+        init: ChartSeriesBuilder.() -> Unit,
+    ) {
+        addSeries(name, ChartSeriesType.BAR, color, init)
+    }
+
+    fun area(
+        name: String,
+        color: Color = nextColor(),
+        init: ChartSeriesBuilder.() -> Unit,
+    ) {
+        addSeries(name, ChartSeriesType.AREA, color, init)
+    }
+
+    private fun addSeries(
+        name: String,
+        type: ChartSeriesType,
+        color: Color,
+        init: ChartSeriesBuilder.() -> Unit,
+    ) {
+        val builder = ChartSeriesBuilder().apply(init)
+        seriesItems.add(builder.build(name, type, color))
+    }
+
+    private fun nextColor(): Color {
+        val color = DEFAULT_PALETTE[paletteIndex % DEFAULT_PALETTE.size]
+        paletteIndex++
+        return color
+    }
+
+    internal fun build(): ChartData {
+        val itemCount = maxOf(
+            categoryItems.size,
+            seriesItems.maxOfOrNull { it.values.size } ?: 0,
+        )
+        val normalizedCategories = List(itemCount) { index ->
+            categoryItems.getOrNull(index) ?: (index + 1).toString()
+        }
+        return ChartData(normalizedCategories, seriesItems.toList())
+    }
+
+    private companion object {
+        val DEFAULT_PALETTE = listOf(
+            Color(0xFF0052D9L),
+            Color(0xFF00A870L),
+            Color(0xFFED7B2FL),
+            Color(0xFFE34D59L),
+            Color(0xFF7B61FFL),
+            Color(0xFF00A6A6L),
+        )
+    }
+}

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartView.kt
@@ -102,6 +102,8 @@ class ChartView : ComposeView<ChartAttr, ChartEvent>() {
                     },
                 ),
             )
+        } else {
+            event.selectionClearedHandler?.invoke()
         }
     }
 }
@@ -129,6 +131,7 @@ class ChartAttr : ComposeAttr() {
     internal var tooltipBackgroundColor by observable(Color(0xE6222222L))
     internal var areaOpacity by observable(0.18f)
     internal var yLabelFormatter: (Float) -> String = ::formatChartValue
+    internal var valueLabelFormatter: (Float) -> String = ::formatChartValue
     internal var tooltipValueFormatter: (Float) -> String = ::formatChartValue
 
     override fun width(width: Float): Attr {
@@ -221,14 +224,23 @@ class ChartAttr : ComposeAttr() {
         yLabelFormatter = formatter
     }
 
+    fun valueLabelFormatter(formatter: (Float) -> String) {
+        valueLabelFormatter = formatter
+    }
+
     fun tooltipValueFormatter(formatter: (Float) -> String) {
         tooltipValueFormatter = formatter
     }
 
-    internal fun effectiveInsets(): ChartInsets {
+    internal fun effectiveInsets(legendLineCount: Int = 1): ChartInsets {
+        val legendHeight = if (legendLineCount <= 0) {
+            0f
+        } else {
+            22f + (legendLineCount - 1) * (legendFontSize + 6f)
+        }
         return when (legendPosition) {
-            ChartLegendPosition.TOP -> chartInsets.copy(top = chartInsets.top + 22f)
-            ChartLegendPosition.BOTTOM -> chartInsets.copy(bottom = chartInsets.bottom + 22f)
+            ChartLegendPosition.TOP -> chartInsets.copy(top = chartInsets.top + legendHeight)
+            ChartLegendPosition.BOTTOM -> chartInsets.copy(bottom = chartInsets.bottom + legendHeight)
             ChartLegendPosition.NONE -> chartInsets
         }
     }
@@ -236,9 +248,14 @@ class ChartAttr : ComposeAttr() {
 
 class ChartEvent : ComposeEvent() {
     internal var selectionChangedHandler: ((ChartSelection) -> Unit)? = null
+    internal var selectionClearedHandler: (() -> Unit)? = null
 
     fun selectionChanged(handler: (ChartSelection) -> Unit) {
         selectionChangedHandler = handler
+    }
+
+    fun selectionCleared(handler: () -> Unit) {
+        selectionClearedHandler = handler
     }
 }
 
@@ -257,11 +274,12 @@ private object ChartRenderer {
     ) {
         fillRect(context, 0f, 0f, width, height, attr.chartBackgroundColor)
         val data = attr.chartData
+        val legendLineCount = legendLineCount(context, width, data, attr)
         val layout = ChartLayoutEngine.layout(
             data = data,
             width = width,
             height = height,
-            insets = attr.effectiveInsets(),
+            insets = attr.effectiveInsets(legendLineCount),
             requestedTickCount = attr.yTickCount,
             includeZero = attr.includeZero,
             minimumOverride = attr.yMinimum,
@@ -276,7 +294,7 @@ private object ChartRenderer {
         drawAreas(context, data, layout, attr)
         drawBars(context, data, layout, attr)
         drawLines(context, data, layout, attr)
-        drawLegend(context, width, height, data, attr)
+        drawLegend(context, width, height, data, attr, legendLineCount)
 
         if (selectedIndex in data.categories.indices) {
             drawSelection(context, data, layout, attr, selectedIndex)
@@ -388,7 +406,19 @@ private object ChartRenderer {
                     val rect = layout.barRect(categoryIndex, barSeriesIndex, value)
                     fillRect(context, rect.left, rect.top, rect.width, max(rect.height, 1f), series.color)
                     if (series.showValues) {
-                        drawValueLabel(context, layout, attr, series, categoryIndex, value)
+                        val labelY = if (value >= 0f) {
+                            rect.top - 7f
+                        } else {
+                            rect.bottom + attr.labelFontSize + 3f
+                        }
+                        drawValueLabel(
+                            context = context,
+                            attr = attr,
+                            series = series,
+                            value = value,
+                            x = (rect.left + rect.right) / 2f,
+                            y = labelY,
+                        )
                     }
                 }
             }
@@ -431,7 +461,14 @@ private object ChartRenderer {
                     val point = layout.point(index, value)
                     if (series.showPoints) fillCircle(context, point.x, point.y, 3f, series.color)
                     if (series.showValues) {
-                        drawValueLabel(context, layout, attr, series, index, value)
+                        drawValueLabel(
+                            context = context,
+                            attr = attr,
+                            series = series,
+                            value = value,
+                            x = point.x,
+                            y = point.y - 7f,
+                        )
                     }
                 }
             }
@@ -440,17 +477,16 @@ private object ChartRenderer {
 
     private fun drawValueLabel(
         context: CanvasContext,
-        layout: ChartLayout,
         attr: ChartAttr,
         series: ChartSeries,
-        index: Int,
         value: Float,
+        x: Float,
+        y: Float,
     ) {
-        val point = layout.point(index, value)
         context.font(attr.labelFontSize)
         context.textAlign(TextAlign.CENTER)
         context.fillStyle(series.color)
-        context.fillText(attr.tooltipValueFormatter(value), point.x, point.y - 7f)
+        context.fillText(attr.valueLabelFormatter(value), x, y)
     }
 
     private fun drawLegend(
@@ -459,27 +495,47 @@ private object ChartRenderer {
         height: Float,
         data: ChartData,
         attr: ChartAttr,
+        lineCount: Int,
     ) {
         if (attr.legendPosition == ChartLegendPosition.NONE) return
         context.font(attr.legendFontSize)
         context.textAlign(TextAlign.LEFT)
         var x = attr.chartInsets.left
+        val lineHeight = attr.legendFontSize + 6f
         var y = if (attr.legendPosition == ChartLegendPosition.TOP) {
             attr.chartInsets.top + attr.legendFontSize
         } else {
-            height - attr.chartInsets.bottom + attr.legendFontSize + 6f
+            height - attr.chartInsets.bottom + attr.legendFontSize + 6f -
+                (lineCount - 1).coerceAtLeast(0) * lineHeight
         }
         data.series.forEach { series ->
             val itemWidth = 14f + context.measureText(series.name).width + 14f
             if (x + itemWidth > width - attr.chartInsets.right && x > attr.chartInsets.left) {
                 x = attr.chartInsets.left
-                y += attr.legendFontSize + 6f
+                y += lineHeight
             }
             fillRect(context, x, y - 9f, 9f, 9f, series.color)
             context.fillStyle(attr.labelColor)
             context.fillText(series.name, x + 14f, y)
             x += itemWidth
         }
+    }
+
+    private fun legendLineCount(
+        context: CanvasContext,
+        width: Float,
+        data: ChartData,
+        attr: ChartAttr,
+    ): Int {
+        if (attr.legendPosition == ChartLegendPosition.NONE || data.series.isEmpty()) return 0
+        context.font(attr.legendFontSize)
+        val itemWidths = data.series.map { series ->
+            14f + context.measureText(series.name).width + 14f
+        }
+        return chartLegendLineCount(
+            itemWidths = itemWidths,
+            availableWidth = width - attr.chartInsets.left - attr.chartInsets.right,
+        )
     }
 
     private fun drawSelection(

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartView.kt
@@ -577,7 +577,11 @@ private object ChartRenderer {
             )
         }
         context.font(attr.labelFontSize)
-        val tooltipWidth = lines.maxOf { context.measureText(it).width } + 18f
+        var tooltipTextWidth = 0f
+        lines.forEach { line ->
+            tooltipTextWidth = max(tooltipTextWidth, context.measureText(line).width)
+        }
+        val tooltipWidth = tooltipTextWidth + 18f
         val lineHeight = attr.labelFontSize + 5f
         val tooltipHeight = lines.size * lineHeight + 10f
         var left = x + 9f

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartView.kt
@@ -1,0 +1,602 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.core.views.chart
+
+import com.tencent.kuikly.core.base.Attr
+import com.tencent.kuikly.core.base.Color
+import com.tencent.kuikly.core.base.ComposeAttr
+import com.tencent.kuikly.core.base.ComposeEvent
+import com.tencent.kuikly.core.base.ComposeView
+import com.tencent.kuikly.core.base.ViewBuilder
+import com.tencent.kuikly.core.base.ViewContainer
+import com.tencent.kuikly.core.exception.throwRuntimeError
+import com.tencent.kuikly.core.layout.undefined
+import com.tencent.kuikly.core.layout.valueEquals
+import com.tencent.kuikly.core.reactive.handler.observable
+import com.tencent.kuikly.core.views.Canvas
+import com.tencent.kuikly.core.views.CanvasContext
+import com.tencent.kuikly.core.views.TextAlign
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Cross-platform chart component backed by Kuikly's Canvas implementation.
+ *
+ * The component supports mixed line, bar, and area series, automatic or fixed
+ * Y-axis ranges, legends, value labels, and tap/drag selection.
+ */
+class ChartView : ComposeView<ChartAttr, ChartEvent>() {
+    private var selectedIndex by observable(-1)
+
+    override fun createAttr(): ChartAttr = ChartAttr()
+
+    override fun createEvent(): ChartEvent = ChartEvent()
+
+    override fun didInit() {
+        if (flexNode.styleWidth.valueEquals(Float.undefined) ||
+            flexNode.styleHeight.valueEquals(Float.undefined)
+        ) {
+            throwRuntimeError("Chart组件需要通过attr { size(width, height) }设置宽度和高度")
+        }
+        super.didInit()
+    }
+
+    override fun body(): ViewBuilder {
+        val chart = this
+        return {
+            Canvas({
+                attr {
+                    absolutePosition(0f, 0f, 0f, 0f)
+                }
+                event {
+                    click { chart.selectCategory(it.x) }
+                    pan { chart.selectCategory(it.x) }
+                }
+            }) { context, width, height ->
+                ChartRenderer.draw(context, width, height, chart.attr, chart.selectedIndex)
+            }
+        }
+    }
+
+    private fun selectCategory(x: Float) {
+        if (!attr.interactive || attr.chartWidth <= 0f || attr.chartHeight <= 0f) return
+        val layout = ChartLayoutEngine.layout(
+            data = attr.chartData,
+            width = attr.chartWidth,
+            height = attr.chartHeight,
+            insets = attr.effectiveInsets(),
+            requestedTickCount = attr.yTickCount,
+            includeZero = attr.includeZero,
+            minimumOverride = attr.yMinimum,
+            maximumOverride = attr.yMaximum,
+        )
+        val newIndex = layout.categoryIndexAt(x)
+        if (newIndex == selectedIndex) return
+        selectedIndex = newIndex
+        if (newIndex >= 0) {
+            val data = attr.chartData
+            event.selectionChangedHandler?.invoke(
+                ChartSelection(
+                    index = newIndex,
+                    category = data.categories[newIndex],
+                    values = data.series.map { series ->
+                        ChartSelectionValue(
+                            seriesName = series.name,
+                            value = series.values.getOrNull(newIndex),
+                            color = series.color,
+                        )
+                    },
+                ),
+            )
+        }
+    }
+}
+
+class ChartAttr : ComposeAttr() {
+    internal var chartData by observable(ChartData.EMPTY)
+    internal var chartWidth by observable(0f)
+    internal var chartHeight by observable(0f)
+    internal var chartInsets by observable(ChartInsets())
+    internal var legendPosition by observable(ChartLegendPosition.TOP)
+    internal var interactive by observable(true)
+    internal var showTooltip by observable(true)
+    internal var showGridLines by observable(true)
+    internal var includeZero by observable(false)
+    internal var yTickCount by observable(5)
+    internal var yMinimum by observable(Float.NaN)
+    internal var yMaximum by observable(Float.NaN)
+    internal var labelFontSize by observable(11f)
+    internal var legendFontSize by observable(11f)
+    internal var emptyText by observable("No data")
+    internal var chartBackgroundColor by observable(Color.TRANSPARENT)
+    internal var axisColor by observable(Color(0xFF8C8C8CL))
+    internal var gridColor by observable(Color(0xFFE7E7E7L))
+    internal var labelColor by observable(Color(0xFF5E5E5EL))
+    internal var tooltipBackgroundColor by observable(Color(0xE6222222L))
+    internal var areaOpacity by observable(0.18f)
+    internal var yLabelFormatter: (Float) -> String = ::formatChartValue
+    internal var tooltipValueFormatter: (Float) -> String = ::formatChartValue
+
+    override fun width(width: Float): Attr {
+        chartWidth = width
+        return super.width(width)
+    }
+
+    override fun height(height: Float): Attr {
+        chartHeight = height
+        return super.height(height)
+    }
+
+    fun data(data: ChartData) {
+        chartData = data
+    }
+
+    fun data(init: ChartDataBuilder.() -> Unit) {
+        chartData = ChartDataBuilder().apply(init).build()
+    }
+
+    fun insets(insets: ChartInsets) {
+        chartInsets = insets
+    }
+
+    fun legend(position: ChartLegendPosition) {
+        legendPosition = position
+    }
+
+    fun interactive(enabled: Boolean) {
+        interactive = enabled
+    }
+
+    fun tooltip(visible: Boolean) {
+        showTooltip = visible
+    }
+
+    fun gridLines(visible: Boolean) {
+        showGridLines = visible
+    }
+
+    fun includeZero(include: Boolean) {
+        includeZero = include
+    }
+
+    fun yTickCount(count: Int) {
+        yTickCount = count.coerceIn(2, 10)
+    }
+
+    fun yRange(minimum: Float, maximum: Float) {
+        yMinimum = minimum
+        yMaximum = maximum
+    }
+
+    fun autoYRange() {
+        yMinimum = Float.NaN
+        yMaximum = Float.NaN
+    }
+
+    fun labelFontSize(size: Float) {
+        labelFontSize = size.coerceAtLeast(8f)
+    }
+
+    fun legendFontSize(size: Float) {
+        legendFontSize = size.coerceAtLeast(8f)
+    }
+
+    fun emptyText(text: String) {
+        emptyText = text
+    }
+
+    fun colors(
+        background: Color = chartBackgroundColor,
+        axis: Color = axisColor,
+        grid: Color = gridColor,
+        label: Color = labelColor,
+        tooltipBackground: Color = tooltipBackgroundColor,
+    ) {
+        chartBackgroundColor = background
+        axisColor = axis
+        gridColor = grid
+        labelColor = label
+        tooltipBackgroundColor = tooltipBackground
+    }
+
+    fun areaOpacity(opacity: Float) {
+        areaOpacity = opacity.coerceIn(0f, 1f)
+    }
+
+    fun yLabelFormatter(formatter: (Float) -> String) {
+        yLabelFormatter = formatter
+    }
+
+    fun tooltipValueFormatter(formatter: (Float) -> String) {
+        tooltipValueFormatter = formatter
+    }
+
+    internal fun effectiveInsets(): ChartInsets {
+        return when (legendPosition) {
+            ChartLegendPosition.TOP -> chartInsets.copy(top = chartInsets.top + 22f)
+            ChartLegendPosition.BOTTOM -> chartInsets.copy(bottom = chartInsets.bottom + 22f)
+            ChartLegendPosition.NONE -> chartInsets
+        }
+    }
+}
+
+class ChartEvent : ComposeEvent() {
+    internal var selectionChangedHandler: ((ChartSelection) -> Unit)? = null
+
+    fun selectionChanged(handler: (ChartSelection) -> Unit) {
+        selectionChangedHandler = handler
+    }
+}
+
+/** Add a chart to any declarative Kuikly container. */
+fun ViewContainer<*, *>.Chart(init: ChartView.() -> Unit) {
+    addChild(ChartView(), init)
+}
+
+private object ChartRenderer {
+    fun draw(
+        context: CanvasContext,
+        width: Float,
+        height: Float,
+        attr: ChartAttr,
+        selectedIndex: Int,
+    ) {
+        fillRect(context, 0f, 0f, width, height, attr.chartBackgroundColor)
+        val data = attr.chartData
+        val layout = ChartLayoutEngine.layout(
+            data = data,
+            width = width,
+            height = height,
+            insets = attr.effectiveInsets(),
+            requestedTickCount = attr.yTickCount,
+            includeZero = attr.includeZero,
+            minimumOverride = attr.yMinimum,
+            maximumOverride = attr.yMaximum,
+        )
+        if (data.categories.isEmpty() || data.series.isEmpty()) {
+            drawEmptyState(context, width, height, attr)
+            return
+        }
+
+        drawAxes(context, data, layout, attr)
+        drawAreas(context, data, layout, attr)
+        drawBars(context, data, layout, attr)
+        drawLines(context, data, layout, attr)
+        drawLegend(context, width, height, data, attr)
+
+        if (selectedIndex in data.categories.indices) {
+            drawSelection(context, data, layout, attr, selectedIndex)
+        }
+    }
+
+    private fun drawAxes(
+        context: CanvasContext,
+        data: ChartData,
+        layout: ChartLayout,
+        attr: ChartAttr,
+    ) {
+        context.font(attr.labelFontSize)
+        context.fillStyle(attr.labelColor)
+        context.textAlign(TextAlign.RIGHT)
+        layout.scale.ticks.forEach { tick ->
+            val y = layout.yForValue(tick)
+            if (attr.showGridLines) {
+                drawLine(
+                    context,
+                    layout.plot.left,
+                    y,
+                    layout.plot.right,
+                    y,
+                    attr.gridColor,
+                    0.7f,
+                    dashed = true,
+                )
+            }
+            context.fillText(attr.yLabelFormatter(tick), layout.plot.left - 7f, y + attr.labelFontSize * 0.35f)
+        }
+
+        drawLine(
+            context,
+            layout.plot.left,
+            layout.plot.top,
+            layout.plot.left,
+            layout.plot.bottom,
+            attr.axisColor,
+            1f,
+        )
+        drawLine(
+            context,
+            layout.plot.left,
+            layout.plot.bottom,
+            layout.plot.right,
+            layout.plot.bottom,
+            attr.axisColor,
+            1f,
+        )
+
+        context.textAlign(TextAlign.CENTER)
+        val labelStep = max(1, ceil(data.categories.size / 8f).toInt())
+        data.categories.forEachIndexed { index, label ->
+            if (index % labelStep == 0 || index == data.categories.lastIndex) {
+                context.fillText(
+                    label,
+                    layout.xForCategory(index),
+                    layout.plot.bottom + attr.labelFontSize + 7f,
+                )
+            }
+        }
+    }
+
+    private fun drawAreas(
+        context: CanvasContext,
+        data: ChartData,
+        layout: ChartLayout,
+        attr: ChartAttr,
+    ) {
+        data.series.filter { it.type == ChartSeriesType.AREA }.forEach { series ->
+            val segment = mutableListOf<ChartCoordinate>()
+            fun flushSegment() {
+                if (segment.isEmpty()) return
+                val baseline = layout.yForValue(0f.coerceIn(layout.scale.minimum, layout.scale.maximum))
+                context.beginPath()
+                context.moveTo(segment.first().x, baseline)
+                segment.forEach { point -> context.lineTo(point.x, point.y) }
+                context.lineTo(segment.last().x, baseline)
+                context.closePath()
+                context.fillStyle(series.color.opacity(attr.areaOpacity))
+                context.fill()
+                segment.clear()
+            }
+            data.categories.indices.forEach { index ->
+                val value = series.values.getOrNull(index)
+                if (value == null || !value.isFinite()) {
+                    flushSegment()
+                } else {
+                    segment.add(layout.point(index, value))
+                }
+            }
+            flushSegment()
+        }
+    }
+
+    private fun drawBars(
+        context: CanvasContext,
+        data: ChartData,
+        layout: ChartLayout,
+        attr: ChartAttr,
+    ) {
+        var barSeriesIndex = 0
+        data.series.forEach { series ->
+            if (series.type != ChartSeriesType.BAR) return@forEach
+            data.categories.indices.forEach { categoryIndex ->
+                val value = series.values.getOrNull(categoryIndex)
+                if (value != null && value.isFinite()) {
+                    val rect = layout.barRect(categoryIndex, barSeriesIndex, value)
+                    fillRect(context, rect.left, rect.top, rect.width, max(rect.height, 1f), series.color)
+                    if (series.showValues) {
+                        drawValueLabel(context, layout, attr, series, categoryIndex, value)
+                    }
+                }
+            }
+            barSeriesIndex++
+        }
+    }
+
+    private fun drawLines(
+        context: CanvasContext,
+        data: ChartData,
+        layout: ChartLayout,
+        attr: ChartAttr,
+    ) {
+        data.series.filter { it.type != ChartSeriesType.BAR }.forEach { series ->
+            var pathOpen = false
+            data.categories.indices.forEach { index ->
+                val value = series.values.getOrNull(index)
+                if (value == null || !value.isFinite()) {
+                    if (pathOpen) context.stroke()
+                    pathOpen = false
+                } else {
+                    val point = layout.point(index, value)
+                    if (!pathOpen) {
+                        context.beginPath()
+                        context.strokeStyle(series.color)
+                        context.lineWidth(series.lineWidth)
+                        context.lineCapRound()
+                        context.moveTo(point.x, point.y)
+                        pathOpen = true
+                    } else {
+                        context.lineTo(point.x, point.y)
+                    }
+                }
+            }
+            if (pathOpen) context.stroke()
+
+            data.categories.indices.forEach { index ->
+                val value = series.values.getOrNull(index)
+                if (value != null && value.isFinite()) {
+                    val point = layout.point(index, value)
+                    if (series.showPoints) fillCircle(context, point.x, point.y, 3f, series.color)
+                    if (series.showValues) {
+                        drawValueLabel(context, layout, attr, series, index, value)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun drawValueLabel(
+        context: CanvasContext,
+        layout: ChartLayout,
+        attr: ChartAttr,
+        series: ChartSeries,
+        index: Int,
+        value: Float,
+    ) {
+        val point = layout.point(index, value)
+        context.font(attr.labelFontSize)
+        context.textAlign(TextAlign.CENTER)
+        context.fillStyle(series.color)
+        context.fillText(attr.tooltipValueFormatter(value), point.x, point.y - 7f)
+    }
+
+    private fun drawLegend(
+        context: CanvasContext,
+        width: Float,
+        height: Float,
+        data: ChartData,
+        attr: ChartAttr,
+    ) {
+        if (attr.legendPosition == ChartLegendPosition.NONE) return
+        context.font(attr.legendFontSize)
+        context.textAlign(TextAlign.LEFT)
+        var x = attr.chartInsets.left
+        var y = if (attr.legendPosition == ChartLegendPosition.TOP) {
+            attr.chartInsets.top + attr.legendFontSize
+        } else {
+            height - attr.chartInsets.bottom + attr.legendFontSize + 6f
+        }
+        data.series.forEach { series ->
+            val itemWidth = 14f + context.measureText(series.name).width + 14f
+            if (x + itemWidth > width - attr.chartInsets.right && x > attr.chartInsets.left) {
+                x = attr.chartInsets.left
+                y += attr.legendFontSize + 6f
+            }
+            fillRect(context, x, y - 9f, 9f, 9f, series.color)
+            context.fillStyle(attr.labelColor)
+            context.fillText(series.name, x + 14f, y)
+            x += itemWidth
+        }
+    }
+
+    private fun drawSelection(
+        context: CanvasContext,
+        data: ChartData,
+        layout: ChartLayout,
+        attr: ChartAttr,
+        selectedIndex: Int,
+    ) {
+        val x = layout.xForCategory(selectedIndex)
+        drawLine(
+            context,
+            x,
+            layout.plot.top,
+            x,
+            layout.plot.bottom,
+            attr.axisColor,
+            1f,
+            dashed = true,
+        )
+        data.series.forEach { series ->
+            val value = series.values.getOrNull(selectedIndex)
+            if (value != null && value.isFinite()) {
+                val point = layout.point(selectedIndex, value)
+                fillCircle(context, point.x, point.y, 4f, series.color)
+            }
+        }
+        if (!attr.showTooltip) return
+
+        val lines = mutableListOf(data.categories[selectedIndex])
+        data.series.forEach { series ->
+            val value = series.values.getOrNull(selectedIndex)
+            lines.add(
+                if (value != null && value.isFinite()) {
+                    "${series.name}: ${attr.tooltipValueFormatter(value)}"
+                } else {
+                    "${series.name}: --"
+                },
+            )
+        }
+        context.font(attr.labelFontSize)
+        val tooltipWidth = lines.maxOf { context.measureText(it).width } + 18f
+        val lineHeight = attr.labelFontSize + 5f
+        val tooltipHeight = lines.size * lineHeight + 10f
+        var left = x + 9f
+        if (left + tooltipWidth > layout.plot.right) left = x - tooltipWidth - 9f
+        left = left.coerceIn(layout.plot.left, max(layout.plot.left, layout.plot.right - tooltipWidth))
+        val top = (layout.plot.top + 7f).coerceAtMost(max(layout.plot.top, layout.plot.bottom - tooltipHeight))
+        fillRect(context, left, top, tooltipWidth, tooltipHeight, attr.tooltipBackgroundColor)
+        context.textAlign(TextAlign.LEFT)
+        context.fillStyle(Color.WHITE)
+        lines.forEachIndexed { index, line ->
+            context.fillText(line, left + 9f, top + 7f + lineHeight * (index + 1) - 3f)
+        }
+    }
+
+    private fun drawEmptyState(
+        context: CanvasContext,
+        width: Float,
+        height: Float,
+        attr: ChartAttr,
+    ) {
+        context.font(max(attr.labelFontSize, 12f))
+        context.textAlign(TextAlign.CENTER)
+        context.fillStyle(attr.labelColor)
+        context.fillText(attr.emptyText, width / 2f, height / 2f)
+    }
+
+    private fun drawLine(
+        context: CanvasContext,
+        startX: Float,
+        startY: Float,
+        endX: Float,
+        endY: Float,
+        color: Color,
+        width: Float,
+        dashed: Boolean = false,
+    ) {
+        context.beginPath()
+        context.strokeStyle(color)
+        context.lineWidth(width)
+        context.setLineDash(if (dashed) listOf(3f, 3f) else emptyList())
+        context.moveTo(startX, startY)
+        context.lineTo(endX, endY)
+        context.stroke()
+        if (dashed) context.setLineDash(emptyList())
+    }
+
+    private fun fillRect(
+        context: CanvasContext,
+        left: Float,
+        top: Float,
+        width: Float,
+        height: Float,
+        color: Color,
+    ) {
+        if (width <= 0f || height <= 0f) return
+        context.beginPath()
+        context.moveTo(left, top)
+        context.lineTo(left + width, top)
+        context.lineTo(left + width, top + height)
+        context.lineTo(left, top + height)
+        context.closePath()
+        context.fillStyle(color)
+        context.fill()
+    }
+
+    private fun fillCircle(
+        context: CanvasContext,
+        centerX: Float,
+        centerY: Float,
+        radius: Float,
+        color: Color,
+    ) {
+        context.beginPath()
+        context.arc(centerX, centerY, radius, 0f, (kotlin.math.PI * 2).toFloat(), false)
+        context.fillStyle(color)
+        context.fill()
+    }
+}

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/chart/ChartView.kt
@@ -82,7 +82,7 @@ class ChartView : ComposeView<ChartAttr, ChartEvent>() {
             requestedTickCount = attr.yTickCount,
             includeZero = attr.includeZero,
             minimumOverride = attr.yMinimum,
-            maximumOverride = attr.yMaximum,
+            maximumOverride = attr.yMaximum
         )
         val newIndex = layout.categoryIndexAt(x)
         if (newIndex == selectedIndex) return
@@ -97,10 +97,10 @@ class ChartView : ComposeView<ChartAttr, ChartEvent>() {
                         ChartSelectionValue(
                             seriesName = series.name,
                             value = series.values.getOrNull(newIndex),
-                            color = series.color,
+                            color = series.color
                         )
-                    },
-                ),
+                    }
+                )
             )
         } else {
             event.selectionClearedHandler?.invoke()
@@ -207,7 +207,7 @@ class ChartAttr : ComposeAttr() {
         axis: Color = axisColor,
         grid: Color = gridColor,
         label: Color = labelColor,
-        tooltipBackground: Color = tooltipBackgroundColor,
+        tooltipBackground: Color = tooltipBackgroundColor
     ) {
         chartBackgroundColor = background
         axisColor = axis
@@ -270,7 +270,7 @@ private object ChartRenderer {
         width: Float,
         height: Float,
         attr: ChartAttr,
-        selectedIndex: Int,
+        selectedIndex: Int
     ) {
         fillRect(context, 0f, 0f, width, height, attr.chartBackgroundColor)
         val data = attr.chartData
@@ -283,7 +283,7 @@ private object ChartRenderer {
             requestedTickCount = attr.yTickCount,
             includeZero = attr.includeZero,
             minimumOverride = attr.yMinimum,
-            maximumOverride = attr.yMaximum,
+            maximumOverride = attr.yMaximum
         )
         if (data.categories.isEmpty() || data.series.isEmpty()) {
             drawEmptyState(context, width, height, attr)
@@ -305,7 +305,7 @@ private object ChartRenderer {
         context: CanvasContext,
         data: ChartData,
         layout: ChartLayout,
-        attr: ChartAttr,
+        attr: ChartAttr
     ) {
         context.font(attr.labelFontSize)
         context.fillStyle(attr.labelColor)
@@ -321,7 +321,7 @@ private object ChartRenderer {
                     y,
                     attr.gridColor,
                     0.7f,
-                    dashed = true,
+                    dashed = true
                 )
             }
             context.fillText(attr.yLabelFormatter(tick), layout.plot.left - 7f, y + attr.labelFontSize * 0.35f)
@@ -334,7 +334,7 @@ private object ChartRenderer {
             layout.plot.left,
             layout.plot.bottom,
             attr.axisColor,
-            1f,
+            1f
         )
         drawLine(
             context,
@@ -343,7 +343,7 @@ private object ChartRenderer {
             layout.plot.right,
             layout.plot.bottom,
             attr.axisColor,
-            1f,
+            1f
         )
 
         context.textAlign(TextAlign.CENTER)
@@ -353,7 +353,7 @@ private object ChartRenderer {
                 context.fillText(
                     label,
                     layout.xForCategory(index),
-                    layout.plot.bottom + attr.labelFontSize + 7f,
+                    layout.plot.bottom + attr.labelFontSize + 7f
                 )
             }
         }
@@ -363,7 +363,7 @@ private object ChartRenderer {
         context: CanvasContext,
         data: ChartData,
         layout: ChartLayout,
-        attr: ChartAttr,
+        attr: ChartAttr
     ) {
         data.series.filter { it.type == ChartSeriesType.AREA }.forEach { series ->
             val segment = mutableListOf<ChartCoordinate>()
@@ -395,7 +395,7 @@ private object ChartRenderer {
         context: CanvasContext,
         data: ChartData,
         layout: ChartLayout,
-        attr: ChartAttr,
+        attr: ChartAttr
     ) {
         var barSeriesIndex = 0
         data.series.forEach { series ->
@@ -417,7 +417,7 @@ private object ChartRenderer {
                             series = series,
                             value = value,
                             x = (rect.left + rect.right) / 2f,
-                            y = labelY,
+                            y = labelY
                         )
                     }
                 }
@@ -430,7 +430,7 @@ private object ChartRenderer {
         context: CanvasContext,
         data: ChartData,
         layout: ChartLayout,
-        attr: ChartAttr,
+        attr: ChartAttr
     ) {
         data.series.filter { it.type != ChartSeriesType.BAR }.forEach { series ->
             var pathOpen = false
@@ -467,7 +467,7 @@ private object ChartRenderer {
                             series = series,
                             value = value,
                             x = point.x,
-                            y = point.y - 7f,
+                            y = point.y - 7f
                         )
                     }
                 }
@@ -481,7 +481,7 @@ private object ChartRenderer {
         series: ChartSeries,
         value: Float,
         x: Float,
-        y: Float,
+        y: Float
     ) {
         context.font(attr.labelFontSize)
         context.textAlign(TextAlign.CENTER)
@@ -495,7 +495,7 @@ private object ChartRenderer {
         height: Float,
         data: ChartData,
         attr: ChartAttr,
-        lineCount: Int,
+        lineCount: Int
     ) {
         if (attr.legendPosition == ChartLegendPosition.NONE) return
         context.font(attr.legendFontSize)
@@ -525,7 +525,7 @@ private object ChartRenderer {
         context: CanvasContext,
         width: Float,
         data: ChartData,
-        attr: ChartAttr,
+        attr: ChartAttr
     ): Int {
         if (attr.legendPosition == ChartLegendPosition.NONE || data.series.isEmpty()) return 0
         context.font(attr.legendFontSize)
@@ -534,7 +534,7 @@ private object ChartRenderer {
         }
         return chartLegendLineCount(
             itemWidths = itemWidths,
-            availableWidth = width - attr.chartInsets.left - attr.chartInsets.right,
+            availableWidth = width - attr.chartInsets.left - attr.chartInsets.right
         )
     }
 
@@ -543,7 +543,7 @@ private object ChartRenderer {
         data: ChartData,
         layout: ChartLayout,
         attr: ChartAttr,
-        selectedIndex: Int,
+        selectedIndex: Int
     ) {
         val x = layout.xForCategory(selectedIndex)
         drawLine(
@@ -554,7 +554,7 @@ private object ChartRenderer {
             layout.plot.bottom,
             attr.axisColor,
             1f,
-            dashed = true,
+            dashed = true
         )
         data.series.forEach { series ->
             val value = series.values.getOrNull(selectedIndex)
@@ -573,7 +573,7 @@ private object ChartRenderer {
                     "${series.name}: ${attr.tooltipValueFormatter(value)}"
                 } else {
                     "${series.name}: --"
-                },
+                }
             )
         }
         context.font(attr.labelFontSize)
@@ -596,7 +596,7 @@ private object ChartRenderer {
         context: CanvasContext,
         width: Float,
         height: Float,
-        attr: ChartAttr,
+        attr: ChartAttr
     ) {
         context.font(max(attr.labelFontSize, 12f))
         context.textAlign(TextAlign.CENTER)
@@ -612,7 +612,7 @@ private object ChartRenderer {
         endY: Float,
         color: Color,
         width: Float,
-        dashed: Boolean = false,
+        dashed: Boolean = false
     ) {
         context.beginPath()
         context.strokeStyle(color)
@@ -630,7 +630,7 @@ private object ChartRenderer {
         top: Float,
         width: Float,
         height: Float,
-        color: Color,
+        color: Color
     ) {
         if (width <= 0f || height <= 0f) return
         context.beginPath()
@@ -648,7 +648,7 @@ private object ChartRenderer {
         centerX: Float,
         centerY: Float,
         radius: Float,
-        color: Color,
+        color: Color
     ) {
         context.beginPath()
         context.arc(centerX, centerY, radius, 0f, (kotlin.math.PI * 2).toFloat(), false)

--- a/core/src/commonTest/kotlin/com/tencent/kuikly/core/views/chart/ChartLayoutEngineTest.kt
+++ b/core/src/commonTest/kotlin/com/tencent/kuikly/core/views/chart/ChartLayoutEngineTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.core.views.chart
+
+import com.tencent.kuikly.core.base.Color
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ChartLayoutEngineTest {
+    @Test
+    fun dataBuilderNormalizesMissingCategoryLabels() {
+        val data = ChartDataBuilder().apply {
+            categories("Mon")
+            line("Visits") { values(10f, 20f, 30f) }
+        }.build()
+
+        assertEquals(listOf("Mon", "2", "3"), data.categories)
+        assertEquals(3, data.series.single().values.size)
+    }
+
+    @Test
+    fun barSeriesAutomaticallyIncludesZeroInScale() {
+        val data = ChartData(
+            categories = listOf("A", "B"),
+            series = listOf(
+                ChartSeries("Sales", ChartSeriesType.BAR, listOf(12f, 18f), Color.BLUE),
+            ),
+        )
+
+        val layout = layout(data)
+
+        assertEquals(0f, layout.scale.minimum)
+        assertTrue(layout.scale.maximum >= 18f)
+    }
+
+    @Test
+    fun negativeAndPositiveValuesMapInsidePlot() {
+        val data = ChartData(
+            categories = listOf("A", "B", "C"),
+            series = listOf(
+                ChartSeries("Delta", ChartSeriesType.LINE, listOf(-8f, 0f, 12f), Color.RED),
+            ),
+        )
+
+        val layout = layout(data)
+
+        assertTrue(layout.yForValue(12f) < layout.yForValue(0f))
+        assertTrue(layout.yForValue(0f) < layout.yForValue(-8f))
+        assertTrue(layout.yForValue(12f) >= layout.plot.top)
+        assertTrue(layout.yForValue(-8f) <= layout.plot.bottom)
+    }
+
+    @Test
+    fun fixedRangeIsRespected() {
+        val data = ChartData(
+            categories = listOf("A"),
+            series = listOf(
+                ChartSeries("Temperature", ChartSeriesType.LINE, listOf(22f), Color.GREEN),
+            ),
+        )
+
+        val layout = layout(data, minimum = -10f, maximum = 50f)
+
+        assertEquals(-10f, layout.scale.minimum)
+        assertEquals(50f, layout.scale.maximum)
+    }
+
+    @Test
+    fun groupedBarsNeverOverlap() {
+        val data = ChartData(
+            categories = listOf("A", "B"),
+            series = listOf(
+                ChartSeries("2025", ChartSeriesType.BAR, listOf(10f, 20f), Color.BLUE),
+                ChartSeries("2026", ChartSeriesType.BAR, listOf(12f, 24f), Color.GREEN),
+            ),
+        )
+        val layout = layout(data)
+
+        val first = layout.barRect(categoryIndex = 0, barSeriesIndex = 0, value = 10f)
+        val second = layout.barRect(categoryIndex = 0, barSeriesIndex = 1, value = 12f)
+
+        assertTrue(first.right <= second.left)
+        assertTrue(first.width > 0f)
+        assertTrue(second.right < layout.xForCategory(1))
+    }
+
+    @Test
+    fun categoryHitTestingHandlesEdgesAndOutsideCoordinates() {
+        val data = ChartData(
+            categories = listOf("A", "B", "C"),
+            series = listOf(
+                ChartSeries("Value", ChartSeriesType.LINE, listOf(1f, 2f, 3f), Color.BLUE),
+            ),
+        )
+        val layout = layout(data)
+
+        assertEquals(0, layout.categoryIndexAt(layout.plot.left))
+        assertEquals(1, layout.categoryIndexAt(layout.xForCategory(1)))
+        assertEquals(2, layout.categoryIndexAt(layout.plot.right))
+        assertEquals(-1, layout.categoryIndexAt(layout.plot.left - 1f))
+        assertEquals(-1, layout.categoryIndexAt(layout.plot.right + 1f))
+    }
+
+    @Test
+    fun emptyAndConstantDataProduceUsableScales() {
+        val empty = layout(ChartData.EMPTY)
+        assertTrue(empty.scale.maximum > empty.scale.minimum)
+
+        val constant = layout(
+            ChartData(
+                categories = listOf("A", "B"),
+                series = listOf(
+                    ChartSeries("Flat", ChartSeriesType.LINE, listOf(5f, 5f), Color.BLUE),
+                ),
+            ),
+        )
+        assertTrue(constant.scale.minimum < 5f)
+        assertTrue(constant.scale.maximum > 5f)
+    }
+
+    @Test
+    fun tinyViewportKeepsPlotInsideCanvas() {
+        val data = ChartData(
+            categories = listOf("A"),
+            series = listOf(
+                ChartSeries("Value", ChartSeriesType.LINE, listOf(1f), Color.BLUE),
+            ),
+        )
+
+        val layout = ChartLayoutEngine.layout(
+            data = data,
+            width = 20f,
+            height = 10f,
+            insets = ChartInsets(),
+            requestedTickCount = 5,
+            includeZero = false,
+            minimumOverride = Float.NaN,
+            maximumOverride = Float.NaN,
+        )
+
+        assertTrue(layout.plot.left in 0f..20f)
+        assertTrue(layout.plot.right in layout.plot.left..20f)
+        assertTrue(layout.plot.top in 0f..10f)
+        assertTrue(layout.plot.bottom in layout.plot.top..10f)
+    }
+
+    @Test
+    fun valueFormatterUsesReadableSuffixes() {
+        assertEquals("12", formatChartValue(12f))
+        assertEquals("1.25K", formatChartValue(1_250f))
+        assertEquals("-2.5M", formatChartValue(-2_500_000f))
+    }
+
+    private fun layout(
+        data: ChartData,
+        minimum: Float = Float.NaN,
+        maximum: Float = Float.NaN,
+    ): ChartLayout {
+        return ChartLayoutEngine.layout(
+            data = data,
+            width = 360f,
+            height = 240f,
+            insets = ChartInsets(),
+            requestedTickCount = 5,
+            includeZero = false,
+            minimumOverride = minimum,
+            maximumOverride = maximum,
+        )
+    }
+}

--- a/core/src/commonTest/kotlin/com/tencent/kuikly/core/views/chart/ChartLayoutEngineTest.kt
+++ b/core/src/commonTest/kotlin/com/tencent/kuikly/core/views/chart/ChartLayoutEngineTest.kt
@@ -37,8 +37,8 @@ class ChartLayoutEngineTest {
         val data = ChartData(
             categories = listOf("A", "B"),
             series = listOf(
-                ChartSeries("Sales", ChartSeriesType.BAR, listOf(12f, 18f), Color.BLUE),
-            ),
+                ChartSeries("Sales", ChartSeriesType.BAR, listOf(12f, 18f), Color.BLUE)
+            )
         )
 
         val layout = layout(data)
@@ -52,8 +52,8 @@ class ChartLayoutEngineTest {
         val data = ChartData(
             categories = listOf("A", "B", "C"),
             series = listOf(
-                ChartSeries("Delta", ChartSeriesType.LINE, listOf(-8f, 0f, 12f), Color.RED),
-            ),
+                ChartSeries("Delta", ChartSeriesType.LINE, listOf(-8f, 0f, 12f), Color.RED)
+            )
         )
 
         val layout = layout(data)
@@ -69,8 +69,8 @@ class ChartLayoutEngineTest {
         val data = ChartData(
             categories = listOf("A"),
             series = listOf(
-                ChartSeries("Temperature", ChartSeriesType.LINE, listOf(22f), Color.GREEN),
-            ),
+                ChartSeries("Temperature", ChartSeriesType.LINE, listOf(22f), Color.GREEN)
+            )
         )
 
         val layout = layout(data, minimum = -10f, maximum = 50f)
@@ -85,8 +85,8 @@ class ChartLayoutEngineTest {
             categories = listOf("A", "B"),
             series = listOf(
                 ChartSeries("2025", ChartSeriesType.BAR, listOf(10f, 20f), Color.BLUE),
-                ChartSeries("2026", ChartSeriesType.BAR, listOf(12f, 24f), Color.GREEN),
-            ),
+                ChartSeries("2026", ChartSeriesType.BAR, listOf(12f, 24f), Color.GREEN)
+            )
         )
         val layout = layout(data)
 
@@ -103,8 +103,8 @@ class ChartLayoutEngineTest {
         val data = ChartData(
             categories = listOf("A", "B", "C"),
             series = listOf(
-                ChartSeries("Value", ChartSeriesType.LINE, listOf(1f, 2f, 3f), Color.BLUE),
-            ),
+                ChartSeries("Value", ChartSeriesType.LINE, listOf(1f, 2f, 3f), Color.BLUE)
+            )
         )
         val layout = layout(data)
 
@@ -124,9 +124,9 @@ class ChartLayoutEngineTest {
             ChartData(
                 categories = listOf("A", "B"),
                 series = listOf(
-                    ChartSeries("Flat", ChartSeriesType.LINE, listOf(5f, 5f), Color.BLUE),
-                ),
-            ),
+                    ChartSeries("Flat", ChartSeriesType.LINE, listOf(5f, 5f), Color.BLUE)
+                )
+            )
         )
         assertTrue(constant.scale.minimum < 5f)
         assertTrue(constant.scale.maximum > 5f)
@@ -137,8 +137,8 @@ class ChartLayoutEngineTest {
         val data = ChartData(
             categories = listOf("A"),
             series = listOf(
-                ChartSeries("Value", ChartSeriesType.LINE, listOf(1f), Color.BLUE),
-            ),
+                ChartSeries("Value", ChartSeriesType.LINE, listOf(1f), Color.BLUE)
+            )
         )
 
         val layout = ChartLayoutEngine.layout(
@@ -149,7 +149,7 @@ class ChartLayoutEngineTest {
             requestedTickCount = 5,
             includeZero = false,
             minimumOverride = Float.NaN,
-            maximumOverride = Float.NaN,
+            maximumOverride = Float.NaN
         )
 
         assertTrue(layout.plot.left in 0f..20f)
@@ -176,7 +176,7 @@ class ChartLayoutEngineTest {
     private fun layout(
         data: ChartData,
         minimum: Float = Float.NaN,
-        maximum: Float = Float.NaN,
+        maximum: Float = Float.NaN
     ): ChartLayout {
         return ChartLayoutEngine.layout(
             data = data,
@@ -186,7 +186,7 @@ class ChartLayoutEngineTest {
             requestedTickCount = 5,
             includeZero = false,
             minimumOverride = minimum,
-            maximumOverride = maximum,
+            maximumOverride = maximum
         )
     }
 }

--- a/core/src/commonTest/kotlin/com/tencent/kuikly/core/views/chart/ChartLayoutEngineTest.kt
+++ b/core/src/commonTest/kotlin/com/tencent/kuikly/core/views/chart/ChartLayoutEngineTest.kt
@@ -165,6 +165,14 @@ class ChartLayoutEngineTest {
         assertEquals("-2.5M", formatChartValue(-2_500_000f))
     }
 
+    @Test
+    fun legendRowsExpandWhenItemsWrap() {
+        assertEquals(0, chartLegendLineCount(emptyList(), 200f))
+        assertEquals(1, chartLegendLineCount(listOf(60f, 70f), 200f))
+        assertEquals(2, chartLegendLineCount(listOf(90f, 90f, 90f), 200f))
+        assertEquals(3, chartLegendLineCount(listOf(90f, 90f, 90f), 100f))
+    }
+
     private fun layout(
         data: ChartData,
         minimum: Float = Float.NaN,

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/ChartExamplePage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/ChartExamplePage.kt
@@ -1,0 +1,129 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.demo.pages.demo
+
+import com.tencent.kuikly.core.annotations.Page
+import com.tencent.kuikly.core.base.Color
+import com.tencent.kuikly.core.base.ViewBuilder
+import com.tencent.kuikly.core.reactive.handler.observable
+import com.tencent.kuikly.core.views.List
+import com.tencent.kuikly.core.views.Text
+import com.tencent.kuikly.core.views.chart.Chart
+import com.tencent.kuikly.core.views.chart.ChartLegendPosition
+import com.tencent.kuikly.demo.pages.base.BasePager
+import com.tencent.kuikly.demo.pages.demo.base.NavBar
+
+@Page("ChartExamplePage")
+internal class ChartExamplePage : BasePager() {
+    private var selectionSummary by observable("点击或滑动图表查看数据")
+
+    override fun body(): ViewBuilder {
+        val page = this
+        return {
+            attr {
+                backgroundColor(Color(0xFFF5F7FAL))
+            }
+            NavBar {
+                attr { title = "Chart 图表组件" }
+            }
+            List {
+                attr { flex(1f) }
+
+                Text {
+                    attr {
+                        margin(top = 20f, left = 20f, right = 20f)
+                        text("混合折线图与分组柱状图")
+                        fontSize(17f)
+                        fontWeightMedium()
+                        color(Color(0xFF1D2129L))
+                    }
+                }
+                Text {
+                    attr {
+                        margin(top = 6f, left = 20f, right = 20f)
+                        text(page.selectionSummary)
+                        fontSize(12f)
+                        color(Color(0xFF6B7785L))
+                    }
+                }
+                Chart {
+                    attr {
+                        margin(top = 12f, left = 16f, right = 16f)
+                        size(pagerData.pageViewWidth - 32f, 270f)
+                        backgroundColor(Color.WHITE)
+                        borderRadius(12f)
+                        colors(background = Color.WHITE)
+                        legend(ChartLegendPosition.TOP)
+                        data {
+                            categories("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+                            bar("Orders", Color(0xFF00A870L)) {
+                                values(120f, 168f, 142f, 210f, 232f, 198f, 256f)
+                                showValues = true
+                            }
+                            bar("Returns", Color(0xFFED7B2FL)) {
+                                values(18f, 21f, 15f, 27f, 24f, 20f, 30f)
+                            }
+                            line("Revenue (K)", Color(0xFF0052D9L)) {
+                                values(92f, 126f, 118f, 168f, 182f, 160f, 205f)
+                                lineWidth = 2.5f
+                            }
+                        }
+                    }
+                    event {
+                        selectionChanged { selection ->
+                            val values = selection.values.joinToString { item ->
+                                "${item.seriesName}=${item.value ?: "--"}"
+                            }
+                            page.selectionSummary = "${selection.category}: $values"
+                        }
+                    }
+                }
+
+                Text {
+                    attr {
+                        margin(top = 28f, left = 20f, right = 20f)
+                        text("面积图、负数与缺失数据")
+                        fontSize(17f)
+                        fontWeightMedium()
+                        color(Color(0xFF1D2129L))
+                    }
+                }
+                Chart {
+                    attr {
+                        margin(top = 12f, left = 16f, right = 16f, bottom = 28f)
+                        size(pagerData.pageViewWidth - 32f, 250f)
+                        backgroundColor(Color.WHITE)
+                        borderRadius(12f)
+                        colors(background = Color.WHITE)
+                        legend(ChartLegendPosition.BOTTOM)
+                        areaOpacity(0.22f)
+                        data {
+                            categories("Jan", "Feb", "Mar", "Apr", "May", "Jun")
+                            area("Net change", Color(0xFF7B61FFL)) {
+                                values(-12f, 8f, 24f, null, 18f, 36f)
+                                lineWidth = 2.5f
+                            }
+                            line("Baseline", Color(0xFFE34D59L)) {
+                                values(0f, 0f, 0f, 0f, 0f, 0f)
+                                showPoints = false
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/ChartExamplePage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/ChartExamplePage.kt
@@ -22,6 +22,7 @@ import com.tencent.kuikly.core.reactive.handler.observable
 import com.tencent.kuikly.core.views.List
 import com.tencent.kuikly.core.views.Text
 import com.tencent.kuikly.core.views.chart.Chart
+import com.tencent.kuikly.core.views.chart.ChartInsets
 import com.tencent.kuikly.core.views.chart.ChartLegendPosition
 import com.tencent.kuikly.demo.pages.base.BasePager
 import com.tencent.kuikly.demo.pages.demo.base.NavBar
@@ -106,7 +107,7 @@ internal class ChartExamplePage : BasePager() {
                 }
                 Chart {
                     attr {
-                        margin(top = 12f, left = 16f, right = 16f, bottom = 28f)
+                        margin(top = 12f, left = 16f, right = 16f)
                         size(pagerData.pageViewWidth - 32f, 250f)
                         backgroundColor(Color.WHITE)
                         borderRadius(12f)
@@ -124,6 +125,228 @@ internal class ChartExamplePage : BasePager() {
                                 showPoints = false
                             }
                         }
+                    }
+                }
+
+                Text {
+                    attr {
+                        margin(top = 28f, left = 20f, right = 20f)
+                        text("固定范围与自定义格式")
+                        fontSize(17f)
+                        fontWeightMedium()
+                        color(Color(0xFF1D2129L))
+                    }
+                }
+                Text {
+                    attr {
+                        margin(top = 6f, left = 20f, right = 20f)
+                        text("固定 0%～100% 范围，分别格式化坐标、数值标签和 Tooltip")
+                        fontSize(12f)
+                        color(Color(0xFF6B7785L))
+                    }
+                }
+                Chart {
+                    attr {
+                        margin(top = 12f, left = 16f, right = 16f)
+                        size(pagerData.pageViewWidth - 32f, 260f)
+                        backgroundColor(Color.WHITE)
+                        borderRadius(12f)
+                        colors(background = Color.WHITE)
+                        legend(ChartLegendPosition.BOTTOM)
+                        yRange(0f, 1f)
+                        yTickCount(6)
+                        yLabelFormatter { value -> "${(value * 100f).toInt()}%" }
+                        valueLabelFormatter { value -> "${(value * 100f).toInt()}%" }
+                        tooltipValueFormatter { value -> "${(value * 100f).toInt()} percent" }
+                        data {
+                            categories("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug")
+                            line("Conversion", Color(0xFF0052D9L)) {
+                                values(0.42f, 0.48f, 0.55f, 0.61f, 0.58f, 0.66f, 0.72f, 0.78f)
+                                lineWidth = 2.5f
+                                showValues = true
+                            }
+                            line("Target", Color(0xFF00A870L)) {
+                                values(0.6f, 0.6f, 0.6f, 0.6f, 0.6f, 0.6f, 0.6f, 0.6f)
+                                showPoints = false
+                            }
+                        }
+                    }
+                }
+
+                Text {
+                    attr {
+                        margin(top = 28f, left = 20f, right = 20f)
+                        text("多行图例与自动布局")
+                        fontSize(17f)
+                        fontWeightMedium()
+                        color(Color(0xFF1D2129L))
+                    }
+                }
+                Text {
+                    attr {
+                        margin(top = 6f, left = 20f, right = 20f)
+                        text("长图例会自动换行，并同步扩大绘图区边距")
+                        fontSize(12f)
+                        color(Color(0xFF6B7785L))
+                    }
+                }
+                Chart {
+                    attr {
+                        margin(top = 12f, left = 16f, right = 16f)
+                        size(pagerData.pageViewWidth - 32f, 290f)
+                        backgroundColor(Color.WHITE)
+                        borderRadius(12f)
+                        colors(background = Color.WHITE)
+                        legend(ChartLegendPosition.TOP)
+                        legendFontSize(11f)
+                        yTickCount(4)
+                        data {
+                            categories("Q1", "Q2", "Q3", "Q4")
+                            line("North America Enterprise", Color(0xFF0052D9L)) {
+                                values(32f, 46f, 58f, 74f)
+                                showPoints = false
+                            }
+                            line("Europe Consumer", Color(0xFF00A870L)) {
+                                values(28f, 41f, 49f, 62f)
+                                showPoints = false
+                            }
+                            line("Asia Pacific Growth", Color(0xFFED7B2FL)) {
+                                values(20f, 35f, 54f, 78f)
+                                showPoints = false
+                            }
+                            line("Latin America Online", Color(0xFFE34D59L)) {
+                                values(18f, 27f, 38f, 51f)
+                                showPoints = false
+                            }
+                            line("Middle East Partner", Color(0xFF7B61FFL)) {
+                                values(12f, 22f, 34f, 46f)
+                                showPoints = false
+                            }
+                            line("Africa New Business", Color(0xFF00A6A6L)) {
+                                values(8f, 16f, 25f, 37f)
+                                showPoints = false
+                            }
+                            line("Oceania Direct Channel", Color(0xFF9C6ADEL)) {
+                                values(15f, 24f, 36f, 48f)
+                                showPoints = false
+                            }
+                            line("Global Strategic Accounts", Color(0xFF4C7A34L)) {
+                                values(36f, 48f, 63f, 81f)
+                                showPoints = false
+                            }
+                        }
+                    }
+                }
+
+                Text {
+                    attr {
+                        margin(top = 28f, left = 20f, right = 20f)
+                        text("纯分组柱状图与自定义样式")
+                        fontSize(17f)
+                        fontWeightMedium()
+                        color(Color(0xFF1D2129L))
+                    }
+                }
+                Text {
+                    attr {
+                        margin(top = 6f, left = 20f, right = 20f)
+                        text("关闭图例、网格、Tooltip 和交互，并调整绘图区边距")
+                        fontSize(12f)
+                        color(Color(0xFF6B7785L))
+                    }
+                }
+                Chart {
+                    attr {
+                        margin(top = 12f, left = 16f, right = 16f)
+                        size(pagerData.pageViewWidth - 32f, 245f)
+                        backgroundColor(Color.WHITE)
+                        borderRadius(12f)
+                        colors(
+                            background = Color.WHITE,
+                            axis = Color(0xFF86909CL),
+                            grid = Color(0xFFE5E6EBL),
+                            label = Color(0xFF4E5969L),
+                            tooltipBackground = Color(0xE61D2129L)
+                        )
+                        insets(ChartInsets(left = 58f, top = 24f, right = 24f, bottom = 42f))
+                        legend(ChartLegendPosition.NONE)
+                        gridLines(false)
+                        interactive(false)
+                        tooltip(false)
+                        yLabelFormatter { value -> "${value.toInt()}ms" }
+                        valueLabelFormatter { value -> "${value.toInt()}ms" }
+                        data {
+                            categories("Home", "Search", "Detail", "Checkout")
+                            bar("Android", Color(0xFF0052D9L)) {
+                                values(82f, 96f, 118f, 136f)
+                                showValues = true
+                            }
+                            bar("iOS", Color(0xFF7B61FFL)) {
+                                values(76f, 91f, 109f, 128f)
+                                showValues = true
+                            }
+                        }
+                    }
+                }
+
+                Text {
+                    attr {
+                        margin(top = 28f, left = 20f, right = 20f)
+                        text("常量、单点与自动范围")
+                        fontSize(17f)
+                        fontWeightMedium()
+                        color(Color(0xFF1D2129L))
+                    }
+                }
+                Text {
+                    attr {
+                        margin(top = 6f, left = 20f, right = 20f)
+                        text("常量序列会自动扩展上下界，单点与缺失值也能安全绘制")
+                        fontSize(12f)
+                        color(Color(0xFF6B7785L))
+                    }
+                }
+                Chart {
+                    attr {
+                        margin(top = 12f, left = 16f, right = 16f)
+                        size(pagerData.pageViewWidth - 32f, 230f)
+                        backgroundColor(Color.WHITE)
+                        borderRadius(12f)
+                        colors(background = Color.WHITE)
+                        legend(ChartLegendPosition.BOTTOM)
+                        data {
+                            categories("A", "B", "C", "D")
+                            line("Constant", Color(0xFF00A870L)) {
+                                values(5f, 5f, 5f, 5f)
+                                showValues = true
+                            }
+                            line("Single point", Color(0xFFE34D59L)) {
+                                values(null, null, 8f, null)
+                                showValues = true
+                            }
+                        }
+                    }
+                }
+
+                Text {
+                    attr {
+                        margin(top = 28f, left = 20f, right = 20f)
+                        text("空数据状态")
+                        fontSize(17f)
+                        fontWeightMedium()
+                        color(Color(0xFF1D2129L))
+                    }
+                }
+                Chart {
+                    attr {
+                        margin(top = 12f, left = 16f, right = 16f, bottom = 28f)
+                        size(pagerData.pageViewWidth - 32f, 180f)
+                        backgroundColor(Color.WHITE)
+                        borderRadius(12f)
+                        colors(background = Color.WHITE)
+                        legend(ChartLegendPosition.NONE)
+                        emptyText("暂无可展示数据")
+                        data {}
                     }
                 }
             }

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/ChartExamplePage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/ChartExamplePage.kt
@@ -89,6 +89,9 @@ internal class ChartExamplePage : BasePager() {
                             }
                             page.selectionSummary = "${selection.category}: $values"
                         }
+                        selectionCleared {
+                            page.selectionSummary = "点击或滑动图表查看数据"
+                        }
                     }
                 }
 

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/catalog/ExampleIndexPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/catalog/ExampleIndexPage.kt
@@ -174,6 +174,13 @@ internal class ExampleIndexPage : BasePager() {
         })
 
         itemList.add(ExampleItemData().apply {
+            avatarText = "Ch"
+            titleText = "ChartView"
+            subtitleText = "跨端折线图、柱状图和面积图，支持声明式 DSL 与交互选点"
+            declarativeExampleUrl = generateJumpUrl("ChartExamplePage")
+        })
+
+        itemList.add(ExampleItemData().apply {
             avatarText = "Bu"
             titleText = "ButtonView"
             subtitleText = "Kuikly中的Button实际上是一个带有文字和背景颜色的View"

--- a/docs/API/components/chart.md
+++ b/docs/API/components/chart.md
@@ -1,0 +1,168 @@
+# Chart（跨端图表）
+
+`Chart` 是基于 Kuikly `Canvas` 实现的声明式跨端图表组件。一份 Kotlin 代码可在 Android、iOS、macOS、HarmonyOS、Web 和小程序上运行，无需接入平台图表 SDK。
+
+组件内置以下能力：
+
+- 折线图、分组柱状图和面积图，可在同一坐标系混合展示；
+- 自动计算易读的 Y 轴范围和刻度，也可指定固定范围；
+- 坐标轴、网格线、图例、数值标签和空状态；
+- 通过点击或滑动选中分类，展示十字线和 Tooltip；
+- `null` 数据断点、正负值、单点、常量数据和空数据的安全处理；
+- 使用纯 Kotlin 布局引擎计算刻度、坐标与命中区域，所有平台保持一致。
+
+[完整示例](https://github.com/Tencent-TDS/KuiklyUI/blob/main/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/ChartExamplePage.kt)
+
+## 快速开始
+
+```kotlin
+import com.tencent.kuikly.core.base.Color
+import com.tencent.kuikly.core.views.chart.Chart
+
+Chart {
+    attr {
+        size(360f, 260f)
+        data {
+            categories("Mon", "Tue", "Wed", "Thu", "Fri")
+
+            bar("Orders", Color(0xFF00A870L)) {
+                values(120f, 168f, 142f, 210f, 232f)
+                showValues = true
+            }
+
+            line("Revenue", Color(0xFF0052D9L)) {
+                values(92f, 126f, 118f, 168f, 182f)
+                lineWidth = 2.5f
+            }
+        }
+    }
+    event {
+        selectionChanged { selection ->
+            // selection.index、selection.category、selection.values
+        }
+    }
+}
+```
+
+> `Chart` 必须设置明确的宽度和高度。组件会在初始化时校验尺寸，避免零尺寸 Canvas 静默不渲染。
+
+## 数据 DSL
+
+### categories
+
+设置 X 轴分类：
+
+```kotlin
+categories("Jan", "Feb", "Mar")
+```
+
+如果系列的数据数量多于分类数量，组件会自动使用从 `1` 开始的序号补全标签。
+
+### line
+
+添加折线系列：
+
+```kotlin
+line("Temperature", Color(0xFFE34D59L)) {
+    values(18f, 21f, null, 26f)
+    lineWidth = 2f
+    showPoints = true
+    showValues = false
+}
+```
+
+`null` 表示数据缺失。折线和面积不会跨过缺失点连接，Tooltip 中显示为 `--`。
+
+### bar
+
+添加柱状系列。多个柱状系列会自动在分类带内分组排列：
+
+```kotlin
+bar("2025", Color(0xFF0052D9L)) { values(12f, 18f, 21f) }
+bar("2026", Color(0xFF00A870L)) { values(16f, 22f, 25f) }
+```
+
+### area
+
+添加面积系列。面积以 `0` 或当前 Y 轴中最接近 `0` 的边界作为基线：
+
+```kotlin
+area("Net change", Color(0xFF7B61FFL)) {
+    values(-12f, 8f, 24f, null, 18f)
+}
+```
+
+可通过 `areaOpacity(0.2f)` 调整填充透明度。
+
+## 属性
+
+除所有[基础属性](basic-attr-event.md#基础属性)外，`ChartAttr` 提供以下配置：
+
+| 方法 | 默认值 | 说明 |
+|:---|:---|:---|
+| `data(ChartData)` | 空数据 | 直接传入不可变数据模型 |
+| `data { ... }` | 空数据 | 使用声明式 DSL 构造数据 |
+| `insets(ChartInsets)` | `48,18,16,38` | 绘图区为坐标标签保留的边距 |
+| `legend(position)` | `TOP` | `NONE`、`TOP` 或 `BOTTOM` |
+| `interactive(enabled)` | `true` | 是否响应点击和滑动选点 |
+| `tooltip(visible)` | `true` | 选中时是否展示 Tooltip |
+| `gridLines(visible)` | `true` | 是否绘制水平网格线 |
+| `includeZero(include)` | `false` | 自动范围是否强制包含 0；柱状图和面积图始终包含 0 |
+| `yTickCount(count)` | `5` | 期望 Y 轴刻度数，范围 2～10 |
+| `yRange(min, max)` | 自动 | 固定 Y 轴范围 |
+| `autoYRange()` | — | 恢复自动范围 |
+| `labelFontSize(size)` | `11` | 坐标轴和 Tooltip 字号 |
+| `legendFontSize(size)` | `11` | 图例字号 |
+| `emptyText(text)` | `No data` | 空数据文案 |
+| `colors(...)` | 内置中性色 | 背景、坐标轴、网格、文字和 Tooltip 颜色 |
+| `areaOpacity(opacity)` | `0.18` | 面积填充透明度 |
+| `yLabelFormatter { ... }` | 智能缩写 | 自定义 Y 轴标签 |
+| `tooltipValueFormatter { ... }` | 智能缩写 | 自定义 Tooltip 数值 |
+
+图例会自动为绘图区增加 22dp 的上/下边距，不需要调用方重复预留。
+
+## 事件
+
+### selectionChanged
+
+用户点击或在图表上滑动到新的分类时触发：
+
+```kotlin
+event {
+    selectionChanged { selection ->
+        val index = selection.index
+        val label = selection.category
+        selection.values.forEach { item ->
+            // item.seriesName、item.value、item.color
+        }
+    }
+}
+```
+
+`ChartSelection.values` 保持系列声明顺序，便于业务渲染自定义详情面板。
+
+## 动态更新
+
+`ChartData` 是不可变模型。父组件中的响应式状态改变后，重新执行 `data(newData)` 即可触发 Canvas 重绘：
+
+```kotlin
+Chart {
+    attr {
+        size(360f, 240f)
+        data(currentChartData)
+    }
+}
+```
+
+## 边界行为
+
+- 非有限数值（`NaN`、正负无穷）按缺失数据处理；
+- 空数据展示 `emptyText`，不会产生无效坐标；
+- 全部数值相同时自动扩展上下界，避免除零；
+- 固定范围的 `min > max` 时会自动交换；
+- X 轴分类超过 8 个时自动抽样标签，但所有数据点仍会绘制；
+- 图表本身不滚动或缩放，适合仪表盘和业务卡片；大量数据建议先在业务层采样。
+
+## 平台说明
+
+图表只依赖 `commonMain` 中的 `Canvas`、手势和响应式能力，不包含平台分支。各平台会复用 Kuikly 对应的 Canvas Renderer；颜色、间距和数据布局由同一套纯 Kotlin 布局引擎计算。

--- a/docs/API/components/chart.md
+++ b/docs/API/components/chart.md
@@ -117,9 +117,10 @@ area("Net change", Color(0xFF7B61FFL)) {
 | `colors(...)` | 内置中性色 | 背景、坐标轴、网格、文字和 Tooltip 颜色 |
 | `areaOpacity(opacity)` | `0.18` | 面积填充透明度 |
 | `yLabelFormatter { ... }` | 智能缩写 | 自定义 Y 轴标签 |
+| `valueLabelFormatter { ... }` | 智能缩写 | 自定义系列数值标签 |
 | `tooltipValueFormatter { ... }` | 智能缩写 | 自定义 Tooltip 数值 |
 
-图例会自动为绘图区增加 22dp 的上/下边距，不需要调用方重复预留。
+图例会根据实际换行数动态增加绘图区的上/下边距，不需要调用方重复预留。
 
 ## 事件
 
@@ -135,6 +136,9 @@ event {
         selection.values.forEach { item ->
             // item.seriesName、item.value、item.color
         }
+    }
+    selectionCleared {
+        // 用户移出绘图区、十字线消失时清空业务侧选中状态
     }
 }
 ```

--- a/docs/sidebar/zh.ts
+++ b/docs/sidebar/zh.ts
@@ -175,7 +175,7 @@ export const zhSidebar = sidebar({
             text: "组件",
             prefix: "/API/components",
             children: [
-                "override.md", "basic-attr-event.md", "pager.md", "ios26-liquid-glass.md", "view.md", "text.md", "rich-text.md", "text-selection.md", "image.md", "input.md", "text-area.md",  "canvas.md",
+                "override.md", "basic-attr-event.md", "pager.md", "ios26-liquid-glass.md", "view.md", "text.md", "rich-text.md", "text-selection.md", "image.md", "input.md", "text-area.md",  "canvas.md", "chart.md",
                 "button.md", "scroller.md", "list.md", "waterfall-list.md", "slider-page.md", "page-list.md", "modal.md", "refresh.md",
                 "footer-refresh.md", "date-picker.md", "scroll-picker.md", "slider.md", "switch.md", "blur.md",
                 "activity-indicator.md", "hover.md", "mask.md", "checkbox.md", "pag.md","apng.md", "tabs.md","alert-dialog.md","action-sheet.md", "video.md",


### PR DESCRIPTION
## Summary

- add a Canvas-based cross-platform `Chart` component with line, grouped bar, area, and mixed-series rendering
- add a declarative data DSL, automatic/fixed Y scales, axes, dynamically wrapping legends, independent value/tooltip formatters, empty states, and tap/drag tooltip selection
- keep selection and business state synchronized when the pointer leaves the plot area
- add a catalog demo, Chinese API documentation, and pure-Kotlin layout tests covering scale, bars, hit testing, missing/constant data, tiny viewports, and legend wrapping

## Validation

- `./gradlew :core:jsBrowserTest` — 10 tests passed
- `./gradlew :core:test` — successful
- `./gradlew :core:lint` — successful
- `./gradlew :demo:packLocalJsBundleDebug -Pkuikly.useLocalKsp=false` — successful
- `./gradlew :h5App:jsBrowserDevelopmentExecutableDistribution` — successful
- `./gradlew :androidApp:compileDebugKotlin` — successful
- manually verified both charts and interactive tooltip in Chrome

Closes #1477