### PR TITLE
fix(ios): skip unchanged contentInset calls to prevent pull-to-refresh stutter

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/material3/PullToRefresh.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/material3/PullToRefresh.kt
@@ -237,12 +237,9 @@ internal fun PullToRefreshItem(
     scrollState.kuiklyInfo.pullToRefreshTopInsetPx = with(density) { topInset.roundToPx() }
 
     // Tracks whether the next IDLE was triggered by the failsafe below.
-    // When [0] is true, the IDLE branch skips the inset reset animation to avoid
+    // When true, the IDLE branch skips the inset reset animation to avoid
     // restarting an animation that will soon be re-triggered by the real
     // REFRESHING -> IDLE transition.
-    // Use a plain array (not Compose state) to avoid triggering recomposition,
-    // which could cause Compose to batch the failsafe IDLE away and leave the
-    // flag unconsumed — incorrectly suppressing the real endRefresh inset reset.
     var suppressIdleInsetReset by remember { mutableStateOf(false) }
 
     // Monitor scroll state changes inspired by RefreshView logic
@@ -293,7 +290,7 @@ internal fun PullToRefreshItem(
                     if (!state.isRefreshing) {
                         withFrameNanos { }
                     }
-                    if (!state.isRefreshing) {
+                    if (!state.isRefreshing && state.pullState == PullState.REFRESHING) {
                         suppressIdleInsetReset = true
                         state.updatePullState(PullState.IDLE)
                         state.updateProgress(0f)

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/material3/PullToRefresh.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/material3/PullToRefresh.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameNanos
 import com.tencent.kuikly.compose.foundation.layout.Box
 import com.tencent.kuikly.compose.foundation.layout.fillMaxWidth
 import com.tencent.kuikly.compose.foundation.layout.height
@@ -235,6 +236,15 @@ internal fun PullToRefreshItem(
 
     scrollState.kuiklyInfo.pullToRefreshTopInsetPx = with(density) { topInset.roundToPx() }
 
+    // Tracks whether the next IDLE was triggered by the failsafe below.
+    // When [0] is true, the IDLE branch skips the inset reset animation to avoid
+    // restarting an animation that will soon be re-triggered by the real
+    // REFRESHING -> IDLE transition.
+    // Use a plain array (not Compose state) to avoid triggering recomposition,
+    // which could cause Compose to batch the failsafe IDLE away and leave the
+    // flag unconsumed — incorrectly suppressing the real endRefresh inset reset.
+    var suppressIdleInsetReset by remember { mutableStateOf(false) }
+
     // Monitor scroll state changes inspired by RefreshView logic
     LaunchedEffect(scrollState) {
         snapshotFlow {
@@ -278,7 +288,13 @@ internal fun PullToRefreshItem(
                     // (true -> false) within a single frame interval, Compose may never
                     // observe the intermediate true value. This leaves pullState stuck
                     // in REFRESHING. Detect and force reset to IDLE.
+                    // Wait one frame to give onRefresh's coroutine a chance to set
+                    // isRefreshing = true before concluding the state is stuck.
                     if (!state.isRefreshing) {
+                        withFrameNanos { }
+                    }
+                    if (!state.isRefreshing) {
+                        suppressIdleInsetReset = true
                         state.updatePullState(PullState.IDLE)
                         state.updateProgress(0f)
                     }
@@ -329,6 +345,7 @@ internal fun PullToRefreshItem(
         val isDragging = scrollView?.isDragging == true
         when (state.pullState) {
             PullState.REFRESHING -> {
+                suppressIdleInsetReset = false
                 pullToRefreshLog { "apply inset REFRESHING top=$refreshThresholdLogical animated=true" }
                 scrollView?.setContentInset(top = refreshThresholdLogical, animated = true)
             }
@@ -337,7 +354,9 @@ internal fun PullToRefreshItem(
                 // - iOS: animated inset also animates contentOffset back to bounds
                 // - Android: non-animated inset calls setFinalTranslation and snaps overscroll to 0
                 scrollView?.setContentInsetWhenEndDrag(top = 0f)
-                if (!isDragging) {
+                if (suppressIdleInsetReset) {
+                    suppressIdleInsetReset = false
+                } else if (!isDragging) {
                     pullToRefreshLog { "apply inset IDLE top=0 animated=true isDragging=false" }
                     scrollView?.setContentInset(top = 0f, animated = true)
                 } else {

--- a/core-render-ios/Extension/Components/KRScrollView.m
+++ b/core-render-ios/Extension/Components/KRScrollView.m
@@ -465,6 +465,11 @@ KUIKLY_NESTEDSCROLL_PROTOCOL_PROPERTY_IMP
     NSArray<NSString *> *points = [params componentsSeparatedByString:@" "];
     BOOL animated = [points count] > 4 ? [points[4] boolValue] : NO;
     UIEdgeInsets contentInset = UIEdgeInsetsMake([points[0] doubleValue], [points[1] doubleValue], [points[2] doubleValue], [points[3] doubleValue]);
+    // Skip if inset unchanged — avoids spurious animated setContentOffset that conflicts
+    // with a subsequent inset change (e.g. PullToRefresh REFRESHING→IDLE within same frame)
+    if (UIEdgeInsetsEqualToEdgeInsets(self.contentInset, contentInset)) {
+        return;
+    }
     if (animated) {
         CGPoint maxContentOffset = [self p_maxContentOffsetInContentInset:contentInset];
         if (!CGPointEqualToPoint(self.contentOffset, maxContentOffset)) {


### PR DESCRIPTION
fix(ios): skip unchanged contentInset calls to prevent pull-to-refresh stutter