### PR TITLE
feat(gesture): implement pinch event for Android and iOS renderers

### DIFF
--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/const/KRConst.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/const/KRConst.kt
@@ -60,6 +60,7 @@ object KRCssConst {
     const val FRAME = "frame"
     const val Z_INDEX = "zIndex"
     const val PAN = "pan"
+    const val PINCH = "pinch"
     
     const val PREVENT_TOUCH = "preventTouch"
     const val CONSUME_TOUCH_DOWN = "consumeDown"

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/gesture/KRCSSGestureDetector.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/gesture/KRCSSGestureDetector.kt
@@ -22,9 +22,10 @@ import android.view.SoundEffectConstants
 import android.view.View
 import com.tencent.kuikly.core.render.android.export.KuiklyRenderCallback
 import java.lang.ref.WeakReference
+import kotlin.math.hypot
 
 /**
- * 手势检测器。在[GestureDetector]的基础上扩展了pan事件
+ * 手势检测器。在[GestureDetector]的基础上扩展了pan、pinch事件
  */
 class KRCSSGestureDetector(
     context: Context,
@@ -38,9 +39,214 @@ class KRCSSGestureDetector(
 
     private val targetViewWeakRef = WeakReference(targetView)
 
+    // region pinch(捏合)手势
+    //
+    // 未使用 android.view.ScaleGestureDetector，而是直接跟踪两指间距计算缩放倍数。
+    //
+    // 原因: ScaleGestureDetector 面向「带阈值的增量式缩放」设计，与 Kuikly 的
+    // PinchGestureParams 契约(相对手势起点的累计倍数，两指落下即开始)不一致:
+    // 1. 存在 minSpan 门槛(约27mm)与手势识别过程，起手一段位移被吞掉，
+    //    表现为手指移动很多而缩放很少，跟手感明显弱于iOS
+    // 2. 识别态会反复进出，onScaleBegin 多次触发导致基准间距被重复采集，
+    //    表现为缩放过程抖动，且倍数容易被推向极值后无法回退
+    //
+    // 直接计算指间距可保证: 无阈值、起手即响应、倍数严格等于 当前间距/起始间距，
+    // 与 iOS UIPinchGestureRecognizer、鸿蒙 ArkUI pinch 的语义一致。
+
+    /** 参与捏合的两个手指id，[INVALID_POINTER_ID]表示未激活 */
+    private var pinchPointerId1 = INVALID_POINTER_ID
+    private var pinchPointerId2 = INVALID_POINTER_ID
+
+    /** 手势开始时的两指间距(px)，作为累计倍数的分母 */
+    private var pinchInitialDistance = 0f
+
+    /** 最近一次的缩放倍数与焦点，用于手势结束时补发end事件 */
+    private var lastPinchScale = 1f
+    private var lastPinchFocusX = 0f
+    private var lastPinchFocusY = 0f
+
+    /** 坐标映射缓冲区(两个点共4个分量)，避免每帧分配 */
+    private val pinchPointBuffer = FloatArray(4)
+
+    /**
+     * 是否已因pinch而要求父容器不拦截事件。
+     *
+     * 用于保证「谁设置谁清除」: 手势结束时必须复位，否则外层滚动容器会永久无法滚动。
+     */
+    private var hasDisallowInterceptForPinch = false
+
+    /**
+     * 处理捏合手势。
+     * @return 是否消费了事件
+     */
+    private fun handlePinchEvent(ev: MotionEvent): Boolean {
+        when (ev.actionMasked) {
+            MotionEvent.ACTION_POINTER_DOWN -> {
+                if (!listener.isPinchEventHappening && ev.pointerCount >= PINCH_POINTER_COUNT) {
+                    return startPinch(ev)
+                }
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                if (listener.isPinchEventHappening) {
+                    return movePinch(ev)
+                }
+            }
+
+            MotionEvent.ACTION_POINTER_UP -> {
+                // 抬起的是参与捏合的手指时结束手势
+                if (listener.isPinchEventHappening) {
+                    val liftedId = ev.getPointerId(ev.actionIndex)
+                    if (liftedId == pinchPointerId1 || liftedId == pinchPointerId2) {
+                        endPinch()
+                        return true
+                    }
+                }
+            }
+
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                if (listener.isPinchEventHappening) {
+                    endPinch()
+                }
+                releasePinchInterceptIfNeeded()
+            }
+        }
+        return false
+    }
+
+    private fun startPinch(ev: MotionEvent): Boolean {
+        val index1 = 0
+        val index2 = 1
+        val distance = pointerDistance(ev, index1, index2)
+        if (distance <= 0f) {
+            return false
+        }
+
+        // 第一根手指的移动可能已触发pan，此处需补发pan结束事件，
+        // 否则业务侧只收到start/move而收不到end，状态会一直停留在拖拽中
+        if (listener.isPanEventHappening) {
+            listener.onCancel(ev)
+        }
+
+        pinchPointerId1 = ev.getPointerId(index1)
+        pinchPointerId2 = ev.getPointerId(index2)
+        pinchInitialDistance = distance
+        lastPinchScale = 1f
+        lastPinchFocusX = (ev.getX(index1) + ev.getX(index2)) * 0.5f
+        lastPinchFocusY = (ev.getY(index1) + ev.getY(index2)) * 0.5f
+        listener.isPinchEventHappening = true
+
+        // 两指落下即表明缩放意图，此时就要求父容器不拦截。
+        //
+        // 必须在此刻请求: 外层滚动容器在移动超过 touchSlop 时便会拦截并向本View
+        // 派发 ACTION_CANCEL，之后收不到任何事件。若等到手势被识别后再请求，
+        // 竖向捏合会被列表滚动抢走，横向捏合也会因竖向抖动而时好时坏。
+        if (!hasDisallowInterceptForPinch) {
+            hasDisallowInterceptForPinch = true
+            disallowParentInterceptEvent(true)
+        }
+
+        listener.updatePinchRawOffset(ev)
+        listener.dispatchPinchEvent(
+            KRCSSGestureListener.EVENT_STATE_START,
+            lastPinchFocusX,
+            lastPinchFocusY,
+            1f
+        )
+        return true
+    }
+
+    private fun movePinch(ev: MotionEvent): Boolean {
+        val index1 = ev.findPointerIndex(pinchPointerId1)
+        val index2 = ev.findPointerIndex(pinchPointerId2)
+        if (index1 < 0 || index2 < 0) { // 手指已离开，结束手势
+            endPinch()
+            return true
+        }
+
+        val distance = pointerDistance(ev, index1, index2)
+        if (distance <= 0f || pinchInitialDistance <= 0f) {
+            return false
+        }
+
+        lastPinchScale = distance / pinchInitialDistance
+        lastPinchFocusX = (ev.getX(index1) + ev.getX(index2)) * 0.5f
+        lastPinchFocusY = (ev.getY(index1) + ev.getY(index2)) * 0.5f
+
+        listener.updatePinchRawOffset(ev)
+        listener.dispatchPinchEvent(
+            KRCSSGestureListener.EVENT_STATE_MOVE,
+            lastPinchFocusX,
+            lastPinchFocusY,
+            lastPinchScale
+        )
+        return true
+    }
+
+    private fun endPinch() {
+        listener.isPinchEventHappening = false
+        pinchPointerId1 = INVALID_POINTER_ID
+        pinchPointerId2 = INVALID_POINTER_ID
+        pinchInitialDistance = 0f
+        listener.dispatchPinchEvent(
+            KRCSSGestureListener.EVENT_STATE_END,
+            lastPinchFocusX,
+            lastPinchFocusY,
+            lastPinchScale
+        )
+    }
+
+    /**
+     * 复位「父容器不拦截」标志。
+     *
+     * 仅在所有手指抬起或事件被取消时调用: 若在手势中途(如仅松开一根手指)复位，
+     * 外层容器会立刻抢走剩余手指的移动事件。
+     */
+    private fun releasePinchInterceptIfNeeded() {
+        if (hasDisallowInterceptForPinch) {
+            hasDisallowInterceptForPinch = false
+            disallowParentInterceptEvent(false)
+        }
+    }
+
+    /**
+     * 计算两指间距，在**父坐标系**下测量。
+     *
+     * 不能直接用 [MotionEvent.getX] 的局部坐标测距: ViewGroup 派发事件给子View时会
+     * 施加子View矩阵的逆变换，故局部指间距约等于「物理指间距 / 当前scale」。
+     * 若用它计算 scale 会形成自激振荡:
+     *   scale变大 → 局部指间距变小 → 算出的scale变小 → scale变小 → 局部指间距变大 → ...
+     * 表现为两指静止不动时画面持续抖动，且scale越大抖动越剧烈。
+     *
+     * 经 [View.getMatrix] 映射到父坐标系后即可消除本View自身transform的影响，
+     * 与 iOS UIPinchGestureRecognizer 在窗口坐标系计算scale的做法一致。
+     * 当本View未设置transform时矩阵为单位矩阵，映射为空操作，行为不变。
+     */
+    private fun pointerDistance(ev: MotionEvent, index1: Int, index2: Int): Float {
+        val targetView = targetViewWeakRef.get()
+            ?: return hypot(ev.getX(index1) - ev.getX(index2), ev.getY(index1) - ev.getY(index2))
+
+        pinchPointBuffer[0] = ev.getX(index1)
+        pinchPointBuffer[1] = ev.getY(index1)
+        pinchPointBuffer[2] = ev.getX(index2)
+        pinchPointBuffer[3] = ev.getY(index2)
+        targetView.matrix.mapPoints(pinchPointBuffer)
+        return hypot(
+            pinchPointBuffer[0] - pinchPointBuffer[2],
+            pinchPointBuffer[1] - pinchPointBuffer[3]
+        )
+    }
+
+    // endregion
+
     override fun onTouchEvent(ev: MotionEvent): Boolean {
         if (containPanEvent() && ev.action == MotionEvent.ACTION_DOWN) { // 对齐原来逻辑，有pan事件时, 要求父亲不拦截
             disallowParentInterceptEvent(true)
+        }
+
+        var pinchHandle = false
+        if (containPinchEvent()) {
+            pinchHandle = handlePinchEvent(ev)
         }
 
         val handle = super.onTouchEvent(ev)
@@ -64,13 +270,15 @@ class KRCSSGestureDetector(
             }
         }
 
-        return handle
+        return handle || pinchHandle
     }
 
     private fun disallowParentInterceptEvent(disallow: Boolean) =
         targetViewWeakRef.get()?.parent?.requestDisallowInterceptTouchEvent(disallow)
 
     private fun containPanEvent(): Boolean = listener.containEvent(KRCSSGestureListener.TYPE_PAN)
+
+    private fun containPinchEvent(): Boolean = listener.containEvent(KRCSSGestureListener.TYPE_PINCH)
 
     fun hasListener(type: Int): Boolean = listener.containEvent(type)
     fun addListener(type: Int, callback: KuiklyRenderCallback) {
@@ -98,5 +306,11 @@ class KRCSSGestureDetector(
 
     companion object {
         const val GESTURE_TAG = "hr_gesture_tag"
+
+        /** 触发pinch所需的手指数 */
+        private const val PINCH_POINTER_COUNT = 2
+
+        /** 无效的手指id */
+        private const val INVALID_POINTER_ID = -1
     }
 }

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/gesture/KRCSSGestureDetector.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/gesture/KRCSSGestureDetector.kt
@@ -75,6 +75,11 @@ class KRCSSGestureDetector(
      */
     private var hasDisallowInterceptForPinch = false
 
+    /** 上次的缩放倍数与时间戳，用于计算 velocity(倍/秒) */
+    private var prevPinchScale = 0f
+    private var prevPinchTimeMs = 0L
+    private var lastPinchVelocity = 0f
+
     /**
      * 处理捏合手势。
      * @return 是否消费了事件
@@ -147,11 +152,15 @@ class KRCSSGestureDetector(
         }
 
         listener.updatePinchRawOffset(ev)
+        prevPinchScale = 1f
+        prevPinchTimeMs = 0L
+        lastPinchVelocity = 0f
         listener.dispatchPinchEvent(
             KRCSSGestureListener.EVENT_STATE_START,
             lastPinchFocusX,
             lastPinchFocusY,
-            1f
+            1f,
+            0f
         )
         return true
     }
@@ -174,11 +183,23 @@ class KRCSSGestureDetector(
         lastPinchFocusY = (ev.getY(index1) + ev.getY(index2)) * 0.5f
 
         listener.updatePinchRawOffset(ev)
+        // 计算 velocity: scale 变化率(倍/秒)，与 iOS UIPinchGestureRecognizer.velocity 语义一致
+        val nowMs = System.currentTimeMillis()
+        if (prevPinchTimeMs > 0 && nowMs > prevPinchTimeMs) {
+            val dt = (nowMs - prevPinchTimeMs) / 1000.0
+            if (dt > 0) {
+                lastPinchVelocity = ((lastPinchScale - prevPinchScale) / dt).toFloat()
+            }
+        }
+        prevPinchScale = lastPinchScale
+        prevPinchTimeMs = nowMs
+
         listener.dispatchPinchEvent(
             KRCSSGestureListener.EVENT_STATE_MOVE,
             lastPinchFocusX,
             lastPinchFocusY,
-            lastPinchScale
+            lastPinchScale,
+            lastPinchVelocity
         )
         return true
     }
@@ -192,7 +213,8 @@ class KRCSSGestureDetector(
             KRCSSGestureListener.EVENT_STATE_END,
             lastPinchFocusX,
             lastPinchFocusY,
-            lastPinchScale
+            lastPinchScale,
+            lastPinchVelocity
         )
     }
 
@@ -207,6 +229,22 @@ class KRCSSGestureDetector(
             hasDisallowInterceptForPinch = false
             disallowParentInterceptEvent(false)
         }
+    }
+
+    /**
+     * 清理所有手势状态，用于视图复用或销毁时调用。
+     *
+     * 必须在移除 OnTouchListener 之前调用，否则:
+     * - pinch 进行中的 requestDisallowInterceptTouchEvent(true) 不会被复位，父容器永久无法滚动
+     * - isPinchEventHappening / isPanEventHappening 状态残留，可能导致后续手势逻辑异常
+     */
+    fun cleanup() {
+        if (listener.isPinchEventHappening) {
+            endPinch()
+        }
+        releasePinchInterceptIfNeeded()
+        listener.isPanEventHappening = false
+        listener.isLongPressEventHappening = false
     }
 
     /**

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/gesture/KRCSSGestureListener.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/gesture/KRCSSGestureListener.kt
@@ -25,11 +25,12 @@ import java.lang.ref.WeakReference
 
 /**
  * 手势处理类
- * 目前支持以下三种手势:
+ * 目前支持以下五种手势:
  * 1.[TYPE_CLICK]: 单击事件
  * 2.[TYPE_DOUBLE_CLICK]: 双击事件
  * 3.[TYPE_LONG_PRESS]: 长按事件
  * 4.[TYPE_PAN]: 拖拽事件
+ * 5.[TYPE_PINCH]: 捏合事件
  */
 class KRCSSGestureListener(private val kuiklyContext: IKuiklyRenderContext?) : GestureDetector.SimpleOnGestureListener() {
 
@@ -47,6 +48,14 @@ class KRCSSGestureListener(private val kuiklyContext: IKuiklyRenderContext?) : G
      * 是否正在触发longPress事件
      */
     var isLongPressEventHappening = false
+
+    /**
+     * 是否正在触发pinch事件
+     */
+    var isPinchEventHappening = false
+
+    private var pinchRawOffsetX = 0f
+    private var pinchRawOffsetY = 0f
 
     private var gestureDetectorWeakRef: WeakReference<GestureDetector>? = null
 
@@ -225,6 +234,21 @@ class KRCSSGestureListener(private val kuiklyContext: IKuiklyRenderContext?) : G
         distanceX: Float,
         distanceY: Float
     ): Boolean {
+        // pinch进行中不派发pan。
+        //
+        // pan与pinch在语义上并不冲突(可同时表达质心平移与间距缩放)，此处抑制是为了
+        // 划清「单指pan、双指pinch」的职责边界，原因有两点:
+        // 1. pan的坐标语义在多指下不自洽: onScroll的触发条件是所有手指的焦点位移，
+        //    而派发时取的是MotionEvent.getX()(即index 0那根手指)，二者并非同一个点，
+        //    手指增减时报出的位置还会跳变。
+        // 2. 双指平移能力并未丢失: pinch每帧都带焦点坐标(x/y与pageX/pageY)，
+        //    业务可直接由焦点位移派生平移量，无需依赖双指pan。
+        //
+        // 该边界仅在组件同时注册pan与pinch时生效，只注册pan的存量组件行为不变。
+        // 与iOS侧限制panGR最多1指的处理保持一致。
+        if (isPinchEventHappening) {
+            return false
+        }
         // 通过滚动事件来作为pan事件
         return if (containEvent(TYPE_PAN)) {
             if (!isPanEventHappening) { // 首次发生pan事件时, 补down事件
@@ -246,6 +270,37 @@ class KRCSSGestureListener(private val kuiklyContext: IKuiklyRenderContext?) : G
             PAGE_X to kuiklyContext.toDpF(e.rawX),
             PAGE_Y to kuiklyContext.toDpF(e.rawY)
         ))
+    }
+
+    /**
+     * 记录当前触摸事件中，view局部坐标到屏幕坐标的偏移量。
+     *
+     * 捏合焦点由两指坐标取中点得到，只有view局部坐标，
+     * 需要借助该偏移量换算出 pageX/pageY，与pan事件保持一致的坐标语义。
+     */
+    fun updatePinchRawOffset(e: MotionEvent) {
+        pinchRawOffsetX = e.rawX - e.x
+        pinchRawOffsetY = e.rawY - e.y
+    }
+
+    /**
+     * 派发pinch事件
+     * @param state 手势状态: start/move/end
+     * @param focusX 捏合中心点在view局部坐标系下的x
+     * @param focusY 捏合中心点在view局部坐标系下的y
+     * @param scale 相对手势开始时的累计缩放倍数
+     */
+    fun dispatchPinchEvent(state: String, focusX: Float, focusY: Float, scale: Float) {
+        dispatchEvent(
+            TYPE_PINCH, mapOf(
+                KRViewConst.X to kuiklyContext.toDpF(focusX),
+                KRViewConst.Y to kuiklyContext.toDpF(focusY),
+                EVENT_STATE to state,
+                PAGE_X to kuiklyContext.toDpF(focusX + pinchRawOffsetX),
+                PAGE_Y to kuiklyContext.toDpF(focusY + pinchRawOffsetY),
+                SCALE to scale
+            )
+        )
     }
 
     private fun dispatchEvent(type: Int, result: Map<String, Any>): Boolean {
@@ -271,10 +326,12 @@ class KRCSSGestureListener(private val kuiklyContext: IKuiklyRenderContext?) : G
         const val TYPE_DOUBLE_CLICK = 2
         const val TYPE_LONG_PRESS = 3
         const val TYPE_PAN = 4
+        const val TYPE_PINCH = 5
 
         const val EVENT_STATE = "state"
         private const val PAGE_X = "pageX"
         private const val PAGE_Y = "pageY"
+        private const val SCALE = "scale"
         const val EVENT_STATE_START = "start"
         internal const val EVENT_STATE_MOVE = "move"
         internal const val EVENT_STATE_END = "end"

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/gesture/KRCSSGestureListener.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/gesture/KRCSSGestureListener.kt
@@ -289,8 +289,9 @@ class KRCSSGestureListener(private val kuiklyContext: IKuiklyRenderContext?) : G
      * @param focusX 捏合中心点在view局部坐标系下的x
      * @param focusY 捏合中心点在view局部坐标系下的y
      * @param scale 相对手势开始时的累计缩放倍数
+     * @param velocity 缩放倍数变化速率(倍/秒)，与iOS UIPinchGestureRecognizer.velocity语义一致
      */
-    fun dispatchPinchEvent(state: String, focusX: Float, focusY: Float, scale: Float) {
+    fun dispatchPinchEvent(state: String, focusX: Float, focusY: Float, scale: Float, velocity: Float) {
         dispatchEvent(
             TYPE_PINCH, mapOf(
                 KRViewConst.X to kuiklyContext.toDpF(focusX),
@@ -298,7 +299,8 @@ class KRCSSGestureListener(private val kuiklyContext: IKuiklyRenderContext?) : G
                 EVENT_STATE to state,
                 PAGE_X to kuiklyContext.toDpF(focusX + pinchRawOffsetX),
                 PAGE_Y to kuiklyContext.toDpF(focusY + pinchRawOffsetY),
-                SCALE to scale
+                SCALE to scale,
+                VELOCITY to velocity
             )
         )
     }
@@ -332,6 +334,7 @@ class KRCSSGestureListener(private val kuiklyContext: IKuiklyRenderContext?) : G
         private const val PAGE_X = "pageX"
         private const val PAGE_Y = "pageY"
         private const val SCALE = "scale"
+        private const val VELOCITY = "velocity"
         const val EVENT_STATE_START = "start"
         internal const val EVENT_STATE_MOVE = "move"
         internal const val EVENT_STATE_END = "end"

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/gesture/KRCSSGestureListener.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/gesture/KRCSSGestureListener.kt
@@ -158,7 +158,9 @@ class KRCSSGestureListener(private val kuiklyContext: IKuiklyRenderContext?) : G
 
     fun onCancel(e: MotionEvent) {
         if (isPanEventHappening) {
-            onPanEnd(e)
+            // pan 被 pinch 接管时补发 cancel 而非 end，避免 demo 侧在 STATE_END
+            // 固化 translate 导致「捏合变拖拽」。与 iOS 侧 Failed→"cancel" 对齐。
+            dispatchPanEvent(MotionEvent.ACTION_CANCEL, e)
         }
         isPanEventHappening = false
     }
@@ -319,6 +321,7 @@ class KRCSSGestureListener(private val kuiklyContext: IKuiklyRenderContext?) : G
         return when (action) {
             MotionEvent.ACTION_DOWN -> EVENT_STATE_START
             MotionEvent.ACTION_MOVE -> EVENT_STATE_MOVE
+            MotionEvent.ACTION_CANCEL -> EVENT_STATE_CANCEL
             else -> EVENT_STATE_END
         }
     }
@@ -338,6 +341,7 @@ class KRCSSGestureListener(private val kuiklyContext: IKuiklyRenderContext?) : G
         const val EVENT_STATE_START = "start"
         internal const val EVENT_STATE_MOVE = "move"
         internal const val EVENT_STATE_END = "end"
+        internal const val EVENT_STATE_CANCEL = "cancel"
         internal const val IS_CANCEL = "isCancel"
     }
 

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/ktx/KRCSSViewExtension.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/ktx/KRCSSViewExtension.kt
@@ -162,6 +162,10 @@ fun View.setCommonProp(key: String, value: Any): Boolean {
             addEventListener(KRCSSGestureListener.TYPE_PAN, value as KuiklyRenderCallback)
             true
         }
+        KRCssConst.PINCH -> {
+            addEventListener(KRCSSGestureListener.TYPE_PINCH, value as KuiklyRenderCallback)
+            true
+        }
         KRCssConst.ANIMATION_COMPLETION_BLOCK -> {
             animationCompletionBlock = value as KuiklyRenderCallback
             true
@@ -300,6 +304,9 @@ fun View.resetCommonProp(propKey: String): Boolean {
             return true
         }
         KRCssConst.PAN -> {
+            resetEventListener()
+        }
+        KRCssConst.PINCH -> {
             resetEventListener()
         }
         KRCssConst.ANIMATION -> {

--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/ktx/KRCSSViewExtension.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/css/ktx/KRCSSViewExtension.kt
@@ -612,6 +612,9 @@ fun View.hasEventListener(type: Int): Boolean {
  * 重置事件监听
  */
 fun View.resetEventListener() {
+    // 必须先清理手势状态再移除监听器，否则 pinch 进行中的
+    // requestDisallowInterceptTouchEvent(true) 不会被复位，父容器将永久无法滚动
+    getViewData<KRCSSGestureDetector>(KRCSSGestureDetector.GESTURE_TAG)?.cleanup()
     setOnTouchListener(null)
     removeViewData<Any>(KRCSSGestureDetector.GESTURE_TAG)
 }

--- a/core-render-ios/Extension/Category/UIView+CSS.h
+++ b/core-render-ios/Extension/Category/UIView+CSS.h
@@ -58,6 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) KuiklyRenderCallback css_doubleClick;
 @property (nonatomic, strong, nullable) KuiklyRenderCallback css_longPress;
 @property (nonatomic, strong, nullable) KuiklyRenderCallback css_pan;
+@property (nonatomic, strong, nullable) KuiklyRenderCallback css_pinch;
 @property (nonatomic, strong, nullable) KuiklyRenderCallback css_animationCompletion;
 /// 在列表中是否可以允许滑动
 @property (nonatomic, assign) BOOL kr_canCancelInScrollView;

--- a/core-render-ios/Extension/Category/UIView+CSS.m
+++ b/core-render-ios/Extension/Category/UIView+CSS.m
@@ -90,9 +90,11 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
 @property (nonatomic, strong) UITapGestureRecognizer *css_doubleTapGR;
 @property (nonatomic, strong) UILongPressGestureRecognizer *css_longPressGR;
 @property (nonatomic, strong) UIPanGestureRecognizer *css_panGR;
+#if !TARGET_OS_OSX // [macOS] 无 UIPinchGestureRecognizer 对应实现，暂不支持pinch
 @property (nonatomic, strong) UIPinchGestureRecognizer *css_pinchGR;
 /// 捏合期间被临时禁止滚动的祖先ScrollView，手势结束后恢复
 @property (nonatomic, weak) UIScrollView *css_pinchLockedScrollView;
+#endif
 @property (nonatomic, strong, readonly) NSMutableSet<NSString *> *css_didSetProps;
 
 @end
@@ -902,6 +904,7 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
     objc_setAssociatedObject(self, @selector(css_panGR), css_panGR, OBJC_ASSOCIATION_RETAIN);
 }
 
+#if !TARGET_OS_OSX // [macOS] pinch相关的手势与ScrollView处理在macOS不适用
 - (UIPinchGestureRecognizer *)css_pinchGR {
     return objc_getAssociatedObject(self, @selector(css_pinchGR));
 }
@@ -917,6 +920,7 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
 - (void)setCss_pinchLockedScrollView:(UIScrollView *)css_pinchLockedScrollView {
     objc_setAssociatedObject(self, @selector(css_pinchLockedScrollView), css_pinchLockedScrollView, OBJC_ASSOCIATION_ASSIGN);
 }
+#endif
 
 - (KuiklyRenderCallback)css_click {
     return objc_getAssociatedObject(self, @selector(css_click));
@@ -1035,6 +1039,7 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
 - (void)setCss_pinch:(KuiklyRenderCallback)css_pinch {
     if (self.css_pinch != css_pinch) {
         objc_setAssociatedObject(self, @selector(css_pinch), css_pinch, OBJC_ASSOCIATION_RETAIN);
+#if !TARGET_OS_OSX // [macOS] 无对应的捏合手势识别器，仅保留回调存取，事件不会触发
         if (self.css_pinchGR) {
             // 若手势正处于锁定状态被移除，需恢复ScrollView，否则其将永久无法滚动
             [self css_unlockAncestorScrollViewForPinch];
@@ -1049,6 +1054,7 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
             }
         }
         [self css_syncPanPinchExclusion];
+#endif
     }
 }
 
@@ -1063,7 +1069,7 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
 /// 该边界仅在同时存在 css_pinchGR 时生效，只注册pan的存量组件行为不变。
 /// 与Android侧「pinch进行中不派发pan」的处理保持一致。
 - (void)css_syncPanPinchExclusion {
-#if !TARGET_OS_OSX // [macOS] NSPanGestureRecognizer 无 maximumNumberOfTouches
+#if !TARGET_OS_OSX // [macOS] 不支持pinch，且 NSPanGestureRecognizer 无 maximumNumberOfTouches
     if (!self.css_panGR) {
         return;
     }
@@ -1193,6 +1199,7 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
     }
 }
 
+#if !TARGET_OS_OSX // [macOS] 无 UIPinchGestureRecognizer 对应实现，暂不支持pinch
 - (void)css_onPinchWithSender:(UIPinchGestureRecognizer *)sender {
     NSDictionary *config = @{
         @(UIGestureRecognizerStateBegan): @"start",
@@ -1214,11 +1221,7 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
 
     // 捏合中心点。手势少于2指时locationInView语义不明确，此处仍取其提供的中心点，与系统行为保持一致
     CGPoint location = [sender locationInView:self];
-    #if TARGET_OS_OSX
-    CGPoint pageLocation = [sender locationInView:nil];
-    #else
     CGPoint pageLocation = [self kr_convertLocalPointToRenderRoot:location];
-    #endif
     NSDictionary *param = @{
         @"state": config[@(sender.state)] ? : @"end",
         @"x": @(location.x),
@@ -1260,6 +1263,7 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
         self.css_pinchLockedScrollView = nil;
     }
 }
+#endif
 
 
 + (NSString *)css_string:(id)value {

--- a/core-render-ios/Extension/Category/UIView+CSS.m
+++ b/core-render-ios/Extension/Category/UIView+CSS.m
@@ -90,6 +90,9 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
 @property (nonatomic, strong) UITapGestureRecognizer *css_doubleTapGR;
 @property (nonatomic, strong) UILongPressGestureRecognizer *css_longPressGR;
 @property (nonatomic, strong) UIPanGestureRecognizer *css_panGR;
+@property (nonatomic, strong) UIPinchGestureRecognizer *css_pinchGR;
+/// 捏合期间被临时禁止滚动的祖先ScrollView，手势结束后恢复
+@property (nonatomic, weak) UIScrollView *css_pinchLockedScrollView;
 @property (nonatomic, strong, readonly) NSMutableSet<NSString *> *css_didSetProps;
 
 @end
@@ -899,6 +902,22 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
     objc_setAssociatedObject(self, @selector(css_panGR), css_panGR, OBJC_ASSOCIATION_RETAIN);
 }
 
+- (UIPinchGestureRecognizer *)css_pinchGR {
+    return objc_getAssociatedObject(self, @selector(css_pinchGR));
+}
+
+- (void)setCss_pinchGR:(UIPinchGestureRecognizer *)css_pinchGR {
+    objc_setAssociatedObject(self, @selector(css_pinchGR), css_pinchGR, OBJC_ASSOCIATION_RETAIN);
+}
+
+- (UIScrollView *)css_pinchLockedScrollView {
+    return objc_getAssociatedObject(self, @selector(css_pinchLockedScrollView));
+}
+
+- (void)setCss_pinchLockedScrollView:(UIScrollView *)css_pinchLockedScrollView {
+    objc_setAssociatedObject(self, @selector(css_pinchLockedScrollView), css_pinchLockedScrollView, OBJC_ASSOCIATION_ASSIGN);
+}
+
 - (KuiklyRenderCallback)css_click {
     return objc_getAssociatedObject(self, @selector(css_click));
 }
@@ -1005,7 +1024,51 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
                 self.userInteractionEnabled = YES;
             }
         }
+        [self css_syncPanPinchExclusion];
     }
+}
+
+- (KuiklyRenderCallback)css_pinch {
+    return objc_getAssociatedObject(self, @selector(css_pinch));
+}
+
+- (void)setCss_pinch:(KuiklyRenderCallback)css_pinch {
+    if (self.css_pinch != css_pinch) {
+        objc_setAssociatedObject(self, @selector(css_pinch), css_pinch, OBJC_ASSOCIATION_RETAIN);
+        if (self.css_pinchGR) {
+            // 若手势正处于锁定状态被移除，需恢复ScrollView，否则其将永久无法滚动
+            [self css_unlockAncestorScrollViewForPinch];
+            [self removeGestureRecognizer:self.css_pinchGR];
+            self.css_pinchGR = nil;
+        }
+        if (css_pinch != nil) {
+            self.css_pinchGR = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(css_onPinchWithSender:)];
+            [self addGestureRecognizer:self.css_pinchGR];
+            if (!self.css_touchEnable) {
+                self.userInteractionEnabled = YES;
+            }
+        }
+        [self css_syncPanPinchExclusion];
+    }
+}
+
+/// 同时注册pan与pinch时，将pan限制为单指，划清「单指pan、双指pinch」的职责边界。
+///
+/// pan与pinch在语义上并不冲突(UIKit 开启同时识别即可并行，如系统相册的缩放兼平移)，
+/// 此处限制为单指是出于两点考虑:
+/// 1. UIPanGestureRecognizer 默认不限制手指数，双指移动同样被识别为pan；
+///    而未开启同时识别时 UIKit 只让先识别者生效，pan阈值更低会抢先，导致pinch永不触发。
+/// 2. 双指平移能力并未丢失: pinch每帧都带焦点坐标，业务可由焦点位移派生平移量。
+///
+/// 该边界仅在同时存在 css_pinchGR 时生效，只注册pan的存量组件行为不变。
+/// 与Android侧「pinch进行中不派发pan」的处理保持一致。
+- (void)css_syncPanPinchExclusion {
+#if !TARGET_OS_OSX // [macOS] NSPanGestureRecognizer 无 maximumNumberOfTouches
+    if (!self.css_panGR) {
+        return;
+    }
+    self.css_panGR.maximumNumberOfTouches = self.css_pinchGR ? 1 : NSUIntegerMax;
+#endif
 }
 
 - (KuiklyRenderCallback)css_animationCompletion {
@@ -1127,6 +1190,74 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
     };
     if (self.css_pan) {
         self.css_pan(param);
+    }
+}
+
+- (void)css_onPinchWithSender:(UIPinchGestureRecognizer *)sender {
+    NSDictionary *config = @{
+        @(UIGestureRecognizerStateBegan): @"start",
+        @(UIGestureRecognizerStateChanged): @"move",
+    };
+
+    // 捏合期间临时禁止祖先ScrollView滚动。
+    //
+    // UIScrollView 的 touchesShouldCancelInContentView: 对非UIControl子视图默认返回YES，
+    // 一旦其开始滚动便会取消本视图上的触摸，导致捏合手势中断。
+    // 此处与 Android 侧 requestDisallowInterceptTouchEvent(true) 的意图一致。
+    if (sender.state == UIGestureRecognizerStateBegan) {
+        [self css_lockAncestorScrollViewForPinch];
+    } else if (sender.state == UIGestureRecognizerStateEnded ||
+               sender.state == UIGestureRecognizerStateCancelled ||
+               sender.state == UIGestureRecognizerStateFailed) {
+        [self css_unlockAncestorScrollViewForPinch];
+    }
+
+    // 捏合中心点。手势少于2指时locationInView语义不明确，此处仍取其提供的中心点，与系统行为保持一致
+    CGPoint location = [sender locationInView:self];
+    #if TARGET_OS_OSX
+    CGPoint pageLocation = [sender locationInView:nil];
+    #else
+    CGPoint pageLocation = [self kr_convertLocalPointToRenderRoot:location];
+    #endif
+    NSDictionary *param = @{
+        @"state": config[@(sender.state)] ? : @"end",
+        @"x": @(location.x),
+        @"y": @(location.y),
+        @"pageX": @(pageLocation.x),
+        @"pageY": @(pageLocation.y),
+        // UIPinchGestureRecognizer.scale本身即为相对手势开始时的累计倍数，与PinchGestureParams.scale语义一致
+        @"scale": @(sender.scale),
+    };
+    if (self.css_pinch) {
+        self.css_pinch(param);
+    }
+}
+
+/// 向上查找最近的祖先ScrollView并禁止其滚动，避免其取消本视图触摸而中断捏合
+- (void)css_lockAncestorScrollViewForPinch {
+    if (self.css_pinchLockedScrollView) { // 已锁定，避免重复处理
+        return;
+    }
+    UIView *superView = self.superview;
+    while (superView) {
+        if ([superView isKindOfClass:[UIScrollView class]]) {
+            UIScrollView *scrollView = (UIScrollView *)superView;
+            if (scrollView.isScrollEnabled) {
+                scrollView.scrollEnabled = NO;
+                self.css_pinchLockedScrollView = scrollView;
+            }
+            return;
+        }
+        superView = superView.superview;
+    }
+}
+
+/// 恢复此前被禁止滚动的祖先ScrollView
+- (void)css_unlockAncestorScrollViewForPinch {
+    UIScrollView *scrollView = self.css_pinchLockedScrollView;
+    if (scrollView) {
+        scrollView.scrollEnabled = YES;
+        self.css_pinchLockedScrollView = nil;
     }
 }
 

--- a/core-render-ios/Extension/Category/UIView+CSS.m
+++ b/core-render-ios/Extension/Category/UIView+CSS.m
@@ -1216,20 +1216,43 @@ shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRec
 }
 
 - (CGPoint)kr_convertLocalPointToRenderRoot:(CGPoint)point{
-    UIView *root = nil;
+    return [self convertPoint:point toView:[self kr_renderRootView]];
+}
+
+/// 返回渲染根视图(render root)。找不到时返回 nil，调用方可退回 window/自身坐标。
+- (nullable UIView *)kr_renderRootView {
     if ([self respondsToSelector:@selector(hr_rootView)]){
-        root = [self performSelector:@selector(hr_rootView)];
+        return [self performSelector:@selector(hr_rootView)];
     } else if ([self.superview respondsToSelector:@selector(hr_rootView)]){
-        root = [self.superview performSelector:@selector(hr_rootView)];
+        return [self.superview performSelector:@selector(hr_rootView)];
     }
-    
-    return [self convertPoint:point toView:root];
+    return nil;
 }
 
 - (void)css_onPanWithSender:(UIPanGestureRecognizer *)sender {
+    // pinch 进行中时抑制 pan 的 start/move 回调，与 Android 侧 onScroll 中
+    // if (isPinchEventHappening) return false 对齐。
+    // 解决「先放一指 → pan 抢先 Began → 第二指落下 → pinch 接管，pan 位移残留」。
+    //
+    // 注意: 仅抑制 Began/Changed。Cancelled/Failed/Ended 必须放行，否则第二指落下
+    // 使 pan 被取消时，demo 侧收不到 cancel，无法回退 pan 起手前的位移，
+    // 残留的 move 位移会表现为「捏合变拖拽」。
+    #if !TARGET_OS_OSX
+    if ([objc_getAssociatedObject(self, KRPinchActiveKey) boolValue] &&
+        (sender.state == UIGestureRecognizerStateBegan ||
+         sender.state == UIGestureRecognizerStateChanged)) {
+        return;
+    }
+    #endif
     NSDictionary *config = @{
         @(UIGestureRecognizerStateBegan): @"start",
         @(UIGestureRecognizerStateChanged): @"move",
+        // Failed/Cancelled 映射为 cancel，区别于正常结束的 end。
+        // Failed 场景: 同时注册了 pinch 时 pan 被限制为单指(maximumNumberOfTouches=1)，
+        // 第二指落下导致 pan Failed → pinch 接管。此时不应固化 translate，
+        // demo 侧收到 cancel 会回退到 pan 起手前的位置，消除「捏合变拖拽」。
+        @(UIGestureRecognizerStateCancelled): @"cancel",
+        @(UIGestureRecognizerStateFailed): @"cancel",
     };
     
     CGPoint location = [sender locationInView:self];
@@ -1251,6 +1274,10 @@ shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRec
 }
 
 #if !TARGET_OS_OSX // [macOS] 无 UIPinchGestureRecognizer 对应实现，暂不支持pinch
+static void *KRPinchLastLocationKey = &KRPinchLastLocationKey;
+static void *KRPinchLastPageLocationKey = &KRPinchLastPageLocationKey;
+static void *KRPinchActiveKey = &KRPinchActiveKey;
+
 - (void)css_onPinchWithSender:(UIPinchGestureRecognizer *)sender {
     NSDictionary *config = @{
         @(UIGestureRecognizerStateBegan): @"start",
@@ -1264,15 +1291,63 @@ shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRec
     // 与 Android 侧 requestDisallowInterceptTouchEvent(true) 的意图一致。
     if (sender.state == UIGestureRecognizerStateBegan) {
         [self css_lockAncestorScrollViewForPinch];
+        // 标记 pinch 激活，pan handler 检测到此标志时直接跳过(不派发 pan 回调)，
+        // 与 Android 侧 onScroll 中 if (isPinchEventHappening) return false 对齐。
+        // 消除「先放一指 pan 抢先 Began → 第二指落下 pinch 接管，pan 的位移残留」。
+        objc_setAssociatedObject(self, KRPinchActiveKey, @YES, OBJC_ASSOCIATION_RETAIN);
     } else if (sender.state == UIGestureRecognizerStateEnded ||
                sender.state == UIGestureRecognizerStateCancelled ||
                sender.state == UIGestureRecognizerStateFailed) {
         [self css_unlockAncestorScrollViewForPinch];
+        objc_setAssociatedObject(self, KRPinchActiveKey, @NO, OBJC_ASSOCIATION_RETAIN);
     }
 
-    // 捏合中心点。手势少于2指时locationInView语义不明确，此处仍取其提供的中心点，与系统行为保持一致
-    CGPoint location = [sender locationInView:self];
-    CGPoint pageLocation = [self kr_convertLocalPointToRenderRoot:location];
+    // 捏合中心点。
+    // 手势进行中(Began/Changed)正常取 locationInView（双指质心），并缓存供结束时回放。
+    // 手势结束(Ended/Cancelled/Failed)时剩余手指 < 2，locationInView 返回单指位置而非
+    // 双指质心，会导致 x/y/pageX/pageY 跳变。此时回放最后一次 move 的缓存坐标，
+    // 与 Android 端 endPinch() 使用 lastPinchFocusX/Y 的做法一致，消除抬指跳动。
+    //
+    // 额外防护: 抬指瞬间 iOS 可能先发一个 Changed(仅剩1指) 再发 Ended，
+    // 该 Changed 的 locationInView 已跳变为单指位置。若照常缓存会污染缓存，
+    // 导致 Ended 回放的仍是跳变值。因此在 numberOfTouches < 2 时也不缓存、直接回放。
+    BOOL isEndState = (sender.state == UIGestureRecognizerStateEnded ||
+                       sender.state == UIGestureRecognizerStateCancelled ||
+                       sender.state == UIGestureRecognizerStateFailed);
+    BOOL shouldReplayCache = isEndState || sender.numberOfTouches < 2;
+    CGPoint location;
+    CGPoint pageLocation;
+    if (shouldReplayCache) {
+        NSValue *lastLoc = objc_getAssociatedObject(self, KRPinchLastLocationKey);
+        NSValue *lastPageLoc = objc_getAssociatedObject(self, KRPinchLastPageLocationKey);
+        if (lastLoc && lastPageLoc) {
+            [lastLoc getValue:&location];
+            [lastPageLoc getValue:&pageLocation];
+        } else {
+            // 极端情况: start 后直接 end(无 move)，缓存为空，退回系统值
+            location = [sender locationInView:self];
+            pageLocation = [self kr_convertLocalPointToRenderRoot:location];
+        }
+    } else {
+        location = [sender locationInView:self];
+        // pageLocation 直接以渲染根视图坐标取双指质心，绕开 self 自身的 scale 变换。
+        //
+        // 若沿用 [self kr_convertLocalPointToRenderRoot:location]，坐标会经过 self 正在
+        // 逐帧变化的 scale transform 换算: locationInView 先按当前 transform 反算局部点，
+        // convertPoint 再按 transform 正算回根坐标，两次换算基于「正在变化」的 transform，
+        // 放大过程中会引入抖动，传导到 demo 的平移项 (pageX - startPageX) 即表现为「放大轻微抖动」。
+        // 直接向根视图取质心与 Android 侧基于 rawX/rawY(不受组件变换影响)的做法一致。
+        UIView *root = [self kr_renderRootView];
+        if (root) {
+            pageLocation = [sender locationInView:root];
+        } else {
+            pageLocation = [self kr_convertLocalPointToRenderRoot:location];
+        }
+        objc_setAssociatedObject(self, KRPinchLastLocationKey,
+                                 [NSValue valueWithCGPoint:location], OBJC_ASSOCIATION_RETAIN);
+        objc_setAssociatedObject(self, KRPinchLastPageLocationKey,
+                                 [NSValue valueWithCGPoint:pageLocation], OBJC_ASSOCIATION_RETAIN);
+    }
     NSDictionary *param = @{
         @"state": config[@(sender.state)] ? : @"end",
         @"x": @(location.x),

--- a/core-render-ios/Extension/Category/UIView+CSS.m
+++ b/core-render-ios/Extension/Category/UIView+CSS.m
@@ -92,10 +92,43 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
 @property (nonatomic, strong) UIPanGestureRecognizer *css_panGR;
 #if !TARGET_OS_OSX // [macOS] 无 UIPinchGestureRecognizer 对应实现，暂不支持pinch
 @property (nonatomic, strong) UIPinchGestureRecognizer *css_pinchGR;
-/// 捏合期间被临时禁止滚动的祖先ScrollView，手势结束后恢复
-@property (nonatomic, weak) UIScrollView *css_pinchLockedScrollView;
+@property (nonatomic, strong) CSSPinchGestureDelegate *css_pinchDelegate;
+/// 捏合期间被临时禁止滚动的祖先ScrollView列表(weak引用，避免循环引用)，手势结束后恢复
+@property (nonatomic, strong) NSPointerArray *css_pinchLockedScrollViews;
 #endif
 @property (nonatomic, strong, readonly) NSMutableSet<NSString *> *css_didSetProps;
+
+@end
+
+/// pinch 手势优先级委托: 在双指触及时要求祖先 ScrollView 的 pan 手势等待 pinch 失败，
+/// 从根本上消除「ScrollView pan 抢先 Began → 取消内容触摸 → pinch 中断」的竞争窗口。
+///
+/// 使用 delegate 方法而非 requireGestureRecognizerToFail: 是因为后者会给所有滚动
+/// 增加延迟(单指滑动也需等 pinch 超时)，而 delegate 方式仅在 numberOfTouches >= 2 时
+/// 才要求优先，单指滚动零延迟。
+@interface CSSPinchGestureDelegate : NSObject <UIGestureRecognizerDelegate>
+@end
+
+@implementation CSSPinchGestureDelegate
+
+/// 当 pinch 已有 2+ 指时，要求祖先 ScrollView 的 pan 等待 pinch 失败后才能 Began。
+/// 单指时返回 NO，ScrollView 的 pan 可立即响应，无延迟。
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    if (![gestureRecognizer isKindOfClass:[UIPinchGestureRecognizer class]]) {
+        return NO;
+    }
+    // 仅对祖先 ScrollView 的 pan 手势生效
+    if (![otherGestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
+        return NO;
+    }
+    UIView *otherView = otherGestureRecognizer.view;
+    if (![otherView isKindOfClass:[UIScrollView class]]) {
+        return NO;
+    }
+    // 仅在双指触及后才要求优先，避免影响单指滚动的响应速度
+    return gestureRecognizer.numberOfTouches >= 2;
+}
 
 @end
 
@@ -913,12 +946,20 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
     objc_setAssociatedObject(self, @selector(css_pinchGR), css_pinchGR, OBJC_ASSOCIATION_RETAIN);
 }
 
-- (UIScrollView *)css_pinchLockedScrollView {
-    return objc_getAssociatedObject(self, @selector(css_pinchLockedScrollView));
+- (CSSPinchGestureDelegate *)css_pinchDelegate {
+    return objc_getAssociatedObject(self, @selector(css_pinchDelegate));
 }
 
-- (void)setCss_pinchLockedScrollView:(UIScrollView *)css_pinchLockedScrollView {
-    objc_setAssociatedObject(self, @selector(css_pinchLockedScrollView), css_pinchLockedScrollView, OBJC_ASSOCIATION_ASSIGN);
+- (void)setCss_pinchDelegate:(CSSPinchGestureDelegate *)css_pinchDelegate {
+    objc_setAssociatedObject(self, @selector(css_pinchDelegate), css_pinchDelegate, OBJC_ASSOCIATION_RETAIN);
+}
+
+- (NSPointerArray *)css_pinchLockedScrollViews {
+    return objc_getAssociatedObject(self, @selector(css_pinchLockedScrollViews));
+}
+
+- (void)setCss_pinchLockedScrollViews:(NSPointerArray *)css_pinchLockedScrollViews {
+    objc_setAssociatedObject(self, @selector(css_pinchLockedScrollViews), css_pinchLockedScrollViews, OBJC_ASSOCIATION_RETAIN);
 }
 #endif
 
@@ -1048,6 +1089,11 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
         }
         if (css_pinch != nil) {
             self.css_pinchGR = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(css_onPinchWithSender:)];
+            // 设置委托: 双指触及时要求祖先ScrollView的pan等待pinch失败，消除竞争窗口
+            if (!self.css_pinchDelegate) {
+                self.css_pinchDelegate = [[CSSPinchGestureDelegate alloc] init];
+            }
+            self.css_pinchGR.delegate = self.css_pinchDelegate;
             [self addGestureRecognizer:self.css_pinchGR];
             if (!self.css_touchEnable) {
                 self.userInteractionEnabled = YES;
@@ -1206,11 +1252,11 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
         @(UIGestureRecognizerStateChanged): @"move",
     };
 
-    // 捏合期间临时禁止祖先ScrollView滚动。
+    // 双重保护: 委托层(2指时要求ScrollView pan等待pinch失败) + 运行时锁定(禁止scrollEnabled)。
     //
-    // UIScrollView 的 touchesShouldCancelInContentView: 对非UIControl子视图默认返回YES，
-    // 一旦其开始滚动便会取消本视图上的触摸，导致捏合手势中断。
-    // 此处与 Android 侧 requestDisallowInterceptTouchEvent(true) 的意图一致。
+    // 委托层解决竞争窗口: 在pinch进入Began之前，ScrollView的pan不会抢先。
+    // 运行时锁定作为兜底: 若委托时序存在边界情况，pinch Began时仍会禁用所有祖先ScrollView的滚动。
+    // 与 Android 侧 requestDisallowInterceptTouchEvent(true) 的意图一致。
     if (sender.state == UIGestureRecognizerStateBegan) {
         [self css_lockAncestorScrollViewForPinch];
     } else if (sender.state == UIGestureRecognizerStateEnded ||
@@ -1230,38 +1276,49 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
         @"pageY": @(pageLocation.y),
         // UIPinchGestureRecognizer.scale本身即为相对手势开始时的累计倍数，与PinchGestureParams.scale语义一致
         @"scale": @(sender.scale),
+        // 缩放倍数变化速率(倍/秒)，用于实现松手后的惯性动画
+        @"velocity": @(sender.velocity),
     };
     if (self.css_pinch) {
         self.css_pinch(param);
     }
 }
 
-/// 向上查找最近的祖先ScrollView并禁止其滚动，避免其取消本视图触摸而中断捏合
+/// 向上查找所有祖先ScrollView并禁止其滚动，避免任一层级取消本视图触摸而中断捏合
 - (void)css_lockAncestorScrollViewForPinch {
-    if (self.css_pinchLockedScrollView) { // 已锁定，避免重复处理
+    if (self.css_pinchLockedScrollViews.count > 0) { // 已锁定，避免重复处理
         return;
     }
+    NSPointerArray *lockedViews = [NSPointerArray weakObjectsPointerArray];
     UIView *superView = self.superview;
     while (superView) {
         if ([superView isKindOfClass:[UIScrollView class]]) {
             UIScrollView *scrollView = (UIScrollView *)superView;
             if (scrollView.isScrollEnabled) {
                 scrollView.scrollEnabled = NO;
-                self.css_pinchLockedScrollView = scrollView;
+                [lockedViews addPointer:(__bridge void *)scrollView];
             }
-            return;
         }
         superView = superView.superview;
     }
+    if (lockedViews.count > 0) {
+        self.css_pinchLockedScrollViews = lockedViews;
+    }
 }
 
-/// 恢复此前被禁止滚动的祖先ScrollView
+/// 恢复此前被禁止滚动的所有祖先ScrollView
 - (void)css_unlockAncestorScrollViewForPinch {
-    UIScrollView *scrollView = self.css_pinchLockedScrollView;
-    if (scrollView) {
-        scrollView.scrollEnabled = YES;
-        self.css_pinchLockedScrollView = nil;
+    NSPointerArray *lockedViews = self.css_pinchLockedScrollViews;
+    if (lockedViews.count == 0) {
+        return;
     }
+    for (NSUInteger i = 0; i < lockedViews.count; i++) {
+        void *ptr = [lockedViews pointerAtIndex:i];
+        if (!ptr) { continue; } // weak 引用可能已随 ScrollView 释放而置空
+        UIScrollView *scrollView = (__bridge UIScrollView *)ptr;
+        scrollView.scrollEnabled = YES;
+    }
+    self.css_pinchLockedScrollViews = nil;
 }
 #endif
 

--- a/core-render-ios/Extension/Category/UIView+CSS.m
+++ b/core-render-ios/Extension/Category/UIView+CSS.m
@@ -103,6 +103,7 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
 
 @end
 
+#if !TARGET_OS_OSX // [macOS] pinch 委托依赖 UIPinchGestureRecognizer，macOS 不编译
 /// pinch 手势优先级委托: 在双指触及时要求祖先 ScrollView 的 pan 手势等待 pinch 失败，
 /// 从根本上消除「ScrollView pan 抢先 Began → 取消内容触摸 → pinch 中断」的竞争窗口。
 ///
@@ -134,6 +135,7 @@ shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRec
 }
 
 @end
+#endif // [macOS]
 
 @implementation UIView (CSS)
 

--- a/core-render-ios/Extension/Category/UIView+CSS.m
+++ b/core-render-ios/Extension/Category/UIView+CSS.m
@@ -79,6 +79,9 @@ static const NSInteger KRDefaultKeyboardAnimationCurve = 7;
 @end
 
 
+
+@class CSSPinchGestureDelegate;
+
 @interface UIView() <KuiklyRenderViewLifyCycleProtocol>
 
 @property (nonatomic, strong) CSSAnimation *css_animationImp;

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/events/KRBaseEventHandler.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/events/KRBaseEventHandler.cpp
@@ -207,7 +207,7 @@ bool KRBaseEventHandler::FireOnPanCallback(const std::shared_ptr<KRGestureEventD
     params[kParamKeyY] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_point_.y));
     params[kParamKeyPageX] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_window_point_.x));
     params[kParamKeyPageY] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_window_point_.y));
-    params[kParamKeyState] = NewKRRenderValue(state);
+    params[kParamKeyState] = NewKRRenderValue(kuikly::util::GetArkUIGestureActionState(gesture_event_data->gesture_event_));
     pan_event_callback_(NewKRRenderValue(params));
     return true;
 }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/events/KRBaseEventHandler.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/events/KRBaseEventHandler.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "libohos_render/expand/events/KRBaseEventHandler.h"
+#include <chrono>
 
 #include <arkui/native_node.h>
 #include "libohos_render/expand/events/KREventDispatchCenter.h"
@@ -36,6 +37,7 @@ constexpr char kParamKeyState[] = "state";
 constexpr char kStartState[] = "start";
 constexpr char kEndState[] = "end";
 constexpr char kParamKeyScale[] = "scale";
+constexpr char kParamKeyVelocity[] = "velocity";
 constexpr char kParamKeyIsCancel[] = "isCancel";
 
 KRBaseEventHandler::KRBaseEventHandler(const std::shared_ptr<KRConfig> &kr_config) : kr_config_(kr_config) {}
@@ -182,7 +184,7 @@ bool KRBaseEventHandler::FireOnLongPressCallback(const std::shared_ptr<KRGesture
     params[kParamKeyY] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_point_.y));
     params[kParamKeyPageX] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_window_point_.x));
     params[kParamKeyPageY] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_window_point_.y));
-    params[kParamKeyState] = NewKRRenderValue(kuikly::util::GetArkUIGestureActionState(gesture_event_data->gesture_event_));
+    params[kParamKeyState] = NewKRRenderValue(state);
     params[kParamKeyIsCancel] = NewKRRenderValue(kuikly::util::GetArkUIGestureActionType(gesture_event_data->gesture_event_) == GESTURE_EVENT_ACTION_CANCEL);
     long_press_callback_(NewKRRenderValue(params));
     return true;
@@ -205,7 +207,7 @@ bool KRBaseEventHandler::FireOnPanCallback(const std::shared_ptr<KRGestureEventD
     params[kParamKeyY] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_point_.y));
     params[kParamKeyPageX] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_window_point_.x));
     params[kParamKeyPageY] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_window_point_.y));
-    params[kParamKeyState] = NewKRRenderValue(kuikly::util::GetArkUIGestureActionState(gesture_event_data->gesture_event_));
+    params[kParamKeyState] = NewKRRenderValue(state);
     pan_event_callback_(NewKRRenderValue(params));
     return true;
 }
@@ -222,20 +224,41 @@ bool KRBaseEventHandler::FireOnPinchCallback(const std::shared_ptr<KRGestureEven
         return false;
     }
 
+    float scale = kuikly::util::GetArkUIGesturePinchScale(gesture_event_data->gesture_event_);
+    std::string state = kuikly::util::GetArkUIGestureActionState(gesture_event_data->gesture_event_);
+
+    // 计算 velocity: scale 变化率(倍/秒)，与 iOS UIPinchGestureRecognizer.velocity 语义一致
+    auto now = std::chrono::steady_clock::now();
+    auto now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
+    float velocity = 0.0f;
+    if (state == "start") {
+        // 新手势开始: 重置跟踪基准
+        prev_pinch_scale_ = scale;
+        prev_pinch_time_ns_ = now_ns;
+    } else if (prev_pinch_time_ns_ > 0 && now_ns > prev_pinch_time_ns_) {
+        double dt = (now_ns - prev_pinch_time_ns_) / 1e9;
+        if (dt > 0) {
+            velocity = static_cast<float>((scale - prev_pinch_scale_) / dt);
+        }
+        prev_pinch_scale_ = scale;
+        prev_pinch_time_ns_ = now_ns;
+    }
+
     KRRenderValueMap params;
     params[kParamKeyX] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_point_.x));
     params[kParamKeyY] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_point_.y));
     params[kParamKeyPageX] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_window_point_.x));
     params[kParamKeyPageY] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_window_point_.y));
-    params[kParamKeyScale] = NewKRRenderValue(kuikly::util::GetArkUIGesturePinchScale(gesture_event_data->gesture_event_));
-    params[kParamKeyState] = NewKRRenderValue(kuikly::util::GetArkUIGestureActionState(gesture_event_data->gesture_event_));
+    params[kParamKeyScale] = NewKRRenderValue(scale);
+    params[kParamKeyVelocity] = NewKRRenderValue(velocity);
+    params[kParamKeyState] = NewKRRenderValue(state);
     pinch_event_callback_(NewKRRenderValue(params));
     return true;
 }
 
 bool KRBaseEventHandler::HasTouchEvent() {
     return click_callback_ != nullptr || double_click_callback_ != nullptr || pan_event_callback_ != nullptr ||
-           long_press_callback_ != nullptr;
+           long_press_callback_ != nullptr || pinch_event_callback_ != nullptr;
 }
 
 bool KRBaseEventHandler::SetCaptureRule(const std::shared_ptr<IKRRenderViewExport> &view_export,

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/events/KRBaseEventHandler.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/events/KRBaseEventHandler.h
@@ -74,6 +74,9 @@ class KRBaseEventHandler : public std::enable_shared_from_this<KRBaseEventHandle
     std::shared_ptr<KRConfig> kr_config_;
     bool has_capture_rule_ = false;
     bool is_long_press_happening = false;
+    // pinch velocity 跟踪状态
+    float prev_pinch_scale_ = 0.0f;
+    int64_t prev_pinch_time_ns_ = 0;
 };
 
 class KRArkTSBaseEventHandler : public KRBaseEventHandler {

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/base/event/EventParams.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/base/event/EventParams.kt
@@ -174,6 +174,7 @@ data class PinchGestureParams(
     val pageX: Float,  // 捏合中心点在根视图Page下的坐标X
     val pageY: Float,  // 捏合中心点在根视图Page下的坐标Y
     val scale: Float, // 缩放倍数
+    val velocity: Float = 0f, // 缩放倍数变化速率(倍/秒)，与iOS UIPinchGestureRecognizer.velocity语义一致
     val state: String // "start" | "move" | "end"
 ) {
     companion object {
@@ -182,10 +183,11 @@ data class PinchGestureParams(
             val x = tempParams.optDouble("x").toFloat()
             val y = tempParams.optDouble("y").toFloat()
             val scale = tempParams.optDouble("scale").toFloat()
+            val velocity = tempParams.optDouble("velocity").toFloat()
             val pageX = tempParams.optDouble("pageX").toFloat()
             val pageY = tempParams.optDouble("pageY").toFloat()
             val state = tempParams.optString("state")
-            return PinchGestureParams(x, y, pageX, pageY, scale, state)
+            return PinchGestureParams(x, y, pageX, pageY, scale, velocity, state)
         }
     }
     inline val isStart get() = state == "start"

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/base/event/EventParams.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/base/event/EventParams.kt
@@ -174,8 +174,8 @@ data class PinchGestureParams(
     val pageX: Float,  // 捏合中心点在根视图Page下的坐标X
     val pageY: Float,  // 捏合中心点在根视图Page下的坐标Y
     val scale: Float, // 缩放倍数
-    val velocity: Float = 0f, // 缩放倍数变化速率(倍/秒)，与iOS UIPinchGestureRecognizer.velocity语义一致
-    val state: String // "start" | "move" | "end"
+    val state: String, // "start" | "move" | "end"
+    val velocity: Float = 0f // 缩放倍数变化速率(倍/秒)，与iOS UIPinchGestureRecognizer.velocity语义一致
 ) {
     companion object {
         fun decode(params: Any?): PinchGestureParams {
@@ -187,7 +187,7 @@ data class PinchGestureParams(
             val pageX = tempParams.optDouble("pageX").toFloat()
             val pageY = tempParams.optDouble("pageY").toFloat()
             val state = tempParams.optString("state")
-            return PinchGestureParams(x, y, pageX, pageY, scale, velocity, state)
+            return PinchGestureParams(x, y, pageX, pageY, scale, state, velocity)
         }
     }
     inline val isStart get() = state == "start"

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/PinchGestureExampleDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/PinchGestureExampleDemo.kt
@@ -17,67 +17,507 @@ package com.tencent.kuikly.demo.pages.demo
 
 import com.tencent.kuikly.core.annotations.Page
 import com.tencent.kuikly.core.base.Color
+import com.tencent.kuikly.core.base.Scale
+import com.tencent.kuikly.core.base.Translate
 import com.tencent.kuikly.core.base.ViewBuilder
 import com.tencent.kuikly.core.layout.FlexAlign
 import com.tencent.kuikly.core.reactive.handler.observable
 import com.tencent.kuikly.core.views.Image
+import com.tencent.kuikly.core.views.List
 import com.tencent.kuikly.core.views.Text
 import com.tencent.kuikly.core.views.View
 import com.tencent.kuikly.demo.pages.base.BasePager
 import com.tencent.kuikly.demo.pages.demo.base.NavBar
 
+/**
+ * pinch(双指捏合)事件示例页。
+ *
+ * 提供两种缩放建模方式:
+ * - 示例一(transform): 以捏合点为焦点缩放，适用于图片浏览等需要跟手的场景
+ * - 示例二(size): 手势结束时把倍数吸收进宽高，适用于只需最终尺寸的场景
+ *
+ * 示例一覆盖四个验证点:
+ * 1. scale语义: 是否为「相对手势开始时的累计倍数」，而非相邻回调的增量
+ * 2. 捏合中心点: 以捏合点为焦点缩放，该点应保持静止，且多次不同位置捏合不跳变
+ * 3. 手势共存: 位于可滚动容器内时，捏合是否会被外层滚动打断
+ * 4. 手势职责边界: pan / pinch / click 三者的触发时机是否符合预期
+ *
+ * ## 缩放建模说明(示例一)
+ *
+ * 采用 `scale + translate` 而非 `anchor` 表达缩放中心。
+ *
+ * 锚点恒为组件中心 c，渲染位置为 `V(p) = c + s·(p − c) + t`。
+ * 由于锚点 c 出现在表达式中，若在 s != 1 时改变 c，V 会跳变，
+ * 因此无法同时满足「绕任意点缩放」与「不跳变」。改用 translate 补偿:
+ *
+ * 手势开始:  V0 = c + s0·(p0 − c) + t0
+ * 手势过程中要求 V(p0) 恒等于 V0，解得:
+ *
+ *     t = t0 + (s0 − s)·(p0 − c)
+ *
+ * 手势首帧 s == s0，代入得 t == t0，故起手连续不跳变。
+ *
+ * 两端复合顺序一致(均为先 scale 后 translate，且平移量 = 百分比 × 布局宽高，
+ * 不随 scale 放大)，故同一公式在 Android/iOS 表现一致:
+ * - iOS: UIView+CSS.m 中 CGAffineTransformTranslate 后接 CGAffineTransformScale
+ * - Android: KRCSSAnimation.kt 中 translationX = 百分比 × frameWidth，后置于 scaleX
+ */
 @Page("PinchGestureExampleDemo")
 internal class PinchGestureExampleDemo : BasePager() {
-    private var imageWidth by observable(200f)
-    private var imageHeight by observable(200f)
-    private var scale by observable(1f)
+
+    // ---- 示例一: 渲染状态 ----
+
+    /** 当前缩放倍数 */
+    private var currentScale: Float by observable(1f)
+
+    /** 当前平移量(dp)，用于补偿缩放引起的焦点位移 */
+    private var translateX: Float by observable(0f)
+    private var translateY: Float by observable(0f)
+
+    // ---- 示例一: 手势基准(上次手势结束时固化) ----
+
+    private var baseScale: Float = 1f
+    private var baseTranslateX: Float = 0f
+    private var baseTranslateY: Float = 0f
+
+    // ---- 示例一: 本次手势内固定的量 ----
+
+    /** 手势开始时的缩放倍数，即公式中的 s0 */
+    private var startScale: Float = 1f
+
+    /** 手势开始时的捏合焦点(组件内 dp 坐标)，即公式中的 p0，手势内不再变化 */
+    private var focusX: Float = CENTER
+    private var focusY: Float = CENTER
+
+    // ---- 示例一: 界面回显 ----
+
+    private var stateText: String by observable("等待双指捏合")
+    private var scaleText: String by observable("scale: -")
+    private var focusText: String by observable("focus: -")
+    private var translateText: String by observable("translate: -")
+    private var pageCenterText: String by observable("pageCenter: -")
+
+    /** 校验scale是否为累计语义: 若为增量语义，该区间会持续贴在1.0附近抖动 */
+    private var rawScaleRangeText: String by observable("本次手势 scale 区间: -")
+    private var minRawScale: Float = 1f
+    private var maxRawScale: Float = 1f
+
+    /** 最近触发的手势，用于观察 pinch / pan / click 三者的触发边界是否符合预期 */
+    private var gestureLogText: String by observable("最近手势: -")
+
+    // ---- 示例一: pan(单指拖拽)状态 ----
+    //
+    // 拖拽使用 pageX/pageY 而非 x/y 计算位移。
+    // x/y 是组件局部坐标，会随本组件自身的 scale 变化，用它计算增量会引入
+    // 与缩放耦合的误差; pageX/pageY 位于页面坐标系，不受本组件transform影响。
+
+    private var panStartPageX: Float = 0f
+    private var panStartPageY: Float = 0f
+    private var panStartTranslateX: Float = 0f
+    private var panStartTranslateY: Float = 0f
+
+    // ---- 示例二: 以宽高承载缩放 ----
+
+    private var imageWidth by observable(IMAGE_SIZE)
+    private var imageHeight by observable(IMAGE_SIZE)
+    private var sizeScale by observable(1f)
+
     override fun body(): ViewBuilder {
         val ctx = this
         return {
+            attr {
+                backgroundColor(Color(0xFF1E1E1EL))
+            }
+
             NavBar {
                 attr {
                     title = "PinchGestureExampleDemo"
                 }
             }
 
-            View {
+            List {
                 attr {
-                    size(ctx.pagerData.pageViewWidth, 200f)
-                    backgroundColor(Color.YELLOW)
-                    alignItems(FlexAlign.CENTER)
+                    flex(1f)
                 }
-                Image {
+
+                // 数值回显区
+                View {
                     attr {
-                        size(ctx.scale * ctx.imageWidth,ctx.scale * ctx.imageHeight)
-                        src("https://vfiles.gtimg.cn/wuji_dashboard/xy/starter/c498f4b4.jpg")
+                        margin(12f)
+                        padding(12f)
+                        backgroundColor(Color(0xFF2C2C2CL))
+                        borderRadius(8f)
                     }
-                    event {
-                        pinch {
-                            if (it.state != "end") {
-                                ctx.scale = it.scale
+                    Text {
+                        attr {
+                            text(ctx.stateText)
+                            color(Color.YELLOW)
+                            fontSize(16f)
+                        }
+                    }
+                    Text {
+                        attr {
+                            text(ctx.scaleText)
+                            color(Color.WHITE)
+                            fontSize(14f)
+                            marginTop(6f)
+                        }
+                    }
+                    Text {
+                        attr {
+                            text(ctx.rawScaleRangeText)
+                            color(Color(0xFF7FD1AEL))
+                            fontSize(14f)
+                            marginTop(6f)
+                        }
+                    }
+                    Text {
+                        attr {
+                            text(ctx.focusText)
+                            color(Color.WHITE)
+                            fontSize(14f)
+                            marginTop(6f)
+                        }
+                    }
+                    Text {
+                        attr {
+                            text(ctx.translateText)
+                            color(Color.WHITE)
+                            fontSize(14f)
+                            marginTop(6f)
+                        }
+                    }
+                    Text {
+                        attr {
+                            text(ctx.pageCenterText)
+                            color(Color.WHITE)
+                            fontSize(14f)
+                            marginTop(6f)
+                        }
+                    }
+                    Text {
+                        attr {
+                            text(ctx.gestureLogText)
+                            color(Color(0xFF9AD1FFL))
+                            fontSize(14f)
+                            marginTop(6f)
+                        }
+                    }
+                }
+
+                Text {
+                    attr {
+                        text("示例一: transform 缩放(以捏合点为焦点)")
+                        color(Color.WHITE)
+                        fontSize(15f)
+                        marginLeft(12f)
+                        marginRight(12f)
+                        marginTop(4f)
+                    }
+                }
+                Text {
+                    attr {
+                        text("验证点1: 放大后松手，再次放大，应从上次结果继续放大（scale 为累计语义）")
+                        color(Color(0xFFAAAAAAL))
+                        fontSize(12f)
+                        marginLeft(12f)
+                        marginRight(12f)
+                        marginTop(4f)
+                    }
+                }
+                Text {
+                    attr {
+                        text("验证点2: 在任意位置捏合，该点应保持静止；连续在不同位置捏合均不应跳变")
+                        color(Color(0xFFAAAAAAL))
+                        fontSize(12f)
+                        marginLeft(12f)
+                        marginRight(12f)
+                        marginTop(4f)
+                    }
+                }
+                Text {
+                    attr {
+                        text("验证点3: 本页在 List 内，捏合过程不应被列表滚动打断")
+                        color(Color(0xFFAAAAAAL))
+                        fontSize(12f)
+                        marginLeft(12f)
+                        marginRight(12f)
+                        marginTop(4f)
+                    }
+                }
+                Text {
+                    attr {
+                        text("验证点4: 手势职责边界 —— 单指拖动图片、双指缩放、单击切换2倍；双指时不应派发 pan，捏合后不应误触发单击")
+                        color(Color(0xFFAAAAAAL))
+                        fontSize(12f)
+                        marginLeft(12f)
+                        marginRight(12f)
+                        marginTop(4f)
+                    }
+                }
+
+                // 捏合目标区域
+                View {
+                    attr {
+                        height(360f)
+                        margin(12f)
+                        backgroundColor(Color(0xFF2C2C2CL))
+                        borderRadius(8f)
+                        allCenter()
+                        overflow(true)
+                    }
+
+                    Image {
+                        attr {
+                            size(IMAGE_SIZE, IMAGE_SIZE)
+                            src(IMAGE_URL)
+                            // 锚点保持默认(组件中心)，缩放中心由 translate 补偿实现
+                            transform(
+                                scale = Scale(ctx.currentScale, ctx.currentScale),
+                                translate = Translate(
+                                    ctx.translateX / IMAGE_SIZE,
+                                    ctx.translateY / IMAGE_SIZE
+                                )
+                            )
+                        }
+
+                        event {
+                            pinch { params ->
+                                ctx.onPinch(params.state, params.x, params.y, params.scale)
+                                ctx.pageCenterText =
+                                    "pageCenter: (${ctx.format(params.pageX)}, ${ctx.format(params.pageY)})"
+                                ctx.gestureLogText = "最近手势: pinch(${params.state})"
                             }
-                            else {
-                                ctx.imageWidth *= it.scale
-                                ctx.imageHeight *= it.scale
-                                ctx.scale = 1f
+                            // 单指拖拽: 与pinch共存，验证二者的触发边界
+                            pan { params ->
+                                ctx.onPan(params.state, params.pageX, params.pageY)
+                                ctx.gestureLogText = "最近手势: pan(${params.state})"
+                            }
+                            // 单击切换缩放: 验证click不会被pinch/pan误触发
+                            click {
+                                ctx.onClick()
+                                ctx.gestureLogText = "最近手势: click"
                             }
                         }
                     }
                 }
 
-            }
-            Text {
-                attr {
-                    text("Text")
-                    fontSize(30f)
+                // 重置按钮
+                View {
+                    attr {
+                        height(44f)
+                        margin(12f)
+                        borderRadius(22f)
+                        backgroundColor(Color(0xFF4A90D9L))
+                        allCenter()
+                    }
+                    event {
+                        click {
+                            ctx.reset()
+                        }
+                    }
+                    Text {
+                        attr {
+                            text("重置缩放")
+                            color(Color.WHITE)
+                            fontSize(16f)
+                        }
+                    }
+                }
+
+                Text {
+                    attr {
+                        text("示例二: 以宽高承载缩放，手势结束时把倍数吸收进 size")
+                        color(Color.WHITE)
+                        fontSize(15f)
+                        marginLeft(12f)
+                        marginRight(12f)
+                        marginTop(8f)
+                    }
+                }
+
+                View {
+                    attr {
+                        height(280f)
+                        margin(12f)
+                        backgroundColor(Color(0xFF2C2C2CL))
+                        borderRadius(8f)
+                        alignItems(FlexAlign.CENTER)
+                        overflow(true)
+                    }
+                    Image {
+                        attr {
+                            size(ctx.sizeScale * ctx.imageWidth, ctx.sizeScale * ctx.imageHeight)
+                            src(IMAGE_URL)
+                        }
+                        event {
+                            pinch {
+                                if (it.state != STATE_END) {
+                                    ctx.sizeScale = it.scale
+                                } else {
+                                    ctx.imageWidth *= it.scale
+                                    ctx.imageHeight *= it.scale
+                                    ctx.sizeScale = 1f
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // 占位，使列表可滚动，便于验证手势共存
+                View {
+                    attr {
+                        height(500f)
+                    }
                 }
             }
         }
     }
 
-    override fun viewDidLayout() {
-        super.viewDidLayout()
+    /**
+     * 处理捏合回调。
+     *
+     * @param state 手势状态 start/move/end
+     * @param x 捏合中心点在组件内的 x(dp)
+     * @param y 捏合中心点在组件内的 y(dp)
+     * @param rawScale 框架回调的缩放倍数(相对手势起点的累计值)
+     */
+    private fun onPinch(state: String, x: Float, y: Float, rawScale: Float) {
+        if (state == STATE_START) {
+            // 手势开始: 固化基准与焦点，整个手势内不再变化
+            startScale = baseScale
+            focusX = x
+            focusY = y
+            minRawScale = rawScale
+            maxRawScale = rawScale
+        } else {
+            if (rawScale < minRawScale) {
+                minRawScale = rawScale
+            }
+            if (rawScale > maxRawScale) {
+                maxRawScale = rawScale
+            }
+        }
 
+        // 累计倍数 × 上次手势结束时的基准，并夹紧到允许范围
+        val scale = (startScale * rawScale).coerceIn(MIN_SCALE, MAX_SCALE)
+
+        // t = t0 + (s0 − s)·(p0 − c)
+        // 注: 此处使用夹紧后的实际 scale 参与计算，保证到达边界时不跳变
+        //（代价是边界处焦点会缓慢漂移，demo 可接受）
+        val deltaScale = startScale - scale
+        currentScale = scale
+        translateX = baseTranslateX + deltaScale * (focusX - CENTER)
+        translateY = baseTranslateY + deltaScale * (focusY - CENTER)
+
+        stateText = "state: $state"
+        scaleText = "scale(回调原值): ${format(rawScale)}   实际渲染: ${format(scale)}"
+        focusText = "focus: (${format(focusX)}, ${format(focusY)})"
+        translateText = "translate: (${format(translateX)}, ${format(translateY)})"
+        rawScaleRangeText =
+            "本次手势 scale 区间: ${format(minRawScale)} ~ ${format(maxRawScale)}"
+
+        if (state == STATE_END) {
+            // 手势结束: 固化结果，供下次手势累积
+            baseScale = currentScale
+            baseTranslateX = translateX
+            baseTranslateY = translateY
+        }
     }
 
+    /**
+     * 处理单指拖拽。
+     *
+     * @param state 手势状态 start/move/end
+     * @param pageX 触点在页面坐标系的x
+     * @param pageY 触点在页面坐标系的y
+     */
+    private fun onPan(state: String, pageX: Float, pageY: Float) {
+        when (state) {
+            STATE_START -> {
+                panStartPageX = pageX
+                panStartPageY = pageY
+                panStartTranslateX = baseTranslateX
+                panStartTranslateY = baseTranslateY
+            }
+
+            STATE_END -> {
+                baseTranslateX = translateX
+                baseTranslateY = translateY
+            }
+
+            else -> {
+                translateX = panStartTranslateX + (pageX - panStartPageX)
+                translateY = panStartTranslateY + (pageY - panStartPageY)
+                translateText = "translate: (${format(translateX)}, ${format(translateY)})"
+            }
+        }
+    }
+
+    /** 单击在原始大小与2倍之间切换，切换时回到居中 */
+    private fun onClick() {
+        val targetScale = if (baseScale > 1f + SCALE_EPSILON) 1f else CLICK_ZOOM_SCALE
+        baseScale = targetScale
+        currentScale = targetScale
+        baseTranslateX = 0f
+        baseTranslateY = 0f
+        translateX = 0f
+        translateY = 0f
+        scaleText = "scale: 单击切换至 ${format(targetScale)}"
+        translateText = "translate: (0.00, 0.00)"
+    }
+
+    private fun reset() {
+        baseScale = 1f
+        baseTranslateX = 0f
+        baseTranslateY = 0f
+        startScale = 1f
+        focusX = CENTER
+        focusY = CENTER
+        currentScale = 1f
+        translateX = 0f
+        translateY = 0f
+        stateText = "已重置，等待双指捏合"
+        scaleText = "scale: -"
+        focusText = "focus: -"
+        translateText = "translate: -"
+        pageCenterText = "pageCenter: -"
+        rawScaleRangeText = "本次手势 scale 区间: -"
+        gestureLogText = "最近手势: -"
+        panStartPageX = 0f
+        panStartPageY = 0f
+        panStartTranslateX = 0f
+        panStartTranslateY = 0f
+        imageWidth = IMAGE_SIZE
+        imageHeight = IMAGE_SIZE
+        sizeScale = 1f
+    }
+
+    private fun format(value: Float): String {
+        val scaled = (value * 100).toInt()
+        val intPart = scaled / 100
+        val decPart = if (scaled < 0) -(scaled % 100) else scaled % 100
+        return "$intPart.${decPart.toString().padStart(2, '0')}"
+    }
+
+    companion object {
+        private const val MIN_SCALE = 0.5f
+        private const val MAX_SCALE = 4f
+        private const val IMAGE_SIZE = 200f
+
+        /** 组件中心点坐标(dp)，即公式中的 c */
+        private const val CENTER = IMAGE_SIZE / 2
+
+        private const val STATE_START = "start"
+        private const val STATE_END = "end"
+
+        /** 单击切换到的放大倍数 */
+        private const val CLICK_ZOOM_SCALE = 2f
+
+        /** 浮点比较容差 */
+        private const val SCALE_EPSILON = 0.01f
+
+        private const val IMAGE_URL =
+            "https://vfiles.gtimg.cn/wuji_dashboard/xy/starter/c498f4b4.jpg"
+    }
 }

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/PinchGestureExampleDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/PinchGestureExampleDemo.kt
@@ -67,12 +67,13 @@ internal class PinchGestureExampleDemo : BasePager() {
 
     // ---- 示例一: 渲染状态 ----
 
-    /** 当前缩放倍数 */
-    private var currentScale: Float by observable(1f)
-
-    /** 当前平移量(dp)，用于补偿缩放引起的焦点位移 */
-    private var translateX: Float by observable(0f)
-    private var translateY: Float by observable(0f)
+    // scale/translate 合并为单个 observable，避免连续赋值触发多次 transform 重算
+    // （ObservableProperties.setValue 立即 fireObserverFn，中间态 scale↔translate 不一致导致抖动）
+    private data class TransformState(val scale: Float = 1f, val tx: Float = 0f, val ty: Float = 0f)
+    private var transformState: TransformState by observable(TransformState())
+    private val currentScale get() = transformState.scale
+    private val translateX get() = transformState.tx
+    private val translateY get() = transformState.ty
 
     // ---- 示例一: 手势基准(上次手势结束时固化) ----
 
@@ -422,25 +423,33 @@ internal class PinchGestureExampleDemo : BasePager() {
         // 累计倍数 × 上次手势结束时的基准，并夹紧到允许范围
         val scale = (startScale * rawScale).coerceIn(MIN_SCALE, MAX_SCALE)
 
-        // t = t0 + (s0 − s)·(f0 − c) + (pageX − startPageX)
-        //
-        // 第一项 (s0 − s)·(f0 − c): 缩放补偿，保持初始焦点 f0 屏幕位置不变
-        // 第二项 (pageX − startPageX): 平移补偿，双指在屏幕上的位移(pageX 是屏幕坐标，
-        //   不受组件自身 scale 变化影响，避免 unscaled 坐标反馈抖动)
-        // 注: 此处使用夹紧后的实际 scale 参与计算，保证到达边界时不跳变
-        //（代价是边界处焦点会缓慢漂移，demo 可接受）
-        val deltaScale = startScale - scale
-        currentScale = scale
-        translateX = baseTranslateX + deltaScale * (focusX - CENTER) + (pageX - pinchStartPageX)
-        translateY = baseTranslateY + deltaScale * (focusY - CENTER) + (pageY - pinchStartPageY)
-        // 防止图片飘逸: translate 钳制在 ±半个图片视觉尺寸内，
-        // 手指移出组件导致坐标跳变时图片不会飞走
-        val maxOffset = IMAGE_SIZE * scale * 0.5f
-        translateX = translateX.coerceIn(-maxOffset, maxOffset)
-        translateY = translateY.coerceIn(-maxOffset, maxOffset)
+        // END 时 pageX/pageY 可能因抬指导致捏合中心跳变(剩余手指数 < 2，
+        // locationInView 返回单指位置而非双指质心)。
+        // 此时不重算 translate/scale，直接沿用最后一次 move 的值，消除抬指跳动。
+        // iOS 端已做缓存回放(UIView+CSS.m)，此处为 demo 层的兜底防护。
+        if (state != STATE_END) {
+            // t = t0 + (s0 − s)·(f0 − c) + (pageX − startPageX)
+            //
+            // 第一项 (s0 − s)·(f0 − c): 缩放补偿，保持初始焦点 f0 屏幕位置不变
+            // 第二项 (pageX − startPageX): 平移补偿，双指在屏幕上的位移(pageX 是屏幕坐标，
+            //   不受组件自身 scale 变化影响，避免 unscaled 坐标反馈抖动)
+            // 注: 此处使用夹紧后的实际 scale 参与计算，保证到达边界时不跳变
+            //（代价是边界处焦点会缓慢漂移，demo 可接受）
+          val deltaScale = startScale - scale
+           // 平滑死区: 过滤非对称捏合导致的质心微移(通常 < 3dp)，
+           // 保留有意的双指平移，消除放大时的轻微抖动
+           val panX = smoothDeadZone(pageX - pinchStartPageX, PINCH_PAN_DEAD_ZONE)
+           val panY = smoothDeadZone(pageY - pinchStartPageY, PINCH_PAN_DEAD_ZONE)
+            // 防止图片飘逸: translate 钳制在 ±半个图片视觉尺寸内
+            val maxOffset = IMAGE_SIZE * scale * 0.5f
+            val tx = (baseTranslateX + deltaScale * (focusX - CENTER) + panX).coerceIn(-maxOffset, maxOffset)
+            val ty = (baseTranslateY + deltaScale * (focusY - CENTER) + panY).coerceIn(-maxOffset, maxOffset)
+            // 单次赋值合并 scale+translate，只触发一次 transform 重算(消除中间态抖动)
+            transformState = TransformState(scale, tx, ty)
+        }
 
         stateText = "state: $state"
-        scaleText = "scale(回调原值): ${format(rawScale)}   实际渲染: ${format(scale)}"
+        scaleText = "scale(回调原值): ${format(rawScale)}   实际渲染: ${format(currentScale)}"
         focusText = "focus: (${format(x)}, ${format(y)})"
         translateText = "translate: (${format(translateX)}, ${format(translateY)})"
         velocityText = "velocity: ${format(velocity)} 倍/秒"
@@ -476,13 +485,17 @@ internal class PinchGestureExampleDemo : BasePager() {
                 baseTranslateY = translateY
             }
 
+           STATE_CANCEL -> {
+               // pan 被取消(如第二指落下导致 pinch 接管)，回退到 pan 起手前位置
+                transformState = transformState.copy(tx = panStartTranslateX, ty = panStartTranslateY)
+           }
+
             else -> {
-                translateX = panStartTranslateX + (pageX - panStartPageX)
-                translateY = panStartTranslateY + (pageY - panStartPageY)
                 val panMaxOffset = IMAGE_SIZE * currentScale * 0.5f
-                translateX = translateX.coerceIn(-panMaxOffset, panMaxOffset)
-                translateY = translateY.coerceIn(-panMaxOffset, panMaxOffset)
-                translateText = "translate: (${format(translateX)}, ${format(translateY)})"
+                val tx = (panStartTranslateX + (pageX - panStartPageX)).coerceIn(-panMaxOffset, panMaxOffset)
+                val ty = (panStartTranslateY + (pageY - panStartPageY)).coerceIn(-panMaxOffset, panMaxOffset)
+                transformState = transformState.copy(tx = tx, ty = ty)
+                translateText = "translate: (${format(tx)}, ${format(ty)})"
             }
         }
     }
@@ -491,11 +504,9 @@ internal class PinchGestureExampleDemo : BasePager() {
     private fun onClick() {
         val targetScale = if (baseScale > 1f + SCALE_EPSILON) 1f else CLICK_ZOOM_SCALE
         baseScale = targetScale
-        currentScale = targetScale
         baseTranslateX = 0f
         baseTranslateY = 0f
-        translateX = 0f
-        translateY = 0f
+        transformState = TransformState(targetScale, 0f, 0f)
         scaleText = "scale: 单击切换至 ${format(targetScale)}"
         translateText = "translate: (0.00, 0.00)"
     }
@@ -507,9 +518,7 @@ internal class PinchGestureExampleDemo : BasePager() {
         startScale = 1f
         focusX = CENTER
         focusY = CENTER
-        currentScale = 1f
-        translateX = 0f
-        translateY = 0f
+        transformState = TransformState(1f, 0f, 0f)
         stateText = "已重置，等待双指捏合"
         scaleText = "scale: -"
         focusText = "focus: -"
@@ -536,6 +545,13 @@ internal class PinchGestureExampleDemo : BasePager() {
         return "$intPart.${decPart.toString().padStart(2, '0')}"
     }
 
+    /** 平滑死区: |value| <= threshold 时返回 0，超过阈值后平滑过渡(无跳变) */
+    private fun smoothDeadZone(value: Float, threshold: Float): Float {
+        val absVal = kotlin.math.abs(value)
+        if (absVal <= threshold) return 0f
+        return kotlin.math.sign(value) * (absVal - threshold)
+    }
+
     companion object {
         private const val MIN_SCALE = 0.5f
         private const val MAX_SCALE = 4f
@@ -546,6 +562,10 @@ internal class PinchGestureExampleDemo : BasePager() {
 
         private const val STATE_START = "start"
         private const val STATE_END = "end"
+        private const val STATE_CANCEL = "cancel"
+
+        /** pinch 质心平移死区(dp)，过滤非对称捏合的质心微移 */
+        private const val PINCH_PAN_DEAD_ZONE = 3f
 
         /** 单击切换到的放大倍数 */
         private const val CLICK_ZOOM_SCALE = 2f

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/PinchGestureExampleDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/PinchGestureExampleDemo.kt
@@ -434,12 +434,12 @@ internal class PinchGestureExampleDemo : BasePager() {
             // 第二项 (pageX − startPageX): 平移补偿，双指在屏幕上的位移(pageX 是屏幕坐标，
             //   不受组件自身 scale 变化影响，避免 unscaled 坐标反馈抖动)
             // 注: 此处使用夹紧后的实际 scale 参与计算，保证到达边界时不跳变
-            //（代价是边界处焦点会缓慢漂移，demo 可接受）
-          val deltaScale = startScale - scale
-           // 平滑死区: 过滤非对称捏合导致的质心微移(通常 < 3dp)，
-           // 保留有意的双指平移，消除放大时的轻微抖动
-           val panX = smoothDeadZone(pageX - pinchStartPageX, PINCH_PAN_DEAD_ZONE)
-           val panY = smoothDeadZone(pageY - pinchStartPageY, PINCH_PAN_DEAD_ZONE)
+           //（代价是边界处焦点会缓慢漂移，demo 可接受）
+            val deltaScale = startScale - scale
+            // 平滑死区: 过滤非对称捏合导致的质心微移(通常 < 3dp)，
+            // 保留有意的双指平移，消除放大时的轻微抖动
+            val panX = smoothDeadZone(pageX - pinchStartPageX, PINCH_PAN_DEAD_ZONE)
+            val panY = smoothDeadZone(pageY - pinchStartPageY, PINCH_PAN_DEAD_ZONE)
             // 防止图片飘逸: translate 钳制在 ±半个图片视觉尺寸内
             val maxOffset = IMAGE_SIZE * scale * 0.5f
             val tx = (baseTranslateX + deltaScale * (focusX - CENTER) + panX).coerceIn(-maxOffset, maxOffset)
@@ -485,10 +485,11 @@ internal class PinchGestureExampleDemo : BasePager() {
                 baseTranslateY = translateY
             }
 
-           STATE_CANCEL -> {
-               // pan 被取消(如第二指落下导致 pinch 接管)，回退到 pan 起手前位置
+            STATE_CANCEL -> {
+                // pan 被取消(如第二指落下导致 pinch 接管)，回退到 pan 起手前位置
                 transformState = transformState.copy(tx = panStartTranslateX, ty = panStartTranslateY)
-           }
+                translateText = "translate: (${format(panStartTranslateX)}, ${format(panStartTranslateY)})"
+            }
 
             else -> {
                 val panMaxOffset = IMAGE_SIZE * currentScale * 0.5f

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/PinchGestureExampleDemo.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/PinchGestureExampleDemo.kt
@@ -95,6 +95,7 @@ internal class PinchGestureExampleDemo : BasePager() {
     private var scaleText: String by observable("scale: -")
     private var focusText: String by observable("focus: -")
     private var translateText: String by observable("translate: -")
+    private var velocityText: String by observable("velocity: -")
     private var pageCenterText: String by observable("pageCenter: -")
 
     /** 校验scale是否为累计语义: 若为增量语义，该区间会持续贴在1.0附近抖动 */
@@ -115,6 +116,12 @@ internal class PinchGestureExampleDemo : BasePager() {
     private var panStartPageY: Float = 0f
     private var panStartTranslateX: Float = 0f
     private var panStartTranslateY: Float = 0f
+
+    // ---- 示例一: pinch 双指平移 ----
+    // pinch 的焦点 pageX/pageY 是屏幕坐标(不受组件 scale 影响)，
+    // 用它派生平移可避免 unscaled 坐标随 scale 变化导致的反馈抖动。
+    private var pinchStartPageX: Float = 0f
+    private var pinchStartPageY: Float = 0f
 
     // ---- 示例二: 以宽高承载缩放 ----
 
@@ -183,6 +190,14 @@ internal class PinchGestureExampleDemo : BasePager() {
                         attr {
                             text(ctx.translateText)
                             color(Color.WHITE)
+                            fontSize(14f)
+                            marginTop(6f)
+                        }
+                    }
+                    Text {
+                        attr {
+                            text(ctx.velocityText)
+                            color(Color(0xFF9AD1FFL))
                             fontSize(14f)
                             marginTop(6f)
                         }
@@ -283,7 +298,7 @@ internal class PinchGestureExampleDemo : BasePager() {
 
                         event {
                             pinch { params ->
-                                ctx.onPinch(params.state, params.x, params.y, params.scale)
+                                ctx.onPinch(params.state, params.x, params.y, params.scale, params.velocity, params.pageX, params.pageY)
                                 ctx.pageCenterText =
                                     "pageCenter: (${ctx.format(params.pageX)}, ${ctx.format(params.pageY)})"
                                 ctx.gestureLogText = "最近手势: pinch(${params.state})"
@@ -381,13 +396,18 @@ internal class PinchGestureExampleDemo : BasePager() {
      * @param x 捏合中心点在组件内的 x(dp)
      * @param y 捏合中心点在组件内的 y(dp)
      * @param rawScale 框架回调的缩放倍数(相对手势起点的累计值)
+     * @param velocity 缩放倍数变化速率(倍/秒)，用于观察松手时的惯性趋势
+     * @param pageX 捏合中心点在页面坐标系的x(屏幕坐标，不受组件scale影响)
+     * @param pageY 捏合中心点在页面坐标系的y
      */
-    private fun onPinch(state: String, x: Float, y: Float, rawScale: Float) {
+    private fun onPinch(state: String, x: Float, y: Float, rawScale: Float, velocity: Float, pageX: Float, pageY: Float) {
         if (state == STATE_START) {
             // 手势开始: 固化基准与焦点，整个手势内不再变化
             startScale = baseScale
             focusX = x
             focusY = y
+            pinchStartPageX = pageX
+            pinchStartPageY = pageY
             minRawScale = rawScale
             maxRawScale = rawScale
         } else {
@@ -402,18 +422,28 @@ internal class PinchGestureExampleDemo : BasePager() {
         // 累计倍数 × 上次手势结束时的基准，并夹紧到允许范围
         val scale = (startScale * rawScale).coerceIn(MIN_SCALE, MAX_SCALE)
 
-        // t = t0 + (s0 − s)·(p0 − c)
+        // t = t0 + (s0 − s)·(f0 − c) + (pageX − startPageX)
+        //
+        // 第一项 (s0 − s)·(f0 − c): 缩放补偿，保持初始焦点 f0 屏幕位置不变
+        // 第二项 (pageX − startPageX): 平移补偿，双指在屏幕上的位移(pageX 是屏幕坐标，
+        //   不受组件自身 scale 变化影响，避免 unscaled 坐标反馈抖动)
         // 注: 此处使用夹紧后的实际 scale 参与计算，保证到达边界时不跳变
         //（代价是边界处焦点会缓慢漂移，demo 可接受）
         val deltaScale = startScale - scale
         currentScale = scale
-        translateX = baseTranslateX + deltaScale * (focusX - CENTER)
-        translateY = baseTranslateY + deltaScale * (focusY - CENTER)
+        translateX = baseTranslateX + deltaScale * (focusX - CENTER) + (pageX - pinchStartPageX)
+        translateY = baseTranslateY + deltaScale * (focusY - CENTER) + (pageY - pinchStartPageY)
+        // 防止图片飘逸: translate 钳制在 ±半个图片视觉尺寸内，
+        // 手指移出组件导致坐标跳变时图片不会飞走
+        val maxOffset = IMAGE_SIZE * scale * 0.5f
+        translateX = translateX.coerceIn(-maxOffset, maxOffset)
+        translateY = translateY.coerceIn(-maxOffset, maxOffset)
 
         stateText = "state: $state"
         scaleText = "scale(回调原值): ${format(rawScale)}   实际渲染: ${format(scale)}"
-        focusText = "focus: (${format(focusX)}, ${format(focusY)})"
+        focusText = "focus: (${format(x)}, ${format(y)})"
         translateText = "translate: (${format(translateX)}, ${format(translateY)})"
+        velocityText = "velocity: ${format(velocity)} 倍/秒"
         rawScaleRangeText =
             "本次手势 scale 区间: ${format(minRawScale)} ~ ${format(maxRawScale)}"
 
@@ -449,6 +479,9 @@ internal class PinchGestureExampleDemo : BasePager() {
             else -> {
                 translateX = panStartTranslateX + (pageX - panStartPageX)
                 translateY = panStartTranslateY + (pageY - panStartPageY)
+                val panMaxOffset = IMAGE_SIZE * currentScale * 0.5f
+                translateX = translateX.coerceIn(-panMaxOffset, panMaxOffset)
+                translateY = translateY.coerceIn(-panMaxOffset, panMaxOffset)
                 translateText = "translate: (${format(translateX)}, ${format(translateY)})"
             }
         }
@@ -481,6 +514,7 @@ internal class PinchGestureExampleDemo : BasePager() {
         scaleText = "scale: -"
         focusText = "focus: -"
         translateText = "translate: -"
+        velocityText = "velocity: -"
         pageCenterText = "pageCenter: -"
         rawScaleRangeText = "本次手势 scale 区间: -"
         gestureLogText = "最近手势: -"
@@ -488,6 +522,8 @@ internal class PinchGestureExampleDemo : BasePager() {
         panStartPageY = 0f
         panStartTranslateX = 0f
         panStartTranslateY = 0f
+        pinchStartPageX = 0f
+        pinchStartPageY = 0f
         imageWidth = IMAGE_SIZE
         imageHeight = IMAGE_SIZE
         sizeScale = 1f

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/catalog/ExampleIndexPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/catalog/ExampleIndexPage.kt
@@ -174,6 +174,13 @@ internal class ExampleIndexPage : BasePager() {
         })
 
         itemList.add(ExampleItemData().apply {
+            avatarText = "Pi"
+            titleText = "Pinch事件"
+            subtitleText = "双指捏合事件，scale为相对手势起点的累计倍数，配合transform实现缩放"
+            declarativeExampleUrl = generateJumpUrl("PinchGestureExampleDemo")
+        })
+
+        itemList.add(ExampleItemData().apply {
             avatarText = "Bu"
             titleText = "ButtonView"
             subtitleText = "Kuikly中的Button实际上是一个带有文字和背景颜色的View"

--- a/docs/API/components/basic-attr-event.md
+++ b/docs/API/components/basic-attr-event.md
@@ -1291,6 +1291,10 @@ internal class PanEventPage : BasePager() {
 ``EXCLUSIVE_GROUP``手势组内，组内先识别成功者胜出、其余判失败，本就是互斥的。
 Android 与 iOS 的处理比鸿蒙更宽松：仅在捏合实际发生时才让``pan``让位，
 不会出现``pinch``被``pan``抢死而完全不触发的情况。
+:::
+
+:::warning macOS 暂不支持
+macOS 无对应的捏合手势识别器实现，注册``pinch``不会报错，但回调不会触发。
 
 **需要「缩放同时平移」时**，不必依赖双指``pan``：``pinch``每次回调都带焦点坐标
 （``x``/``y``与``pageX``/``pageY``），用焦点相对手势起点的位移即可得到平移量。

--- a/docs/API/components/basic-attr-event.md
+++ b/docs/API/components/basic-attr-event.md
@@ -1250,6 +1250,154 @@ internal class PanEventPage : BasePager() {
 }
 ```
 
+### pinch事件
+
+``pinch``事件为双指捏合事件, 常用于实现图片、地图等内容的缩放效果。当``Kuikly``组件有设置``pinch``事件，并且``Kuikly``组件被双指捏合时，会触发``pinch``闭包回调。
+``pinch``回调闭包中含有``PinchGestureParams``类型参数，以此来描述捏合事件的信息。
+
+<div class="table-01">
+
+**PinchGestureParams**
+
+| 参数  | 描述     | 类型 |
+|:----|:-------|:--|
+| x   | 捏合中心点相对于组件的坐标x  | Float |
+| y   | 捏合中心点相对于组件的坐标y  | Float |
+| pageX   | 捏合中心点相对于页面的坐标x  | Float |
+| pageY   | 捏合中心点相对于页面的坐标y  | Float |
+| scale | 相对手势开始时的累计缩放倍数，手势开始时为1.0  | Float |
+| state | 捏合状态："start", "move", "end" | String |
+
+</div>
+
+:::tip 注意
+- ``scale``为**相对手势开始时**的累计倍数，而非相邻两次回调间的增量。若需在多次手势间累积缩放，需业务侧自行记录手势结束时的基准值。
+- 缩放渲染由业务侧通过``transform``的``scale``实现。
+- ``x``/``y``为组件局部坐标，**会随组件自身的``scale``变化**；若需计算与缩放无关的位移，请使用``pageX``/``pageY``。
+:::
+
+:::warning 与 pan 事件的职责边界
+同一组件同时注册``pan``与``pinch``时，二者按「**单指 pan、双指 pinch**」划分职责：
+
+- 双指捏合期间**不会**派发``pan``事件
+- Android 上若捏合前已触发``pan``，会先补发一次``pan``的``end``状态再开始``pinch``
+- 仅注册``pan``（未注册``pinch``）的组件不受影响，``pan``仍可由多指触发
+
+这不是因为两个手势语义上互斥——双指的质心平移与间距缩放本可同时表达。
+划分职责的原因有两点：一是``pan``在多指下的坐标语义不明确（报出的是其中一根手指的位置，
+手指增减时会跳变），交由``pinch``统一处理更可靠；二是与鸿蒙保持语义方向一致。
+
+鸿蒙渲染层将``pan``/``pinch``/``longPress``/``click``全部注册在同一个
+``EXCLUSIVE_GROUP``手势组内，组内先识别成功者胜出、其余判失败，本就是互斥的。
+Android 与 iOS 的处理比鸿蒙更宽松：仅在捏合实际发生时才让``pan``让位，
+不会出现``pinch``被``pan``抢死而完全不触发的情况。
+
+**需要「缩放同时平移」时**，不必依赖双指``pan``：``pinch``每次回调都带焦点坐标
+（``x``/``y``与``pageX``/``pageY``），用焦点相对手势起点的位移即可得到平移量。
+:::
+
+:::warning 缩放中心的实现方式
+实现「以捏合点为中心缩放」时，**不要用``anchor``表达缩放中心**。
+
+渲染位置为 ``V(p) = c + s·(p − c) + t``（``c``为锚点、``s``为缩放、``t``为位移），
+锚点``c``出现在表达式中，故在``s != 1``时改变``c``会导致画面跳变，
+无法同时满足「绕任意点缩放」与「不跳变」。
+
+正确做法是锚点保持默认（组件中心），改用``translate``补偿：
+
+```
+t = t0 + (s0 − s)·(p0 − c)
+```
+
+其中``s0``/``t0``为手势开始时的缩放与位移，``p0``为手势开始时的捏合中心点。
+手势首帧``s == s0``，代入得``t == t0``，故起手连续不跳变。完整示例见下方。
+:::
+
+:::warning 平台差异
+**手指落点超出组件范围时的行为不一致：**
+
+| 场景 | Android | iOS |
+|:----|:--------|:----|
+| 两指落在组件内，移动时超出组件 | 手势继续 | 手势继续 |
+| 第二根手指直接落在组件外 | 手势继续 | **手势不成立** |
+
+原因是两端触摸路由模型不同：Android 的后续触点均跟随首个按下事件所捕获的 View；
+iOS 对每个触点独立做 hitTest，落在组件外的触点不会关联到该组件的手势识别器。
+
+若业务需要较大的捏合响应范围，建议将``pinch``注册在**外层容器**而非内容组件上。
+:::
+
+**示例**
+
+```kotlin {33-49}
+@Page("demo_page")
+internal class PinchEventPage : BasePager() {
+
+    // 渲染状态
+    private var currentScale by observable(1f)
+    private var translateX by observable(0f)
+    private var translateY by observable(0f)
+
+    // 上次手势结束时固化的基准
+    private var baseScale = 1f
+    private var baseTranslateX = 0f
+    private var baseTranslateY = 0f
+
+    // 本次手势内固定的量
+    private var startScale = 1f
+    private var focusX = SIZE / 2
+    private var focusY = SIZE / 2
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            attr {
+                allCenter()
+            }
+            View {
+                attr {
+                    size(SIZE, SIZE)
+                    backgroundColor(Color.GREEN)
+                    // 锚点保持默认(组件中心)，缩放中心由 translate 补偿实现
+                    transform(
+                        scale = Scale(ctx.currentScale, ctx.currentScale),
+                        translate = Translate(ctx.translateX / SIZE, ctx.translateY / SIZE)
+                    )
+                }
+
+                event {
+                    pinch { params ->
+                        if (params.isStart) {
+                            // 手势开始: 固化基准与捏合中心点，手势内不再变化
+                            ctx.startScale = ctx.baseScale
+                            ctx.focusX = params.x
+                            ctx.focusY = params.y
+                        }
+
+                        val scale = ctx.startScale * params.scale
+                        // t = t0 + (s0 − s)·(p0 − c)
+                        val deltaScale = ctx.startScale - scale
+                        ctx.currentScale = scale
+                        ctx.translateX = ctx.baseTranslateX + deltaScale * (ctx.focusX - SIZE / 2)
+                        ctx.translateY = ctx.baseTranslateY + deltaScale * (ctx.focusY - SIZE / 2)
+
+                        if (params.isEnd) { // 手势结束: 固化结果供下次手势累积
+                            ctx.baseScale = ctx.currentScale
+                            ctx.baseTranslateX = ctx.translateX
+                            ctx.baseTranslateY = ctx.translateY
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val SIZE = 200f
+    }
+}
+```
+
 ### animationCompletion事件
 
 ``animationCompletion``事件为动画结束事件。当``Kuikly``组件有设置``animationCompletion``事件，并且``Kuikly``组件动画结束时，会触发``animationCompletion``闭包回调。

--- a/docs/API/components/basic-attr-event.md
+++ b/docs/API/components/basic-attr-event.md
@@ -1266,6 +1266,7 @@ internal class PanEventPage : BasePager() {
 | pageX   | 捏合中心点相对于页面的坐标x  | Float |
 | pageY   | 捏合中心点相对于页面的坐标y  | Float |
 | scale | 相对手势开始时的累计缩放倍数，手势开始时为1.0  | Float |
+| velocity | 缩放倍数变化速率(倍/秒)，可用于实现松手后的惯性动画 | Float |
 | state | 捏合状态："start", "move", "end" | String |
 
 </div>


### PR DESCRIPTION
# Implement pinch event for Android and iOS renderers

Refs #582.

That issue raises two things: the pinch gesture not working, and a `ZoomScale` capability for
`Scroller`. This PR only addresses the first one, so please do not close the issue on merge —
`ZoomScale` is not covered here.

## Background

The `pinch` event API has been present in `core` for a while:

- `core/.../event/EventName.kt` — `PINCH("pinch")`
- `core/.../event/Event.kt` — `open fun pinch(handler: (PinchGestureParams) -> Unit)`
- `core/.../event/EventParams.kt` — `PinchGestureParams`

The OHOS renderer implements it (`KRPinchGestureEventHandler`), but the Android and iOS
renderers do not. Business code can call `pinch { }` without any error, yet the callback
never fires.

This PR only fills in the missing renderer implementations. **No changes to `core`, no new
public API.**

## Changes

**Android** (`core-render-android`)

- `const/KRConst.kt` — add `PINCH = "pinch"`
- `css/gesture/KRCSSGestureDetector.kt` — pinch implementation
- `css/gesture/KRCSSGestureListener.kt` — `TYPE_PINCH = 5`, `dispatchPinchEvent`, suppress
  `pan` while pinching
- `css/ktx/KRCSSViewExtension.kt` — `setProp` / `resetProp` branches

**iOS** (`core-render-ios`)

- `Extension/Category/UIView+CSS.h` / `.m` — `css_pinch` property, `UIPinchGestureRecognizer`
  registration, ancestor scroll view lock/unlock, pan touch-count limit

**Demo and docs**

- `demo/.../PinchGestureExampleDemo.kt` — extend the existing pinch demo page. It now shows
  two ways to model scaling (transform with a focus point, and absorbing the ratio into the
  image size, which is what the page did before) and echoes the event parameters so the
  behaviour can be checked on device
- `demo/.../catalog/ExampleIndexPage.kt` — add a catalog entry for that page, which previously
  could only be reached by jumping to the page name directly
- `docs/API/components/basic-attr-event.md` — `pinch` section and caveats

## Implementation notes

### Android does not use `ScaleGestureDetector`

`ScaleGestureDetector` is designed for incremental scaling behind a recognition threshold,
which does not match the `PinchGestureParams` contract (accumulated ratio relative to the
gesture start, beginning as soon as two fingers are down). Its `minSpan` threshold swallows
the initial movement, so the user has to move a long way for a small scale change.

Instead the two pointers are tracked directly by pointer id, and
`scale = current distance / initial distance`. This matches `UIPinchGestureRecognizer` on
iOS and the ArkUI pinch gesture on OHOS.

### Android measures pointer distance in the parent coordinate space

When Android dispatches a touch event to a child view it applies the view's inverse matrix,
so the local distance between two pointers is roughly the physical distance divided by the
current scale. Computing the ratio from local coordinates creates a feedback loop — a larger
scale shrinks the local distance, which shrinks the scale — and the view visibly oscillates
even when the fingers are held still.

Distances are therefore mapped to the parent coordinate space with
`View.getMatrix().mapPoints()`. Note the distinction: **measurement uses the parent
coordinate space, while the callback still reports local coordinates**, consistent with
`locationInView:` on iOS.

### Android requests `disallowInterceptTouchEvent` on `ACTION_POINTER_DOWN`

Requesting it only after the gesture is recognized is too late: an ancestor list has already
claimed the touch stream and dispatched `ACTION_CANCEL`. Two fingers going down already
signal scaling intent, so the request happens there. A `hasDisallowInterceptForPinch` flag
guarantees the request is always paired with a reset — missing the reset would leave the
ancestor list permanently unable to scroll.

### iOS: keep the ancestor scroll view from cancelling the touch

`KRScrollView`'s `touchesShouldCancelInContentView:` returns `YES` for non-`UIControl`
subviews by default, so scrolling cancels the touches and breaks the pinch.
`css_lockAncestorScrollViewForPinch` / `css_unlockAncestorScrollViewForPinch` lock on `Began`
and unlock on `Ended` / `Cancelled` / `Failed`, with a fallback unlock when the callback is
detached — otherwise the scroll view would stay locked forever.

### Boundary between `pan` and `pinch`

When a component registers both `pan` and `pinch`, responsibilities are split as
"one finger pans, two fingers pinch": Android does not dispatch `pan` while a pinch is in
progress, and iOS sets `css_panGR.maximumNumberOfTouches = 1`.

This is consistent with the direction the OHOS renderer already takes — it registers `pan`,
`pinch`, `longPress` and `click` in a single `EXCLUSIVE_GROUP` gesture group, where the first
gesture to be recognized wins and the others fail. Android and iOS are more permissive here:
`pan` only yields once a pinch is actually happening, so `pinch` can never be starved by
`pan`.

No capability is lost. Every `pinch` callback carries the focus point (`x`/`y` and
`pageX`/`pageY`), so "pan while zooming" can be derived from the focus movement, identically
on all platforms. The docs note that the translation must be taken from either `pan` or the
focus movement, never both.

## Impact on existing pages

**Please note that this PR changes behaviour for one class of existing pages.**

Because the `pinch` core API already exists and the OHOS renderer implements it, cross
platform pages may already contain `pinch` handlers that have been dead code on Android and
iOS. After this PR:

1. Those pages start receiving `pinch` callbacks, activating logic that previously relied on
   `pinch` never firing
2. If the same component also registers `pan`, it no longer receives `pan` during two-finger
   gestures

This seems unlikely in practice — code that never runs tends to get deleted — but it is not
impossible. The responsibility boundary is documented.

Otherwise there is no impact on existing pages:

- Components that register only `pan` behave exactly as before. On Android the pinch handling
  is gated by `containPinchEvent()`; on iOS `maximumNumberOfTouches` is only lowered to 1 when
  `css_pinchGR` exists
- `core` is untouched, so other renderers are unaffected

## Known platform difference

When a finger lands outside the component, the two platforms differ. This is inherent to the
platforms:

- On Android every pointer follows the view that captured the first `DOWN`, so a finger
  outside the component still takes part in its gesture
- On iOS each touch is hit-tested independently, so a touch outside the component is not
  associated with its gesture recognizers and the pinch does not start

Aligning this would require attaching the recognizer to an ancestor container, which changes
the framework's gesture ownership semantics — out of scope here. The docs suggest registering
`pinch` on an outer container when a larger response area is needed.

## Testing

Verified on physical devices (Android and iOS):

1. Event lifecycle and focus-centred scaling — `start` / `move` / `end` states and the
   accumulated `scale` are correct, and the scale centre follows the pinch focus
2. iOS scroll view conflict — pinching a component inside a `List` is not interrupted by
   scrolling, the list scrolls again after the gesture ends, and entering/leaving the page
   repeatedly never leaves the scroll view locked
3. Android coordinate space and interception timing — `scale` is stable when the fingers are
   held still (no oscillation), zooming back down from the upper bound works, there is no
   initial threshold, and the ancestor list scrolls again after the gesture
4. `pan` / `pinch` / `click` boundary — no `pan` during a two-finger pinch, and no spurious
   `click` when the pinch ends

Reproduce with the "Pinch事件" entry in the demo catalog, which opens `PinchGestureExampleDemo`
— the same page named in #582. The four checks are described on the page, which also echoes
the most recent gesture.
