### PR TITLE
fix(compose): guard sendFrame when official Transition IOOB on shared Snapshot

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/animation/core/Transition.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/animation/core/Transition.kt
@@ -1021,14 +1021,25 @@ class Transition<S> internal constructor(
 
     private fun calculateTotalDurationNanos(): Long {
         var maxDurationNanos = 0L
-        _animations.fastForEach {
-            maxDurationNanos = max(maxDurationNanos, it.durationNanos)
-        }
-        _transitions.fastForEach {
-            maxDurationNanos = max(
-                maxDurationNanos,
-                it.calculateTotalDurationNanos()
-            )
+        // Guard against IndexOutOfBoundsException when _animations/_transitions
+        // (mutableStateListOf) is structurally modified during snapshot apply
+        // notifications. fastForEach captures `indices` then calls get(index);
+        // a concurrent snapshot apply can shrink the list mid-iteration
+        // (e.g. index:1, size:1), which surfaces via SnapshotStateObserver
+        // drainChanges -> derivedStateOf(totalDurationNanos).
+        try {
+            _animations.fastForEach {
+                maxDurationNanos = max(maxDurationNanos, it.durationNanos)
+            }
+            _transitions.fastForEach {
+                maxDurationNanos = max(
+                    maxDurationNanos,
+                    it.calculateTotalDurationNanos()
+                )
+            }
+        } catch (_: IndexOutOfBoundsException) {
+            // Concurrent structural modification. derivedStateOf will re-evaluate
+            // on the next consistent snapshot read; partial max is safe.
         }
         return maxDurationNanos
     }

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/animation/core/Transition.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/animation/core/Transition.kt
@@ -1021,25 +1021,14 @@ class Transition<S> internal constructor(
 
     private fun calculateTotalDurationNanos(): Long {
         var maxDurationNanos = 0L
-        // Guard against IndexOutOfBoundsException when _animations/_transitions
-        // (mutableStateListOf) is structurally modified during snapshot apply
-        // notifications. fastForEach captures `indices` then calls get(index);
-        // a concurrent snapshot apply can shrink the list mid-iteration
-        // (e.g. index:1, size:1), which surfaces via SnapshotStateObserver
-        // drainChanges -> derivedStateOf(totalDurationNanos).
-        try {
-            _animations.fastForEach {
-                maxDurationNanos = max(maxDurationNanos, it.durationNanos)
-            }
-            _transitions.fastForEach {
-                maxDurationNanos = max(
-                    maxDurationNanos,
-                    it.calculateTotalDurationNanos()
-                )
-            }
-        } catch (_: IndexOutOfBoundsException) {
-            // Concurrent structural modification. derivedStateOf will re-evaluate
-            // on the next consistent snapshot read; partial max is safe.
+        _animations.fastForEach {
+            maxDurationNanos = max(maxDurationNanos, it.durationNanos)
+        }
+        _transitions.fastForEach {
+            maxDurationNanos = max(
+                maxDurationNanos,
+                it.calculateTotalDurationNanos()
+            )
         }
         return maxDurationNanos
     }

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/BaseComposeScene.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/BaseComposeScene.kt
@@ -55,7 +55,6 @@ import com.tencent.kuikly.compose.profiler.RecompositionTracker
 import com.tencent.kuikly.compose.profiler.kuiklySetObserver
 import com.tencent.kuikly.compose.ui.KuiklyCanvas
 import com.tencent.kuikly.core.exception.throwRuntimeError
-import com.tencent.kuikly.core.log.KLog
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.CoroutineContext
 
@@ -211,14 +210,7 @@ internal abstract class BaseComposeScene(
 
             frameClock.sendFrame(nanoTime) // Recomposition
             doLayout() // Layout
-            // Swallow IndexOutOfBoundsException from any effect task (not only Transition)
-            // to keep the frame loop alive. FlushCoroutineDispatcher drops remaining tasks
-            // in the batch on throw; animation/recomposition effects reschedule next frame.
-            try {
-                recomposer.performScheduledEffects() // Composition effects (e.g. LaunchedEffect)
-            } catch (e: IndexOutOfBoundsException) {
-                KLog.e("Kuikly.Compose", "performScheduledEffects failed: ${e.stackTraceToString()}")
-            }
+            recomposer.performScheduledEffects() // Composition effects (e.g. LaunchedEffect)
 
             inputHandler.updatePointerPosition() // Synthetic move event
             snapshotInvalidationTracker.onDraw()

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/BaseComposeScene.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/BaseComposeScene.kt
@@ -55,6 +55,7 @@ import com.tencent.kuikly.compose.profiler.RecompositionTracker
 import com.tencent.kuikly.compose.profiler.kuiklySetObserver
 import com.tencent.kuikly.compose.ui.KuiklyCanvas
 import com.tencent.kuikly.core.exception.throwRuntimeError
+import com.tencent.kuikly.core.log.KLog
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.CoroutineContext
 
@@ -208,9 +209,22 @@ internal abstract class BaseComposeScene(
 
             recomposer.performScheduledTasks()
 
-            frameClock.sendFrame(nanoTime) // Recomposition
+            // Transition.totalDurationNanos may throw IndexOutOfBoundsException while
+            // SnapshotStateObserver drains during sendFrame/applyChanges (list shrinks
+            // mid fastForEach). Swallow to keep the frame loop alive; next frame
+            // re-evaluates with a consistent snapshot.
+            try {
+                frameClock.sendFrame(nanoTime) // Recomposition
+            } catch (e: IndexOutOfBoundsException) {
+                KLog.e("Kuikly.Compose", "sendFrame failed: ${e.stackTraceToString()}")
+            }
             doLayout() // Layout
-            recomposer.performScheduledEffects() // Composition effects (e.g. LaunchedEffect)
+            // Same class of Transition IOOB can also surface in composition effects.
+            try {
+                recomposer.performScheduledEffects() // Composition effects (e.g. LaunchedEffect)
+            } catch (e: IndexOutOfBoundsException) {
+                KLog.e("Kuikly.Compose", "performScheduledEffects failed: ${e.stackTraceToString()}")
+            }
 
             inputHandler.updatePointerPosition() // Synthetic move event
             snapshotInvalidationTracker.onDraw()

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/BaseComposeScene.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/BaseComposeScene.kt
@@ -55,6 +55,7 @@ import com.tencent.kuikly.compose.profiler.RecompositionTracker
 import com.tencent.kuikly.compose.profiler.kuiklySetObserver
 import com.tencent.kuikly.compose.ui.KuiklyCanvas
 import com.tencent.kuikly.core.exception.throwRuntimeError
+import com.tencent.kuikly.core.log.KLog
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.CoroutineContext
 
@@ -208,7 +209,22 @@ internal abstract class BaseComposeScene(
 
             recomposer.performScheduledTasks()
 
-            frameClock.sendFrame(nanoTime) // Recomposition
+            // Kuikly runs on HRContextQueueHandlerThread; snapshot apply during sendFrame can
+            // synchronously drain official Jetpack Compose SnapshotStateObservers. If main-thread
+            // official UI (e.g. androidx.compose.animation.Transition) is updated concurrently,
+            // IndexOutOfBoundsException may surface here — not fixable in official Compose.
+            try {
+                frameClock.sendFrame(nanoTime) // Recomposition
+            } catch (e: IndexOutOfBoundsException) {
+                KLog.e(
+                    "Kuikly.Compose",
+                    "sendFrame IndexOutOfBoundsException (often official Compose on shared Snapshot): ${e.stackTraceToString()}",
+                )
+                if (frameSampled) {
+                    tracker?.onFrameEnd(0)
+                }
+                return@postponeInvalidation
+            }
             doLayout() // Layout
             recomposer.performScheduledEffects() // Composition effects (e.g. LaunchedEffect)
 

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/BaseComposeScene.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/BaseComposeScene.kt
@@ -217,12 +217,13 @@ internal abstract class BaseComposeScene(
             try {
                 frameClock.sendFrame(nanoTime) // Recomposition
             } catch (e: IndexOutOfBoundsException) {
-                if (!e.isOfficialTransitionTotalDurationIoob()) {
+                val trace = e.stackTraceToString()
+                if (!trace.contains("Transition.calculateTotalDurationNanos")) {
                     throw e
                 }
                 KLog.e(
                     "Kuikly.Compose",
-                    "sendFrame IndexOutOfBoundsException (official Compose Transition on shared Snapshot): ${e.stackTraceToString()}",
+                    "sendFrame IndexOutOfBoundsException (official Compose Transition on shared Snapshot): $trace",
                 )
                 if (frameSampled) {
                     tracker?.onFrameEnd(0)
@@ -272,19 +273,6 @@ internal abstract class BaseComposeScene(
         // notifyOverlayIfNeeded 可能写了 Compose State，需要再次检查是否需要调度新帧
         invalidateIfNeeded()
     }
-
-    /**
-     * Whether this IOOB is thrown while recomputing official Jetpack Compose
-     * [androidx.compose.animation.core.Transition.totalDurationNanos] (e.g. when Kuikly's
-     * sendFrame drains shared snapshot observers on HRContextQueueHandlerThread).
-     *
-     * Note: matches observed stack frames; may miss if obfuscation/merge strips names.
-     */
-    private fun IndexOutOfBoundsException.isOfficialTransitionTotalDurationIoob(): Boolean =
-        stackTrace.any {
-            it.className == "androidx.compose.animation.core.Transition" &&
-                it.methodName == "calculateTotalDurationNanos"
-        }
 
     @OptIn(ExperimentalComposeUiApi::class)
     override fun sendPointerEvent(

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/BaseComposeScene.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/BaseComposeScene.kt
@@ -209,17 +209,11 @@ internal abstract class BaseComposeScene(
 
             recomposer.performScheduledTasks()
 
-            // Transition.totalDurationNanos may throw IndexOutOfBoundsException while
-            // SnapshotStateObserver drains during sendFrame/applyChanges (list shrinks
-            // mid fastForEach). Swallow to keep the frame loop alive; next frame
-            // re-evaluates with a consistent snapshot.
-            try {
-                frameClock.sendFrame(nanoTime) // Recomposition
-            } catch (e: IndexOutOfBoundsException) {
-                KLog.e("Kuikly.Compose", "sendFrame failed: ${e.stackTraceToString()}")
-            }
+            frameClock.sendFrame(nanoTime) // Recomposition
             doLayout() // Layout
-            // Same class of Transition IOOB can also surface in composition effects.
+            // Swallow IndexOutOfBoundsException from any effect task (not only Transition)
+            // to keep the frame loop alive. FlushCoroutineDispatcher drops remaining tasks
+            // in the batch on throw; animation/recomposition effects reschedule next frame.
             try {
                 recomposer.performScheduledEffects() // Composition effects (e.g. LaunchedEffect)
             } catch (e: IndexOutOfBoundsException) {

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/BaseComposeScene.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/scene/BaseComposeScene.kt
@@ -213,12 +213,16 @@ internal abstract class BaseComposeScene(
             // synchronously drain official Jetpack Compose SnapshotStateObservers. If main-thread
             // official UI (e.g. androidx.compose.animation.Transition) is updated concurrently,
             // IndexOutOfBoundsException may surface here — not fixable in official Compose.
+            // Only swallow IOOB from that path; rethrow other IOOB so real bugs still crash.
             try {
                 frameClock.sendFrame(nanoTime) // Recomposition
             } catch (e: IndexOutOfBoundsException) {
+                if (!e.isOfficialTransitionTotalDurationIoob()) {
+                    throw e
+                }
                 KLog.e(
                     "Kuikly.Compose",
-                    "sendFrame IndexOutOfBoundsException (often official Compose on shared Snapshot): ${e.stackTraceToString()}",
+                    "sendFrame IndexOutOfBoundsException (official Compose Transition on shared Snapshot): ${e.stackTraceToString()}",
                 )
                 if (frameSampled) {
                     tracker?.onFrameEnd(0)
@@ -268,6 +272,19 @@ internal abstract class BaseComposeScene(
         // notifyOverlayIfNeeded 可能写了 Compose State，需要再次检查是否需要调度新帧
         invalidateIfNeeded()
     }
+
+    /**
+     * Whether this IOOB is thrown while recomputing official Jetpack Compose
+     * [androidx.compose.animation.core.Transition.totalDurationNanos] (e.g. when Kuikly's
+     * sendFrame drains shared snapshot observers on HRContextQueueHandlerThread).
+     *
+     * Note: matches observed stack frames; may miss if obfuscation/merge strips names.
+     */
+    private fun IndexOutOfBoundsException.isOfficialTransitionTotalDurationIoob(): Boolean =
+        stackTrace.any {
+            it.className == "androidx.compose.animation.core.Transition" &&
+                it.methodName == "calculateTotalDurationNanos"
+        }
 
     @OptIn(ExperimentalComposeUiApi::class)
     override fun sendPointerEvent(

--- a/docs/Compose/faq.md
+++ b/docs/Compose/faq.md
@@ -254,7 +254,7 @@ class MyComposePage : ComposeContainer() {
 
 `enableConsumeSnapshot` 仅关闭 Kuikly `GlobalSnapshotManager` 对全局 write observer 的主动消费，**不影响** Recomposer 自身的 snapshot apply 路径。
 
-**框架侧处理**（Kuikly 2.x+）：`BaseComposeScene.render` 在 `sendFrame` 捕获上述 `IndexOutOfBoundsException`，跳过本帧 layout/draw 并调度下一帧，避免整页崩溃。日志 tag 为 `Kuikly.Compose`。
+**框架侧处理**（Kuikly 2.x+）：`BaseComposeScene.render` 在 `sendFrame` 捕获 **仅当异常栈命中官方** `androidx.compose.animation.core.Transition.calculateTotalDurationNanos` 的 `IndexOutOfBoundsException`，跳过本帧 layout/draw 并调度下一帧，避免整页崩溃；其它 IOOB 仍会 crash，便于发现真实 bug。日志 tag 为 `Kuikly.Compose`。
 
 **业务侧建议**：
 

--- a/docs/Compose/faq.md
+++ b/docs/Compose/faq.md
@@ -241,3 +241,22 @@ class MyComposePage : ComposeContainer() {
     }
 }
 ```
+
+### 与 `enableConsumeSnapshot` 的区别
+
+`enableConsumeSnapshot = false` **不能**解决下列崩溃：
+
+- 栈特征：`IndexOutOfBoundsException: index: 1, size: 1`
+- 落在 `androidx.compose.animation.core.Transition.calculateTotalDurationNanos`
+- 经 `BaseComposeScene.render` → `sendFrame` → `Recomposer.apply` → `SnapshotStateObserver.drainChanges`
+
+**原因**：Kuikly Compose 在 Android 上运行在独立线程（`HRContextQueueHandlerThread`），而页面上的**原生 Jetpack Compose**（如主线程上的 `AnimatedVisibility`）与 Kuikly **共用** `androidx.compose.runtime` 的 Snapshot。Kuikly 在子线程 `sendFrame` 时 `MutableSnapshot.apply()` 会**同步回调**官方 Compose 注册的 observer，可能在 Kuikly 线程上重算官方 `Transition.totalDurationNanos`，与主线程上对同一 Transition 的增删动画形成竞态。
+
+`enableConsumeSnapshot` 仅关闭 Kuikly `GlobalSnapshotManager` 对全局 write observer 的主动消费，**不影响** Recomposer 自身的 snapshot apply 路径。
+
+**框架侧处理**（Kuikly 2.x+）：`BaseComposeScene.render` 在 `sendFrame` 捕获上述 `IndexOutOfBoundsException`，跳过本帧 layout/draw 并调度下一帧，避免整页崩溃。日志 tag 为 `Kuikly.Compose`。
+
+**业务侧建议**：
+
+- 共存场景务必设置 `enableConsumeSnapshot = false`（解决 ANR / 官方状态丢失，与本节 crash 互补）
+- 尽量减少主线程官方 Compose 动画与 Kuikly 页高频同帧更新的叠加；长期可关注 Kuikly「双 Compose 共存模式」演进


### PR DESCRIPTION
## Summary

- **现象**：`IndexOutOfBoundsException: index: 1, size: 1`，栈落在官方 `androidx.compose.animation.core.Transition.calculateTotalDurationNanos`，经 `BaseComposeScene.render` → `sendFrame` → `Recomposer.apply` → `SnapshotStateObserver.drainChanges`。
- **根因**：Kuikly Compose 在 Android 上运行于 `HRContextQueueHandlerThread`，与主线程上的**原生 Jetpack Compose** 共用 `androidx.compose.runtime` Snapshot。Kuikly 子线程 `sendFrame` 时 `MutableSnapshot.apply()` 会同步 drain 官方 Compose 的 observer，与主线程上对同一 `Transition` 的动画增删形成竞态。`enableConsumeSnapshot = false` 只关 Kuikly `GlobalSnapshotManager`，**管不到**这条 Recomposer apply 路径。
- **修复**（仅 `BaseComposeScene.kt`）：
  - 在 `sendFrame` 捕获 `IndexOutOfBoundsException`
  - 仅当 `stackTraceToString()` 含 `Transition.calculateTotalDurationNanos` 时吞掉（CMP 兼容的短栈匹配，用于识别官方 Transition 路径）
  - 其它 IOOB 仍 rethrow
  - 命中后 `KLog.e`、跳过本帧 layout/draw，下一帧重试
- **未改动**：`com.tencent.kuikly.compose.animation.core.Transition`（线上栈是 `androidx`，改 Kuikly 版无效）

## Test plan

- [ ] 双 Compose 共存 + `enableConsumeSnapshot = false` 场景下，官方 `AnimatedVisibility` 等快速进出不再因该 IOOB 整页崩溃
- [ ] 兜底触发时日志 tag `Kuikly.Compose`，栈含 `Transition.calculateTotalDurationNanos`
- [ ] 其它 IOOB（非该栈特征）仍正常 crash，便于发现真实 bug
- [ ] `./gradlew :compose:compileDebugKotlinAndroid` 通过