### PR TITLE
fix: clamp negative scroll offset index to prevent IndexOutOfBoundsException in TabsView

### DIFF
--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TabsView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TabsView.kt
@@ -81,8 +81,8 @@ class TabsView : ListView<TabsAttr, TabsEvent>(), IPagerLayoutEventObserver {
         var width =  tabItems[selectedIndex].flexNode.layoutFrame.width
         var scrollProgress = if (tabItems.size - 1 <= 0) 0f else (selectedIndex.toFloat() / ((tabItems.size - 1).toFloat()))
         this.attr.scrollParams?.also {
-            selectedIndex = min((it.offsetX / it.viewWidth + 0.5f).toInt(), tabItems.size - 1)
-            val leftIndex = min((it.offsetX / it.viewWidth).toInt(),tabItems.size - 1)
+            selectedIndex = max(0, min((it.offsetX / it.viewWidth + 0.5f).toInt(), tabItems.size - 1))
+            val leftIndex = max(0, min((it.offsetX / it.viewWidth).toInt(),tabItems.size - 1))
             val rightIndex = min(leftIndex + 1, tabItems.size - 1)
             val letItemFrame = tabItems[leftIndex].flexNode.layoutFrame
             val rightItemFrame = tabItems[rightIndex].flexNode.layoutFrame


### PR DESCRIPTION
## Summary

Fix `IndexOutOfBoundsException: index: -1, size: 9` crash in `TabsView` when `scrollParams.offsetX` is negative.

## Root Cause

In `TabsView.updateIndicatorPositionIfNeed()` (TabsView.kt:84-85), the index calculations use `min(idx, size-1)` to guard the upper bound but lack a lower-bound guard. When `offsetX` is sufficiently negative (HarmonyOS overscroll/bounce), `(offsetX / viewWidth).toInt()` produces `-1`, and `min(-1, size-1)` returns `-1`, causing `ArrayList.get(-1)`.

## Fix

Add `max(0, ...)` to clamp `selectedIndex` and `leftIndex` to non-negative values:

```diff
- selectedIndex = min((it.offsetX / it.viewWidth + 0.5f).toInt(), tabItems.size - 1)
- val leftIndex = min((it.offsetX / it.viewWidth).toInt(), tabItems.size - 1)
+ selectedIndex = max(0, min((it.offsetX / it.viewWidth + 0.5f).toInt(), tabItems.size - 1))
+ val leftIndex = max(0, min((it.offsetX / it.viewWidth).toInt(), tabItems.size - 1))
```

## Test Plan

- [x] `./gradlew :core:compileDebugKotlinAndroid` passes
- [ ] Verify on HarmonyOS device with Tabs + PageList overscroll

## Files Changed

- `core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TabsView.kt` (+2, -2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)