### PR TITLE
perf: lazy JSON bridge for Native→Kotlin callKotlin (OHOS + iOS)

### DIFF
--- a/core-ksp/src/main/kotlin/impl/IOSTargetEntryBuilder.kt
+++ b/core-ksp/src/main/kotlin/impl/IOSTargetEntryBuilder.kt
@@ -23,6 +23,8 @@ import com.squareup.kotlinpoet.*
 open class IOSTargetEntryBuilder(private val catchException: Boolean) : KuiklyCoreAbsEntryBuilder() {
 
     override fun build(builder: FileSpec.Builder, pagesAnnotations: List<PageInfo>) {
+        // NSDictionary → lazy JSONObject before BridgeManager (OHOS: KRRenderCValue.toAny).
+        builder.addImport("com.tencent.kuikly.core.utils", "toKotlinBridgeArg")
         builder.addType(
             TypeSpec.classBuilder(entryFileName())
                 .apply {
@@ -72,45 +74,56 @@ open class IOSTargetEntryBuilder(private val catchException: Boolean) : KuiklyCo
     fun createCallKtMethodFuncSpec(
         pagesAnnotations: List<PageInfo>,
     ): FunSpec {
+        // Init / NativeBridge register + dispatch — inlined (no per-call lambda).
+        val body = """
+        |if (!BridgeManager.isDidInit()) {
+        |    BridgeManager.init(${catchException})
+        |    $METHOD_NAME_TRIGGER_REGISTER_PAGES()
+        |}
+        |if (!hadRegisterNativeBridge) {
+        |    hadRegisterNativeBridge = true
+        |    val nativeBridge = NativeBridge()
+        |    nativeBridge.iosNativeBridgeDelegate = object : NativeBridge.IOSNativeBridgeDelegate {
+        |        override fun callNative(
+        |            methodId: Int,
+        |            arg0: Any?,
+        |            arg1: Any?,
+        |            arg2: Any?,
+        |            arg3: Any?,
+        |            arg4: Any?,
+        |            arg5: Any?
+        |            ): Any? {
+        |            return hrCoreDelegate?.callNative(methodId, arg0, arg1, arg2, arg3, arg4, arg5)
+        |        }
+        |    }
+        |    BridgeManager.registerNativeBridge(arg0 as String, nativeBridge)
+        |}
+        |BridgeManager.callKotlinMethod(
+        |    methodId,
+        |    arg0.toKotlinBridgeArg(),
+        |    arg1.toKotlinBridgeArg(),
+        |    arg2.toKotlinBridgeArg(),
+        |    arg3.toKotlinBridgeArg(),
+        |    arg4.toKotlinBridgeArg(),
+        |    arg5.toKotlinBridgeArg()
+        |)
+        """.trimMargin()
+
+        val statement = if (catchException) {
+            """
+            |try {
+            |$body
+            |} catch(t: Throwable) {
+            |    BridgeManager.callExceptionMethod(t.stackTraceToString())
+            |}
+            """.trimMargin()
+        } else {
+            body
+        }
+
         return FunSpec.builder(FUNC_NAME_CALL_KT_METHOD)
             .addParameters(createKtMethodParameters())
-            .addStatement("""
-    val callKotlinClosure =  {
-        if (!BridgeManager.isDidInit()) {
-            BridgeManager.init(${catchException})
-            $METHOD_NAME_TRIGGER_REGISTER_PAGES()
-        }
-        if (!hadRegisterNativeBridge) {
-            hadRegisterNativeBridge = true
-            val nativeBridge = NativeBridge()
-            nativeBridge.iosNativeBridgeDelegate = object : NativeBridge.IOSNativeBridgeDelegate {
-                override fun callNative(
-                    methodId: Int,
-                    arg0: Any?,
-                    arg1: Any?,
-                    arg2: Any?,
-                    arg3: Any?,
-                    arg4: Any?,
-                    arg5: Any?
-                    ): Any? {
-                    return hrCoreDelegate?.callNative(methodId, arg0, arg1, arg2, arg3, arg4, arg5)
-                }
-            }
-            BridgeManager.registerNativeBridge(arg0 as String, nativeBridge)
-        }
-        BridgeManager.callKotlinMethod(methodId, arg0, arg1, arg2, arg3, arg4, arg5)
-    }
-    
-    if (BridgeManager.catchException){
-       try {
-           callKotlinClosure()
-       } catch(t: Throwable) {
-           BridgeManager.callExceptionMethod(t.stackTraceToString())
-       }
-    } else {
-        callKotlinClosure()
-    }
-            """)
+            .addStatement(statement)
             .build()
     }
 

--- a/core-ksp/src/main/kotlin/impl/OhOsTargetEntryBuilder.kt
+++ b/core-ksp/src/main/kotlin/impl/OhOsTargetEntryBuilder.kt
@@ -54,6 +54,51 @@ class OhOsTargetEntryBuilder(private val catchException: Boolean) : KuiklyCoreAb
     private fun createInitKuiklyMethod(
         pagesAnnotations: List<PageInfo>,
     ): FunSpec {
+        val dispatchBody = """
+            |when (methodId) {
+            |    KotlinMethod.CREATE_INSTANCE -> {
+            |        val instanceId = arg0.asString()
+            |        val nativeBridge = NativeBridge()
+            |        nativeBridge.callNativeCallback = { mid, a0, a1, a2, a3, a4, a5 ->
+            |            callNative(mid, a0, a1, a2, a3, a4, a5)
+            |        }
+            |        BridgeManager.registerNativeBridge(instanceId, nativeBridge)
+            |        BridgeManager.callKotlinMethod(methodId, instanceId, arg1.toAny(), arg2.toAny(), null, null, null)
+            |    }
+            |    KotlinMethod.LAYOUT_VIEW -> {
+            |        BridgeManager.callKotlinMethod(methodId, arg0.toAny(), null, null, null, null, null)
+            |    }
+            |    KotlinMethod.FIRE_VIEW_EVENT -> {
+            |        BridgeManager.callKotlinMethod(methodId, arg0.toAny(), arg1.toAny(), arg2.toAny(), arg3.toAny(), null, null)
+            |    }
+            |    KotlinMethod.FIRE_CALLBACK, KotlinMethod.UPDATE_INSTANCE, KotlinMethod.DESTROY_INSTANCE -> {
+            |        BridgeManager.callKotlinMethod(methodId, arg0.toAny(), arg1.toAny(), arg2.toAny(), null, null, null)
+            |    }
+            |    else -> {
+            |        BridgeManager.callKotlinMethod(
+            |            methodId, arg0.toAny(), arg1.toAny(), arg2.toAny(), arg3.toAny(), arg4.toAny(), arg5.toAny()
+            |        )
+            |    }
+            |}
+        """.trimMargin()
+
+        val callBody = if (catchException) {
+            """
+                return com_tencent_kuikly_SetCallKotlin(staticCFunction { methodId, arg0, arg1, arg2, arg3, arg4, arg5 ->
+                    try {
+                        $dispatchBody
+                    } catch (t: Throwable) {
+                        ExceptionTracker.notifyKuiklyException(t)
+                    }
+                })
+            """.trimIndent()
+        } else {
+            """
+                return com_tencent_kuikly_SetCallKotlin(staticCFunction { methodId, arg0, arg1, arg2, arg3, arg4, arg5 ->
+                    $dispatchBody
+                })
+            """.trimIndent()
+        }
         return FunSpec.builder("initKuikly")
             .addAnnotations(createCFuncAnnotations())
             .returns(Int::class)
@@ -63,38 +108,7 @@ class OhOsTargetEntryBuilder(private val catchException: Boolean) : KuiklyCoreAb
             )
             .addRegisterPageRouteStatement(pagesAnnotations)
             .addStatement("}\n")
-            .addStatement("""
-                return com_tencent_kuikly_SetCallKotlin(staticCFunction { methodId, arg0, arg1, arg2, arg3, arg4, arg5 ->
-                            val callKotlinClosure = {
-                                if (methodId == KotlinMethod.CREATE_INSTANCE) {
-                                    val nativeBridge = NativeBridge()
-                                    nativeBridge.callNativeCallback = { methodId, arg0, arg1, arg2, arg3, arg4, arg5 ->
-                                        callNative(methodId, arg0, arg1, arg2, arg3, arg4, arg5)
-                                    }
-                                    BridgeManager.registerNativeBridge(arg0.asString(), nativeBridge)
-                                }
-                                BridgeManager.callKotlinMethod(
-                                     methodId,
-                                     arg0.toAny(),
-                                     arg1.toAny(),
-                                     arg2.toAny(),
-                                     arg3.toAny(),
-                                     arg4.toAny(),
-                                     arg5.toAny()
-                                )
-                            }
-                             
-                            if (BridgeManager.catchException){
-                                try {
-                                    callKotlinClosure()
-                                } catch(t: Throwable){
-                                    ExceptionTracker.notifyKuiklyException(t)
-                                }
-                            }else{
-                                callKotlinClosure()
-                            }
-                })
-            """.trimIndent())
+            .addStatement(callBody)
             .build()
     }
 

--- a/core-ksp/src/main/kotlin/impl/OhOsTargetMultiEntryBuilder.kt
+++ b/core-ksp/src/main/kotlin/impl/OhOsTargetMultiEntryBuilder.kt
@@ -58,6 +58,51 @@ class OhOsTargetMultiEntryBuilder(private val catchException: Boolean, private v
     private fun createInitKuiklyMethod(
         pagesAnnotations: List<PageInfo>,
     ): FunSpec {
+        val dispatchBody = """
+            |when (methodId) {
+            |    KotlinMethod.CREATE_INSTANCE -> {
+            |        val instanceId = arg0.asString()
+            |        val nativeBridge = NativeBridge()
+            |        nativeBridge.callNativeCallback = { mid, a0, a1, a2, a3, a4, a5 ->
+            |            callNative(mid, a0, a1, a2, a3, a4, a5)
+            |        }
+            |        BridgeManager.registerNativeBridge(instanceId, nativeBridge)
+            |        BridgeManager.callKotlinMethod(methodId, instanceId, arg1.toAny(), arg2.toAny(), null, null, null)
+            |    }
+            |    KotlinMethod.LAYOUT_VIEW -> {
+            |        BridgeManager.callKotlinMethod(methodId, arg0.toAny(), null, null, null, null, null)
+            |    }
+            |    KotlinMethod.FIRE_VIEW_EVENT -> {
+            |        BridgeManager.callKotlinMethod(methodId, arg0.toAny(), arg1.toAny(), arg2.toAny(), arg3.toAny(), null, null)
+            |    }
+            |    KotlinMethod.FIRE_CALLBACK, KotlinMethod.UPDATE_INSTANCE, KotlinMethod.DESTROY_INSTANCE -> {
+            |        BridgeManager.callKotlinMethod(methodId, arg0.toAny(), arg1.toAny(), arg2.toAny(), null, null, null)
+            |    }
+            |    else -> {
+            |        BridgeManager.callKotlinMethod(
+            |            methodId, arg0.toAny(), arg1.toAny(), arg2.toAny(), arg3.toAny(), arg4.toAny(), arg5.toAny()
+            |        )
+            |    }
+            |}
+        """.trimMargin()
+
+        val callBody = if (catchException) {
+            """
+                return com_tencent_kuikly_SetCallKotlin(staticCFunction { methodId, arg0, arg1, arg2, arg3, arg4, arg5 ->
+                    try {
+                        $dispatchBody
+                    } catch (t: Throwable) {
+                        ExceptionTracker.notifyKuiklyException(t)
+                    }
+                })
+            """.trimIndent()
+        } else {
+            """
+                return com_tencent_kuikly_SetCallKotlin(staticCFunction { methodId, arg0, arg1, arg2, arg3, arg4, arg5 ->
+                    $dispatchBody
+                })
+            """.trimIndent()
+        }
         return FunSpec.builder("initKuikly")
             .addAnnotations(createCFuncAnnotations())
             .returns(Int::class)
@@ -68,37 +113,7 @@ class OhOsTargetMultiEntryBuilder(private val catchException: Boolean, private v
             .addRegisterPageRouteStatement(pagesAnnotations)
             .addSubModuleStatement()
             .addStatement("}\n")
-            .addStatement("""
-                return com_tencent_kuikly_SetCallKotlin(staticCFunction { methodId, arg0, arg1, arg2, arg3, arg4, arg5 ->
-                            val callKotlinClosure = {
-                                if (methodId == KotlinMethod.CREATE_INSTANCE) {
-                                    val nativeBridge = NativeBridge()
-                                    nativeBridge.callNativeCallback = { methodId, arg0, arg1, arg2, arg3, arg4, arg5 ->
-                                        callNative(methodId, arg0, arg1, arg2, arg3, arg4, arg5)
-                                    }
-                                    BridgeManager.registerNativeBridge(arg0.asString(), nativeBridge)
-                                }
-                                BridgeManager.callKotlinMethod(
-                                     methodId,
-                                     arg0.toAny(),
-                                     arg1.toAny(),
-                                     arg2.toAny(),
-                                     arg3.toAny(),
-                                     arg4.toAny(),
-                                     arg5.toAny()
-                                )
-                            }
-                            if(BridgeManager.catchException){
-                                try {
-                                    callKotlinClosure()
-                                } catch(t: Throwable){
-                                    ExceptionTracker.notifyKuiklyException(t)
-                                }
-                            }else{
-                                callKotlinClosure()
-                            }
-                })
-            """.trimIndent())
+            .addStatement(callBody)
             .build()
     }
 

--- a/core-ksp/src/main/kotlin/impl/submodule/IOSMultiTargetEntryBuilder.kt
+++ b/core-ksp/src/main/kotlin/impl/submodule/IOSMultiTargetEntryBuilder.kt
@@ -32,6 +32,7 @@ class IOSMultiTargetEntryBuilder(private val catchException: Boolean, private va
                     .build()
             )
         } else {
+            builder.addImport("com.tencent.kuikly.core.utils", "toKotlinBridgeArg")
             builder.addType(
                 TypeSpec.classBuilder(entryFileName())
                         .addProperty(createDelegateProperty())

--- a/core-render-ios/Core/KuiklyRenderCore.m
+++ b/core-render-ios/Core/KuiklyRenderCore.m
@@ -559,6 +559,15 @@ NSString *const kCustomFirstScreenTag = @"customFirstScreenTag";
     return [[KuiklyRenderLayerHandler alloc] initWithRootView:rootView contextParam:_contextParam];
 }
 
+#if DEBUG
+- (void)perf_callWithMethod:(KuiklyRenderContextMethod)method args:(NSArray *)args {
+    [self.contextHandler callWithMethod:method args:args];
+}
+
+- (NSString *)perf_instanceId {
+    return self.instanceId ?: @"";
+}
+#endif
 
 #pragma mark - dealloc
 

--- a/core-render-ios/Extension/Category/KRConvertUtil.m
+++ b/core-render-ios/Extension/Category/KRConvertUtil.m
@@ -766,9 +766,9 @@ const NSString *lineargradientPrefix = @"linear-gradient(";
 }
 
 + (id)nativeObjectToKotlinObject:(id)ocObject {
-    if ([ocObject isKindOfClass:[NSDictionary class]] || [KRConvertUtil hr_isJsonArray:ocObject] ) {
-        return  [KRConvertUtil hr_dictionaryToJSON:ocObject];
-    }
+    // Pass NSDictionary / JSON NSArray through. Kotlin entry wraps NSDictionary
+    // via toKotlinBridgeArg → LazyNSDictionaryMap (OHOS: NATIVE_JSON → toAny).
+    // Scalars / NSString unchanged.
     return ocObject;
 }
 

--- a/core-render-ios/Handler/KuiklyRenderFrameworkContextHandler.m
+++ b/core-render-ios/Handler/KuiklyRenderFrameworkContextHandler.m
@@ -98,6 +98,8 @@
         (method == KuiklyRenderContextMethodFireCallback || method == KuiklyRenderContextMethodLayoutView)) {
         return ;
     }
+    // All methods: pass collections through (no NSJSONSerialization). Kotlin
+    // entry wraps NSDictionary as lazy JSONObject before BridgeManager.
     NSMutableArray * arguments = [[NSMutableArray alloc] initWithCapacity:6];
     for (id arg in args) {
         id ele = [KRConvertUtil nativeObjectToKotlinObject:arg];

--- a/core-render-ios/View/KuiklyRenderView.m
+++ b/core-render-ios/View/KuiklyRenderView.m
@@ -52,6 +52,13 @@ NSString *const KRDensity = @"density";
 
 @end
 
+#if DEBUG
+@interface KuiklyRenderCore (CallKotlinPerfPrivate)
+- (void)perf_callWithMethod:(KuiklyRenderContextMethod)method args:(NSArray *)args;
+- (NSString *)perf_instanceId;
+@end
+#endif
+
 @implementation KuiklyRenderView {
     CFTimeInterval _beginTime;
     NSMutableArray<dispatch_block_t> *_dellocTasks;
@@ -341,6 +348,16 @@ NSString *const KRDensity = @"density";
     }
     return nil;
 }
+
+#if DEBUG
+- (void)perf_callWithMethod:(KuiklyRenderContextMethod)method args:(NSArray *)args {
+    [self.renderCore perf_callWithMethod:method args:args];
+}
+
+- (NSString *)perf_instanceId {
+    return [self.renderCore perf_instanceId];
+}
+#endif
 
 #pragma mark - dealloc
 

--- a/core-render-ohos/build-profile.json5
+++ b/core-render-ohos/build-profile.json5
@@ -39,6 +39,9 @@
     },
     {
       "name": "debug",
+      "externalNativeOptions": {
+        "arguments": "-DCMAKE_BUILD_TYPE=Debug"
+      },
       "arkOptions": {
         "obfuscation": {
           "ruleOptions": {

--- a/core-render-ohos/src/main/cpp/CMakeLists.txt
+++ b/core-render-ohos/src/main/cpp/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SOURCE_SET
         libohos_render/expand/components/hover/KRHoverView.cpp
         libohos_render/expand/components/canvas/KRCanvasView.cpp
         libohos_render/export/IKRRenderViewExport.cpp
+        libohos_render/export/IKRRenderModuleExport.cpp
         libohos_render/expand/modules/codec/codec.c
         libohos_render/expand/modules/codec/md5.c
         libohos_render/expand/modules/codec/sha256.c
@@ -92,6 +93,7 @@ set(SOURCE_SET
         libohos_render/utils/KRURIHelper.cpp
         libohos_render/utils/KRBase64Util.cpp
         libohos_render/utils/KRJSONObject.cpp
+        libohos_render/foundation/type/KRLazyCJsonBridge.cpp
         libohos_render/utils/KRStringUtil.cpp
         libohos_render/utils/KRViewUtil.cpp
         libohos_render/utils/KRThreadChecker.cpp
@@ -116,6 +118,14 @@ set(SOURCE_SET
         libohos_render/expand/modules/preferences/KROhSharedPreferencesModule.cpp
         libohos_render/expand/modules/preferences/KROhPreferences.cpp
 )
+
+# Test-only CallKotlinPerfTestModule: compile only for Debug.
+# Release uses RelWithDebInfo (defines NDEBUG); .h/.cpp also #ifndef NDEBUG.
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    list(APPEND SOURCE_SET
+            libohos_render/expand/modules/performance/CallKotlinPerfTestModule.cpp
+    )
+endif()
 
 add_library(kuikly SHARED ${SOURCE_SET})
 target_compile_options(kuikly PRIVATE

--- a/core-render-ohos/src/main/cpp/libohos_render/core/KRRenderCore.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/core/KRRenderCore.cpp
@@ -106,7 +106,8 @@ void KRRenderCore::DidInit() {
     auto sync = context_->ExecuteMode()->IsContextSyncInit();
     KRContextScheduler::DirectRunOnMainThread(sync, [strongSelf = shared_from_this(), sync] {
         auto page_name = KRRenderValue::Make(strongSelf->context_->PageName());
-        auto page_data = KRRenderValue::Make(strongSelf->context_->PageData()->toString());
+        // Pass PageData as structured Map (NATIVE_JSON) — avoid toString() + Kotlin parse.
+        auto page_data = strongSelf->context_->PageData();
         auto null_arg = strongSelf->defaultNullValue_;
         strongSelf->notifyInitState(KRInitState::kStateInitContextStart);
         strongSelf->contextHandler_->InitContext();
@@ -128,16 +129,43 @@ void KRRenderCore::SendEvent(std::string event_name, const std::string &json_dat
     if (auto rv = renderView_.lock()) {
         needSync = rv->syncSendEvent(event_name);
     }
-    SendEvent(event_name, json_data, needSync);
+    SendEvent(std::move(event_name), json_data, needSync);
 }
 
 void KRRenderCore::SendEvent(std::string event_name, const std::string &json_data, bool need_sync) {
-    auto task = [self = shared_from_this(), need_sync, event_name, json_data] {
+    // Legacy string API: parse into Map once so CallKotlin gets NATIVE_JSON (lazy),
+    // matching FireViewEvent structured payloads.
+    KRAnyValue data;
+    if (json_data.empty()) {
+        data = KRRenderValue::Make(KRRenderValue::Map{});
+    } else {
+        auto as_str = KRRenderValue::Make(json_data);
+        data = KRRenderValue::Make(as_str->toMap());
+    }
+    SendEvent(std::move(event_name), data, need_sync);
+}
+
+void KRRenderCore::SendEvent(std::string event_name, const KRAnyValue &data) {
+    bool needSync = false;
+    if (auto rv = renderView_.lock()) {
+        needSync = rv->syncSendEvent(event_name);
+    }
+    SendEvent(std::move(event_name), data, needSync);
+}
+
+void KRRenderCore::SendEvent(std::string event_name, const KRAnyValue &data, bool need_sync) {
+    auto task = [self = shared_from_this(), need_sync, event_name, data] {
         auto event = KRRenderValue::Make(event_name);
-        auto data = KRRenderValue::Make(json_data);
+        auto payload = data;
+        if (!payload) {
+            payload = KRRenderValue::Make(KRRenderValue::Map{});
+        } else if (payload->isString()) {
+            // Defensive: if a string slipped through, promote to Map for lazy bridge.
+            payload = KRRenderValue::Make(payload->toMap());
+        }
         auto nullValue = self->defaultNullValue_;
-        self->CallKotlinMethod(KuiklyRenderContextMethod::KuiklyRenderContextMethodUpdateInstance, event, data, nullValue,
-                               nullValue, nullValue);
+        self->CallKotlinMethod(KuiklyRenderContextMethod::KuiklyRenderContextMethodUpdateInstance, event, payload,
+                               nullValue, nullValue, nullValue);
         if (need_sync) {
             self->uiScheduler_->PerformSyncMainQueueTasksBlockIfNeed(true);
         }

--- a/core-render-ohos/src/main/cpp/libohos_render/core/KRRenderCore.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/core/KRRenderCore.cpp
@@ -74,6 +74,8 @@ KRRenderCore::KRRenderCore(std::weak_ptr<IKRRenderView> renderView, std::shared_
     renderView_ = renderView;
     context_ = context;
     defaultNullValue_ = KRRenderValue::Make();
+    // instanceId 生命周期与 Core 一致：缓存 KRRenderValue，避免每次 CallKotlin 重新 Make/toCValue
+    instanceIdValue_ = KRRenderValue::Make(context_->InstanceId());
     uiScheduler_ = std::make_shared<KRUIScheduler>(this);
     contextHandler_ = IKRRenderNativeContextHandler::CreateContextHandler(context);
     // 注册kotlin call native回调（走onCallNative接口）
@@ -434,8 +436,7 @@ void KRRenderCore::WillPerformUITasksWithScheduler() {  // 运行在 context 线
 
 void KRRenderCore::CallKotlinMethod(const KuiklyRenderContextMethod &method, const KRAnyValue &arg1, const KRAnyValue &arg2,
                                     const KRAnyValue &arg3, const KRAnyValue &arg4, const KRAnyValue &arg5) {
-    auto arg0 = KRRenderValue::Make(context_->InstanceId());
-    contextHandler_->Call(method, arg0, arg1, arg2, arg3, arg4, arg5);
+    contextHandler_->Call(method, instanceIdValue_, arg1, arg2, arg3, arg4, arg5);
 }
 
 void KRRenderCore::notifyInitState(KRInitState state) {

--- a/core-render-ohos/src/main/cpp/libohos_render/core/KRRenderCore.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/core/KRRenderCore.h
@@ -141,6 +141,8 @@ class KRRenderCore : public std::enable_shared_from_this<KRRenderCore>,
     std::shared_ptr<IKRRenderLayer> renderLayerHandler_;
     /** 默认NUll值 */
     std::shared_ptr<KRRenderValue> defaultNullValue_;
+    /** 缓存的 instanceId KRRenderValue，避免每次 CallKotlinMethod 重新 Make+toCValue */
+    std::shared_ptr<KRRenderValue> instanceIdValue_;
     /** 正在从主线程同步任务到context线程 */
     bool syncingPerformTaskMainThreadToContextThread = false;
 

--- a/core-render-ohos/src/main/cpp/libohos_render/core/KRRenderCore.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/core/KRRenderCore.h
@@ -71,10 +71,13 @@ class KRRenderCore : public std::enable_shared_from_this<KRRenderCore>,
     /**
      * 发送页面事件到kotlin侧
      * @param event_name 事件名
-     * @param json_data json数据字符串）
+     * @param json_data json数据字符串（会解析为 Map 再走 lazy NATIVE_JSON）
      */
     void SendEvent(std::string event_name, const std::string &json_data);
     void SendEvent(std::string event_name, const std::string &json_data, bool need_sync);
+    /** Prefer structured data (Map) — toCValue → NATIVE_JSON without stringify. */
+    void SendEvent(std::string event_name, const KRAnyValue &data);
+    void SendEvent(std::string event_name, const KRAnyValue &data, bool need_sync);
 
     /**
      * 获取渲染节点视图（要求在主线程调用）

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/ModulesRegisterEntry.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/ModulesRegisterEntry.h
@@ -29,6 +29,10 @@
 #include "libohos_render/expand/modules/preferences/KROhSharedPreferencesModule.h"
 #include "libohos_render/expand/modules/file/KRFileModule.h"
 #include "libohos_render/export/IKRRenderModuleExport.h"
+// CallKotlinPerfTestModule: debug/test only — header is empty under NDEBUG.
+#ifndef NDEBUG
+#include "libohos_render/expand/modules/performance/CallKotlinPerfTestModule.h"
+#endif
 
 #endif  // CORE_RENDER_OHOS_MODULESREGISTERENTRY_H
 
@@ -74,4 +78,11 @@ static void ModulesRegisterEntry() {
     IKRRenderModuleExport::RegisterModuleCreator(kuikly::module::KRFileModule::MODULE_NAME, [] {
         return std::make_shared<kuikly::module::KRFileModule>();
     });
+
+#ifndef NDEBUG
+    // Demo/test-only callKotlin interop bench — omitted when NDEBUG (release).
+    IKRRenderModuleExport::RegisterModuleCreator(kuikly::module::CallKotlinPerfTestModule::MODULE_NAME, [] {
+        return std::make_shared<kuikly::module::CallKotlinPerfTestModule>();
+    });
+#endif  // !NDEBUG — CallKotlinPerfTestModule registration
 }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/performance/CallKotlinPerfTestModule.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/performance/CallKotlinPerfTestModule.cpp
@@ -234,27 +234,44 @@ std::string BenchBasic(const std::string &instance_id, int iterations) {
 std::string BenchPhases(const std::string &instance_id, int iterations, size_t json_bytes, const std::string &mode) {
     const auto null_value = KRRenderValue::MakeNull();
     const auto &null_c = null_value->toCValue();
-    const bool use_map = (mode == "map");
+    const bool use_map =
+        (mode == "map" || mode == "update_map" || mode == "callback_map");
+    const bool is_update = (mode == "update" || mode == "update_map");
+    const bool is_callback = (mode == "callback" || mode == "callback_map");
+    const bool is_fire = (mode == "fire" || mode == "map" || mode == "both");
     auto payload_str = MakeJsonPayload(json_bytes);
 
     auto arg0 = KRRenderValue::Make(instance_id);
-    auto arg1 = KRRenderValue::Make(1);
-    auto arg2 = KRRenderValue::Make("click");
-    // mode=fire/both: legacy JSON string; mode=map: structured Map bridge
+    auto arg1_tag = KRRenderValue::Make(1);
+    auto arg2_event = KRRenderValue::Make(is_update ? "perf_update" : "click");
+    auto arg1_cb = KRRenderValue::Make(std::string("0"));
     auto arg3 = use_map ? MakeMapPayload(json_bytes) : KRRenderValue::Make(payload_str);
     const auto &c0 = arg0->toCValue();
-    const auto &c1 = arg1->toCValue();
-    const auto &c2 = arg2->toCValue();
+    const auto &c1_tag = arg1_tag->toCValue();
+    const auto &c2_event = arg2_event->toCValue();
+    const auto &c1_cb = arg1_cb->toCValue();
     const auto &c3 = arg3->toCValue();
+
+    auto call_payload_once = [&]() {
+        if (is_update) {
+            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodUpdateInstance), c0,
+                           c2_event, c3, null_c, null_c, null_c);
+        } else if (is_callback) {
+            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodFireCallback), c0,
+                           c1_cb, c3, null_c, null_c, null_c);
+        } else {
+            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodFireViewEvent), c0,
+                           c1_tag, c2_event, c3, null_c, null_c);
+        }
+    };
 
     for (int i = 0; i < 10; i++) {
         if (mode == "layout" || mode == "both") {
             CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodLayoutView), c0, null_c,
                            null_c, null_c, null_c, null_c);
         }
-        if (mode == "fire" || mode == "both" || mode == "map") {
-            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodFireViewEvent), c0, c1,
-                           c2, c3, null_c, null_c);
+        if (is_fire || is_update || is_callback) {
+            call_payload_once();
         }
     }
 
@@ -279,18 +296,26 @@ std::string BenchPhases(const std::string &instance_id, int iterations, size_t j
         }
     }
 
-    if (mode == "fire" || mode == "both" || mode == "map") {
+    if (is_fire || is_update || is_callback) {
         for (int i = 0; i < iterations; i++) {
             int64_t t0 = NowNs();
             const auto &a0 = arg0->toCValue();
-            const auto &a1 = arg1->toCValue();
-            const auto &a2 = arg2->toCValue();
-            const auto &a3 = arg3->toCValue();
+            const auto &a1 = is_callback ? arg1_cb->toCValue() : (is_update ? arg2_event->toCValue() : arg1_tag->toCValue());
+            const auto &a2 = is_callback ? arg3->toCValue() : (is_update ? arg3->toCValue() : arg2_event->toCValue());
+            const auto &a3 = is_fire ? arg3->toCValue() : null_c;
             const auto &a4 = null_value->toCValue();
             const auto &a5 = null_value->toCValue();
             int64_t t1 = NowNs();
-            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodFireViewEvent), a0, a1,
-                           a2, a3, a4, a5);
+            if (is_update) {
+                CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodUpdateInstance), a0,
+                               a1, a2, null_c, null_c, null_c);
+            } else if (is_callback) {
+                CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodFireCallback), a0, a1,
+                               a2, null_c, null_c, null_c);
+            } else {
+                CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodFireViewEvent), a0,
+                               a1, a2, a3, a4, a5);
+            }
             int64_t t2 = NowNs();
             tocvalue_ns += t1 - t0;
             call_ns += t2 - t1;
@@ -306,10 +331,18 @@ std::string BenchPhases(const std::string &instance_id, int iterations, size_t j
         cold_tocvalue_ns = NowNs() - t0;
     }
 
-    // For mode=both, totals cover 2*iterations calls
     int calls = iterations;
     if (mode == "both") {
         calls = iterations * 2;
+    }
+
+    const char *method_name = "LayoutView";
+    if (is_update) {
+        method_name = "UpdateInstance";
+    } else if (is_callback) {
+        method_name = "FireCallback";
+    } else if (is_fire) {
+        method_name = "FireViewEvent";
     }
 
     std::ostringstream oss;
@@ -317,6 +350,7 @@ std::string BenchPhases(const std::string &instance_id, int iterations, size_t j
     oss.precision(2);
     oss << "{"
         << "\"mode\":\"" << mode << "\","
+        << "\"method\":\"" << method_name << "\","
         << "\"iterations\":" << iterations << ","
         << "\"calls\":" << calls << ","
         << "\"json_bytes\":" << payload_str.size() << ","
@@ -494,7 +528,8 @@ KRAnyValue CallKotlinPerfTestModule::CallMethod(bool sync, const std::string &me
                 }
             }
         }
-        if (mode != "layout" && mode != "fire" && mode != "both" && mode != "map") {
+        if (mode != "layout" && mode != "fire" && mode != "both" && mode != "map" && mode != "update" &&
+            mode != "update_map" && mode != "callback" && mode != "callback_map") {
             mode = "fire";
         }
         json = BenchPhases(instance_id, iterations, static_cast<size_t>(std::max(0, json_bytes)), mode);

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/performance/CallKotlinPerfTestModule.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/performance/CallKotlinPerfTestModule.cpp
@@ -1,0 +1,515 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "libohos_render/expand/modules/performance/CallKotlinPerfTestModule.h"
+
+// Test-only implementation: empty TU when NDEBUG is set (Release / RelWithDebInfo).
+#ifndef NDEBUG
+
+#include <chrono>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "libohos_render/context/IKRRenderNativeContextHandler.h"
+#include "libohos_render/foundation/KRCommon.h"
+#include "libohos_render/foundation/type/KRRenderCValue.h"
+#include "libohos_render/foundation/type/KRLazyCJsonBridge.h"
+#include "libohos_render/utils/KRRenderLoger.h"
+
+extern CallKotlin callKotlin_;
+
+namespace kuikly {
+namespace module {
+
+const char CallKotlinPerfTestModule::MODULE_NAME[] = "CallKotlinPerfTestModule";
+
+namespace {
+
+constexpr char kMethodBench[] = "bench";
+constexpr char kMethodBenchPhases[] = "benchPhases";
+constexpr char kMethodBenchJson[] = "benchJson";
+constexpr char kMethodExportNestedOwner[] = "exportNestedOwner";
+constexpr int kDefaultIterations = 3000;
+constexpr int kWarmup = 100;
+
+int64_t NowNs() {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+double Per(int64_t total, int n) {
+    return n > 0 ? static_cast<double>(total) / static_cast<double>(n) : 0.0;
+}
+
+int ParseIntField(const std::string &s, const char *key, int fallback) {
+    auto pos = s.find(key);
+    if (pos == std::string::npos) {
+        return fallback;
+    }
+    auto colon = s.find(':', pos);
+    if (colon == std::string::npos) {
+        return fallback;
+    }
+    try {
+        return std::stoi(s.substr(colon + 1));
+    } catch (...) {
+        return fallback;
+    }
+}
+
+int ParseIterations(const KRAnyValue &params, int fallback = kDefaultIterations) {
+    if (!params) {
+        return fallback;
+    }
+    auto s = params->toString();
+    if (s.empty()) {
+        return fallback;
+    }
+    return std::max(1, ParseIntField(s, "iterations", fallback));
+}
+
+void CallKotlinOnce(int methodId, const KRRenderCValue &a0, const KRRenderCValue &a1, const KRRenderCValue &a2,
+                    const KRRenderCValue &a3, const KRRenderCValue &a4, const KRRenderCValue &a5) {
+    callKotlin_(methodId, a0, a1, a2, a3, a4, a5);
+}
+
+std::string MakeJsonPayload(size_t target_bytes) {
+    // Produce a valid JSON object whose serialized size is ~target_bytes.
+    // {"d":"<pad>"} overhead is 8 chars + pad.
+    if (target_bytes <= 8) {
+        return "{}";
+    }
+    size_t pad = target_bytes - 8;
+    std::string out;
+    out.reserve(target_bytes + 16);
+    out.append("{\"d\":\"");
+    out.append(pad, 'x');
+    out.append("\"}");
+    return out;
+}
+
+/** Same logical payload as MakeJsonPayload, but as a structured Map (lazy cJSON). */
+KRAnyValue MakeMapPayload(size_t target_bytes) {
+    KRRenderValue::Map m;
+    if (target_bytes <= 8) {
+        return KRRenderValue::Make(m);
+    }
+    size_t pad = target_bytes - 8;
+    m["d"] = KRRenderValue::Make(std::string(pad, 'y'));
+    return KRRenderValue::Make(m);
+}
+
+/** Nested map for optJSONObject lifecycle tests. */
+KRAnyValue MakeNestedMapPayload() {
+    KRRenderValue::Map grand;
+    grand["y"] = KRRenderValue::Make(42);
+    KRRenderValue::Map child;
+    child["x"] = KRRenderValue::Make(std::string("hello"));
+    child["grand"] = KRRenderValue::Make(grand);
+    KRRenderValue::Map root;
+    root["a"] = KRRenderValue::Make(1);
+    root["child"] = KRRenderValue::Make(child);
+    root["blob"] = KRRenderValue::Make(std::string(4096, 'z'));
+    return KRRenderValue::Make(root);
+}
+
+/**
+ * Build nested Map → NATIVE_JSON, retain a handle for Kotlin, then drop the
+ * KRRenderValue (create handle). Returned owner is a transferred shared_ptr copy.
+ */
+std::string ExportNestedOwner() {
+    auto map = MakeNestedMapPayload();
+    const auto &cv = map->toCValue();
+    if (cv.type != KRRenderCValue::Type::NATIVE_JSON || cv.value.longValue == 0) {
+        return "{\"error\":\"expected NATIVE_JSON\"}";
+    }
+    int64_t transferred = kuikly_cjson_retain(cv.value.longValue);
+    if (transferred == 0) {
+        return "{\"error\":\"retain failed\"}";
+    }
+    // map goes out of scope → releases create handle; [transferred] keeps tree alive.
+    std::ostringstream oss;
+    oss << "{\"owner\":" << transferred << "}";
+    return oss.str();
+}
+
+std::string BenchBasic(const std::string &instance_id, int iterations) {
+    const auto null_value = KRRenderValue::MakeNull();
+    const auto &null_c = null_value->toCValue();
+
+    {
+        auto warmup_id = KRRenderValue::Make(instance_id);
+        for (int i = 0; i < kWarmup; i++) {
+            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodLayoutView),
+                           warmup_id->toCValue(), null_c, null_c, null_c, null_c, null_c);
+        }
+    }
+
+    int64_t make_ns = 0, tocvalue_ns = 0, layout_full_ns = 0, layout_cached_ns = 0, fire_ns = 0;
+
+    {
+        int64_t t0 = NowNs();
+        for (int i = 0; i < iterations; i++) {
+            volatile auto v = KRRenderValue::Make(instance_id);
+            (void)v;
+        }
+        make_ns = NowNs() - t0;
+    }
+    {
+        auto arg0 = KRRenderValue::Make(instance_id);
+        (void)arg0->toCValue();
+        (void)null_value->toCValue();
+        int64_t t0 = NowNs();
+        for (int i = 0; i < iterations; i++) {
+            volatile auto c0 = arg0->toCValue();
+            volatile auto c1 = null_value->toCValue();
+            (void)c0;
+            (void)c1;
+        }
+        tocvalue_ns = NowNs() - t0;
+    }
+    {
+        int64_t t0 = NowNs();
+        for (int i = 0; i < iterations; i++) {
+            auto arg0 = KRRenderValue::Make(instance_id);
+            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodLayoutView),
+                           arg0->toCValue(), null_c, null_c, null_c, null_c, null_c);
+        }
+        layout_full_ns = NowNs() - t0;
+    }
+    {
+        auto arg0 = KRRenderValue::Make(instance_id);
+        const auto &c0 = arg0->toCValue();
+        int64_t t0 = NowNs();
+        for (int i = 0; i < iterations; i++) {
+            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodLayoutView), c0, null_c,
+                           null_c, null_c, null_c, null_c);
+        }
+        layout_cached_ns = NowNs() - t0;
+    }
+    {
+        auto arg0 = KRRenderValue::Make(instance_id);
+        auto arg1 = KRRenderValue::Make(1);
+        auto arg2 = KRRenderValue::Make("click");
+        auto arg3 = KRRenderValue::Make("{\"x\":1,\"y\":2}");
+        const auto &c0 = arg0->toCValue();
+        const auto &c1 = arg1->toCValue();
+        const auto &c2 = arg2->toCValue();
+        const auto &c3 = arg3->toCValue();
+        int64_t t0 = NowNs();
+        for (int i = 0; i < iterations; i++) {
+            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodFireViewEvent), c0, c1,
+                           c2, c3, null_c, null_c);
+        }
+        fire_ns = NowNs() - t0;
+    }
+
+    std::ostringstream oss;
+    oss.setf(std::ios::fixed);
+    oss.precision(2);
+    oss << "{"
+        << "\"iterations\":" << iterations << ","
+        << "\"makeInstanceId_ns_per\":" << Per(make_ns, iterations) << ","
+        << "\"toCValue_ns_per\":" << Per(tocvalue_ns, iterations) << ","
+        << "\"layout_full_ns_per\":" << Per(layout_full_ns, iterations) << ","
+        << "\"layout_cachedArg0_ns_per\":" << Per(layout_cached_ns, iterations) << ","
+        << "\"fireEvent_ns_per\":" << Per(fire_ns, iterations)
+        << "}";
+    return oss.str();
+}
+
+std::string BenchPhases(const std::string &instance_id, int iterations, size_t json_bytes, const std::string &mode) {
+    const auto null_value = KRRenderValue::MakeNull();
+    const auto &null_c = null_value->toCValue();
+    const bool use_map = (mode == "map");
+    auto payload_str = MakeJsonPayload(json_bytes);
+
+    auto arg0 = KRRenderValue::Make(instance_id);
+    auto arg1 = KRRenderValue::Make(1);
+    auto arg2 = KRRenderValue::Make("click");
+    // mode=fire/both: legacy JSON string; mode=map: structured Map bridge
+    auto arg3 = use_map ? MakeMapPayload(json_bytes) : KRRenderValue::Make(payload_str);
+    const auto &c0 = arg0->toCValue();
+    const auto &c1 = arg1->toCValue();
+    const auto &c2 = arg2->toCValue();
+    const auto &c3 = arg3->toCValue();
+
+    for (int i = 0; i < 10; i++) {
+        if (mode == "layout" || mode == "both") {
+            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodLayoutView), c0, null_c,
+                           null_c, null_c, null_c, null_c);
+        }
+        if (mode == "fire" || mode == "both" || mode == "map") {
+            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodFireViewEvent), c0, c1,
+                           c2, c3, null_c, null_c);
+        }
+    }
+
+    int64_t tocvalue_ns = 0, call_ns = 0;
+    int64_t cold_make_ns = 0, cold_tocvalue_ns = 0;
+
+    if (mode == "layout" || mode == "both") {
+        for (int i = 0; i < iterations; i++) {
+            int64_t t0 = NowNs();
+            const auto &a0 = arg0->toCValue();
+            const auto &a1 = null_value->toCValue();
+            const auto &a2 = null_value->toCValue();
+            const auto &a3 = null_value->toCValue();
+            const auto &a4 = null_value->toCValue();
+            const auto &a5 = null_value->toCValue();
+            int64_t t1 = NowNs();
+            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodLayoutView), a0, a1, a2,
+                           a3, a4, a5);
+            int64_t t2 = NowNs();
+            tocvalue_ns += t1 - t0;
+            call_ns += t2 - t1;
+        }
+    }
+
+    if (mode == "fire" || mode == "both" || mode == "map") {
+        for (int i = 0; i < iterations; i++) {
+            int64_t t0 = NowNs();
+            const auto &a0 = arg0->toCValue();
+            const auto &a1 = arg1->toCValue();
+            const auto &a2 = arg2->toCValue();
+            const auto &a3 = arg3->toCValue();
+            const auto &a4 = null_value->toCValue();
+            const auto &a5 = null_value->toCValue();
+            int64_t t1 = NowNs();
+            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodFireViewEvent), a0, a1,
+                           a2, a3, a4, a5);
+            int64_t t2 = NowNs();
+            tocvalue_ns += t1 - t0;
+            call_ns += t2 - t1;
+        }
+    }
+
+    {
+        int64_t t0 = NowNs();
+        auto fresh = use_map ? MakeMapPayload(json_bytes) : KRRenderValue::Make(payload_str);
+        cold_make_ns = NowNs() - t0;
+        t0 = NowNs();
+        (void)fresh->toCValue();
+        cold_tocvalue_ns = NowNs() - t0;
+    }
+
+    // For mode=both, totals cover 2*iterations calls
+    int calls = iterations;
+    if (mode == "both") {
+        calls = iterations * 2;
+    }
+
+    std::ostringstream oss;
+    oss.setf(std::ios::fixed);
+    oss.precision(2);
+    oss << "{"
+        << "\"mode\":\"" << mode << "\","
+        << "\"iterations\":" << iterations << ","
+        << "\"calls\":" << calls << ","
+        << "\"json_bytes\":" << payload_str.size() << ","
+        << "\"payload\":\"" << (use_map ? "lazy_cjson" : "string") << "\","
+        << "\"cpp_toCValue_ns_per\":" << Per(tocvalue_ns, calls) << ","
+        << "\"cpp_callKotlin_ns_per\":" << Per(call_ns, calls) << ","
+        << "\"cpp_total_ns_per\":" << Per(tocvalue_ns + call_ns, calls) << ","
+        << "\"cold_make_json_ns\":" << cold_make_ns << ","
+        << "\"cold_toCValue_json_ns\":" << cold_tocvalue_ns
+        << "}";
+    return oss.str();
+}
+
+/**
+ * Size sweep: legacy JSON string vs structured Map bridge for FIRE_VIEW_EVENT.
+ */
+std::string BenchJson(const std::string &instance_id, int iterations_per_size) {
+    // Includes large sizes requested for Map-bridge vs string comparison:
+    // 128KB, 256KB, 496KB, 3MB
+    static const size_t kSizes[] = {0, 64, 256, 1024, 4096, 16384, 65536, 131072, 262144, 507904, 3145728};
+    const auto null_value = KRRenderValue::MakeNull();
+    const auto &null_c = null_value->toCValue();
+    auto arg0 = KRRenderValue::Make(instance_id);
+    auto arg1 = KRRenderValue::Make(1);
+    auto arg2 = KRRenderValue::Make("click");
+    const auto &c0 = arg0->toCValue();
+    const auto &c1 = arg1->toCValue();
+    const auto &c2 = arg2->toCValue();
+
+    std::ostringstream oss;
+    oss.setf(std::ios::fixed);
+    oss.precision(2);
+    oss << "{\"iterations_per_size\":" << iterations_per_size << ",\"sizes\":[";
+
+    bool first = true;
+    for (size_t target : kSizes) {
+        auto payload = MakeJsonPayload(target);
+        const size_t actual = payload.size();
+
+        // Cold: new KRRenderValue + first toCValue (string copy into cache)
+        int64_t cold_make = 0, cold_toc = 0;
+        {
+            int64_t t0 = NowNs();
+            auto v = KRRenderValue::Make(payload);
+            cold_make = NowNs() - t0;
+            t0 = NowNs();
+            (void)v->toCValue();
+            cold_toc = NowNs() - t0;
+        }
+
+        // Hot toCValue only
+        auto hot = KRRenderValue::Make(payload);
+        (void)hot->toCValue();
+        int64_t hot_toc = 0;
+        {
+            int64_t t0 = NowNs();
+            for (int i = 0; i < iterations_per_size; i++) {
+                volatile auto c = hot->toCValue();
+                (void)c;
+            }
+            hot_toc = NowNs() - t0;
+        }
+
+        // Full FIRE_VIEW_EVENT with JSON string (legacy: toKString + JSONObject parse)
+        const auto &c3 = hot->toCValue();
+        for (int i = 0; i < std::min(20, kWarmup); i++) {
+            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodFireViewEvent), c0, c1,
+                           c2, c3, null_c, null_c);
+        }
+        // Scale down iterations for huge payloads to keep wall time sane
+        int iters = iterations_per_size;
+        if (actual >= 3145728) {  // 3MB
+            iters = std::max(5, iterations_per_size / 80);
+        } else if (actual >= 507904) {  // ~496KB
+            iters = std::max(10, iterations_per_size / 40);
+        } else if (actual >= 131072) {  // 128KB
+            iters = std::max(20, iterations_per_size / 20);
+        } else if (actual >= 65536) {
+            iters = std::max(50, iterations_per_size / 10);
+        } else if (actual >= 16384) {
+            iters = std::max(100, iterations_per_size / 3);
+        }
+
+        int64_t call_ns = 0, toc_ns = 0;
+        for (int i = 0; i < iters; i++) {
+            int64_t t0 = NowNs();
+            const auto &a0 = arg0->toCValue();
+            const auto &a1 = arg1->toCValue();
+            const auto &a2 = arg2->toCValue();
+            const auto &a3 = hot->toCValue();
+            int64_t t1 = NowNs();
+            CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodFireViewEvent), a0, a1,
+                           a2, a3, null_c, null_c);
+            int64_t t2 = NowNs();
+            toc_ns += t1 - t0;
+            call_ns += t2 - t1;
+        }
+
+        // Map bridge path: lazy NATIVE_JSON (cJSON*), Kotlin CJsonJSONObject.fromOwner
+        int64_t map_cold_toc = 0, map_call_ns = 0, map_toc_ns = 0;
+        {
+            auto map_v = MakeMapPayload(target);
+            int64_t t0 = NowNs();
+            (void)map_v->toCValue();  // ToNativeJsonLocked → NATIVE_JSON
+            map_cold_toc = NowNs() - t0;
+            const auto &mc3 = map_v->toCValue();
+            for (int i = 0; i < std::min(20, kWarmup); i++) {
+                CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodFireViewEvent), c0,
+                               c1, c2, mc3, null_c, null_c);
+            }
+            for (int i = 0; i < iters; i++) {
+                t0 = NowNs();
+                const auto &a0 = arg0->toCValue();
+                const auto &a1 = arg1->toCValue();
+                const auto &a2 = arg2->toCValue();
+                const auto &a3 = map_v->toCValue();
+                int64_t t1 = NowNs();
+                CallKotlinOnce(static_cast<int>(KuiklyRenderContextMethod::KuiklyRenderContextMethodFireViewEvent), a0,
+                               a1, a2, a3, null_c, null_c);
+                int64_t t2 = NowNs();
+                map_toc_ns += t1 - t0;
+                map_call_ns += t2 - t1;
+            }
+        }
+
+        if (!first) {
+            oss << ',';
+        }
+        first = false;
+        oss << "{"
+            << "\"target_bytes\":" << target << ","
+            << "\"actual_bytes\":" << actual << ","
+            << "\"cold_make_ns\":" << cold_make << ","
+            << "\"cold_toCValue_ns\":" << cold_toc << ","
+            << "\"hot_toCValue_ns_per\":" << Per(hot_toc, iterations_per_size) << ","
+            << "\"fire_cpp_toCValue_ns_per\":" << Per(toc_ns, iters) << ","
+            << "\"fire_cpp_callKotlin_ns_per\":" << Per(call_ns, iters) << ","
+            << "\"fire_total_ns_per\":" << Per(toc_ns + call_ns, iters) << ","
+            << "\"map_cold_toCValue_ns\":" << map_cold_toc << ","
+            << "\"map_fire_cpp_toCValue_ns_per\":" << Per(map_toc_ns, iters) << ","
+            << "\"map_fire_cpp_callKotlin_ns_per\":" << Per(map_call_ns, iters) << ","
+            << "\"map_fire_total_ns_per\":" << Per(map_toc_ns + map_call_ns, iters) << ","
+            << "\"fire_iters\":" << iters
+            << "}";
+    }
+    oss << "]}";
+    return oss.str();
+}
+
+}  // namespace
+
+KRAnyValue CallKotlinPerfTestModule::CallMethod(bool sync, const std::string &method, KRAnyValue params,
+                                              const KRRenderCallback &callback) {
+    if (callKotlin_ == nullptr) {
+        KR_LOG_ERROR << "[CallKotlinPerf] callKotlin_ is null";
+        return KRRenderValue::Make("{\"error\":\"callKotlin_ null\"}");
+    }
+    const auto &instance_id = GetInstanceId();
+    std::string json;
+    if (method == kMethodBench) {
+        json = BenchBasic(instance_id, ParseIterations(params, 5000));
+    } else if (method == kMethodBenchPhases) {
+        int iterations = ParseIterations(params, 2000);
+        int json_bytes = 1024;
+        std::string mode = "fire";
+        if (params) {
+            auto s = params->toString();
+            json_bytes = ParseIntField(s, "jsonBytes", 1024);
+            auto mpos = s.find("mode");
+            if (mpos != std::string::npos) {
+                auto q1 = s.find('"', s.find(':', mpos));
+                auto q2 = s.find('"', q1 + 1);
+                if (q1 != std::string::npos && q2 != std::string::npos && q2 > q1) {
+                    mode = s.substr(q1 + 1, q2 - q1 - 1);
+                }
+            }
+        }
+        if (mode != "layout" && mode != "fire" && mode != "both" && mode != "map") {
+            mode = "fire";
+        }
+        json = BenchPhases(instance_id, iterations, static_cast<size_t>(std::max(0, json_bytes)), mode);
+    } else if (method == kMethodBenchJson) {
+        json = BenchJson(instance_id, ParseIterations(params, 500));
+    } else if (method == kMethodExportNestedOwner) {
+        json = ExportNestedOwner();
+    } else {
+        return KREmptyValue();
+    }
+    KR_LOG_INFO << "[CallKotlinPerf] " << method << " " << json;
+    return KRRenderValue::Make(json);
+}
+
+}  // namespace module
+}  // namespace kuikly
+
+#endif  // !NDEBUG — CallKotlinPerfTestModule (debug/test only)

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/performance/CallKotlinPerfTestModule.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/performance/CallKotlinPerfTestModule.h
@@ -1,0 +1,45 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_CALLKOTLINPERFTESTMODULE_H
+#define CORE_RENDER_OHOS_CALLKOTLINPERFTESTMODULE_H
+
+// Test-only: stripped from Release / RelWithDebInfo (those define NDEBUG).
+// Paired with CMakeLists Debug-only compile of the .cpp and ModulesRegisterEntry.
+#ifndef NDEBUG
+
+#include "libohos_render/export/IKRRenderModuleExport.h"
+
+namespace kuikly {
+namespace module {
+
+/**
+ * Demo/test-only micro-benchmark Native → Kotlin callKotlin interop.
+ * Debug builds only (CMake + NDEBUG guards).
+ */
+class CallKotlinPerfTestModule : public IKRRenderModuleExport {
+ public:
+    CallKotlinPerfTestModule() = default;
+    KRAnyValue CallMethod(bool sync, const std::string &method, KRAnyValue params,
+                          const KRRenderCallback &callback) override;
+    static const char MODULE_NAME[];
+};
+
+}  // namespace module
+}  // namespace kuikly
+
+#endif  // !NDEBUG — CallKotlinPerfTestModule (debug/test only)
+
+#endif  // CORE_RENDER_OHOS_CALLKOTLINPERFTESTMODULE_H

--- a/core-render-ohos/src/main/cpp/libohos_render/export/IKRRenderModuleExport.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/export/IKRRenderModuleExport.cpp
@@ -1,0 +1,44 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "libohos_render/export/IKRRenderModuleExport.h"
+
+// Registry lives in libkuikly.so (not the header) so app-side .so modules
+// that call RegisterModuleCreator share the same map as CreateModule.
+std::unordered_map<std::string, KRModuleCreator> &IKRRenderModuleExport::GetRegisterModuleCreator() {
+    static std::unordered_map<std::string, KRModuleCreator> gRegisterModuleCreator;
+    return gRegisterModuleCreator;
+}
+
+void IKRRenderModuleExport::RegisterModuleCreator(const std::string &module_name, const KRModuleCreator &creator) {
+    GetRegisterModuleCreator()[module_name] = creator;
+}
+
+void IKRRenderModuleExport::RegisterForwardArkTSModuleCreator(const KRModuleCreator &creator) {
+    RegisterModuleCreator(std::string(FOAWARD_ARTKS_MODULE_NAME), creator);
+}
+
+std::shared_ptr<IKRRenderModuleExport> IKRRenderModuleExport::CreateModule(const std::string &module_name) {
+    auto it = GetRegisterModuleCreator().find(module_name);
+    if (it != GetRegisterModuleCreator().end()) {
+        return it->second();
+    }
+    // Fall back to generic ArkTS forward module.
+    it = GetRegisterModuleCreator().find(std::string(FOAWARD_ARTKS_MODULE_NAME));
+    if (it != GetRegisterModuleCreator().end()) {
+        return it->second();
+    }
+    return nullptr;
+}

--- a/core-render-ohos/src/main/cpp/libohos_render/export/IKRRenderModuleExport.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/export/IKRRenderModuleExport.h
@@ -139,40 +139,22 @@ class IKRRenderModuleExport : public std::enable_shared_from_this<IKRRenderModul
      * 注册Module创建器
      * @param creator
      */
-    static void RegisterModuleCreator(const std::string &module_name, const KRModuleCreator &creator) {
-        GetRegisterModuleCreator()[module_name] = creator;
-    }
+    static void RegisterModuleCreator(const std::string &module_name, const KRModuleCreator &creator);
 
     /**
      * 注册通用转发ArkTS层Module创建器
      * @param creator
      */
-    static void RegisterForwardArkTSModuleCreator(const KRModuleCreator &creator) {
-        RegisterModuleCreator(std::string(FOAWARD_ARTKS_MODULE_NAME), creator);
-    }
+    static void RegisterForwardArkTSModuleCreator(const KRModuleCreator &creator);
 
     /**
      * 指定ModuleName生成Module
      * @param module_name
      * @return 新的Module实例
      */
-    static std::shared_ptr<IKRRenderModuleExport> CreateModule(const std::string &module_name) {
-        auto it = GetRegisterModuleCreator().find(module_name);
-        if (it != GetRegisterModuleCreator().end()) {
-            return it->second();
-        } else {  // 使用通用Module，转发到ArkTS层Module
-            it = GetRegisterModuleCreator().find(std::string(FOAWARD_ARTKS_MODULE_NAME));
-            if (it != GetRegisterModuleCreator().end()) {
-                return it->second();
-            }
-        }
-        return nullptr;
-    }
+    static std::shared_ptr<IKRRenderModuleExport> CreateModule(const std::string &module_name);
 
-    static std::unordered_map<std::string, KRModuleCreator> &GetRegisterModuleCreator() {
-        static std::unordered_map<std::string, KRModuleCreator> gRegisterModuleCreator;
-        return gRegisterModuleCreator;
-    }
+    static std::unordered_map<std::string, KRModuleCreator> &GetRegisterModuleCreator();
 
     static KRModuleCreator &GetOrSetForwardArkTModuleCreator(KRModuleCreator module_creator) {
         static KRModuleCreator gForwardArkTSModuleCreator;

--- a/core-render-ohos/src/main/cpp/libohos_render/foundation/type/KRLazyCJsonBridge.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/foundation/type/KRLazyCJsonBridge.cpp
@@ -1,0 +1,206 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "libohos_render/foundation/type/KRLazyCJsonBridge.h"
+
+#include <cstdint>
+#include <memory>
+
+#include "thirdparty/cJSON/cJSON.h"
+
+namespace {
+
+struct KuiklyCJsonOwner {
+    cJSON *json{nullptr};
+
+    explicit KuiklyCJsonOwner(cJSON *tree) : json(tree) {}
+
+    ~KuiklyCJsonOwner() {
+        if (json != nullptr) {
+            cJSON_Delete(json);
+            json = nullptr;
+        }
+    }
+
+    KuiklyCJsonOwner(const KuiklyCJsonOwner &) = delete;
+    KuiklyCJsonOwner &operator=(const KuiklyCJsonOwner &) = delete;
+};
+
+using OwnerPtr = std::shared_ptr<KuiklyCJsonOwner>;
+
+OwnerPtr *AsHandle(int64_t ptr) {
+    return reinterpret_cast<OwnerPtr *>(static_cast<intptr_t>(ptr));
+}
+
+int64_t ToHandle(OwnerPtr sp) {
+    if (!sp) {
+        return 0;
+    }
+    return static_cast<int64_t>(reinterpret_cast<intptr_t>(new OwnerPtr(std::move(sp))));
+}
+
+cJSON *Node(int64_t ptr) {
+    return reinterpret_cast<cJSON *>(static_cast<intptr_t>(ptr));
+}
+
+cJSON *Item(int64_t ptr, const char *key) {
+    if (ptr == 0 || key == nullptr) {
+        return nullptr;
+    }
+    return cJSON_GetObjectItemCaseSensitive(Node(ptr), key);
+}
+
+}  // namespace
+
+extern "C" {
+
+int64_t kuikly_cjson_owner_create(void *cjson) {
+    if (cjson == nullptr) {
+        return 0;
+    }
+    return ToHandle(std::make_shared<KuiklyCJsonOwner>(reinterpret_cast<cJSON *>(cjson)));
+}
+
+int64_t kuikly_cjson_retain(int64_t owner_ptr) {
+    auto *handle = AsHandle(owner_ptr);
+    if (handle == nullptr || !(*handle)) {
+        return 0;
+    }
+    // New heap shared_ptr sharing the same control block.
+    return ToHandle(*handle);
+}
+
+void kuikly_cjson_release(int64_t owner_ptr) {
+    auto *handle = AsHandle(owner_ptr);
+    if (handle == nullptr) {
+        return;
+    }
+    delete handle;
+}
+
+int64_t kuikly_cjson_owner_root(int64_t owner_ptr) {
+    auto *handle = AsHandle(owner_ptr);
+    if (handle == nullptr || !(*handle) || (*handle)->json == nullptr) {
+        return 0;
+    }
+    return static_cast<int64_t>(reinterpret_cast<intptr_t>((*handle)->json));
+}
+
+int kuikly_cjson_has(int64_t ptr, const char *key) {
+    return Item(ptr, key) != nullptr ? 1 : 0;
+}
+
+int kuikly_cjson_size(int64_t ptr) {
+    if (ptr == 0) {
+        return 0;
+    }
+    int n = 0;
+    for (cJSON *c = Node(ptr)->child; c != nullptr; c = c->next) {
+        n++;
+    }
+    return n;
+}
+
+const char *kuikly_cjson_key_at(int64_t ptr, int index) {
+    if (ptr == 0 || index < 0) {
+        return nullptr;
+    }
+    int i = 0;
+    for (cJSON *c = Node(ptr)->child; c != nullptr; c = c->next) {
+        if (i == index) {
+            return c->string;
+        }
+        i++;
+    }
+    return nullptr;
+}
+
+int kuikly_cjson_value_kind(int64_t ptr, const char *key) {
+    cJSON *item = Item(ptr, key);
+    if (item == nullptr || cJSON_IsNull(item)) {
+        return 0;
+    }
+    if (cJSON_IsBool(item)) {
+        return 1;
+    }
+    if (cJSON_IsNumber(item)) {
+        return 2;
+    }
+    if (cJSON_IsString(item)) {
+        return 3;
+    }
+    if (cJSON_IsObject(item)) {
+        return 4;
+    }
+    if (cJSON_IsArray(item)) {
+        return 5;
+    }
+    return 0;
+}
+
+int kuikly_cjson_get_bool(int64_t ptr, const char *key, int fallback) {
+    cJSON *item = Item(ptr, key);
+    if (item == nullptr || !cJSON_IsBool(item)) {
+        return fallback;
+    }
+    return cJSON_IsTrue(item) ? 1 : 0;
+}
+
+double kuikly_cjson_get_number(int64_t ptr, const char *key, double fallback) {
+    cJSON *item = Item(ptr, key);
+    if (item == nullptr || !cJSON_IsNumber(item)) {
+        return fallback;
+    }
+    return cJSON_GetNumberValue(item);
+}
+
+const char *kuikly_cjson_get_string(int64_t ptr, const char *key) {
+    cJSON *item = Item(ptr, key);
+    if (item == nullptr || !cJSON_IsString(item)) {
+        return nullptr;
+    }
+    return cJSON_GetStringValue(item);
+}
+
+int64_t kuikly_cjson_get_object(int64_t ptr, const char *key) {
+    cJSON *item = Item(ptr, key);
+    if (item == nullptr || !cJSON_IsObject(item)) {
+        return 0;
+    }
+    return static_cast<int64_t>(reinterpret_cast<intptr_t>(item));
+}
+
+int64_t kuikly_cjson_get_array(int64_t ptr, const char *key) {
+    cJSON *item = Item(ptr, key);
+    if (item == nullptr || !cJSON_IsArray(item)) {
+        return 0;
+    }
+    return static_cast<int64_t>(reinterpret_cast<intptr_t>(item));
+}
+
+char *kuikly_cjson_print(int64_t ptr) {
+    if (ptr == 0) {
+        return nullptr;
+    }
+    return cJSON_PrintUnformatted(Node(ptr));
+}
+
+void kuikly_cjson_free_string(char *s) {
+    if (s != nullptr) {
+        cJSON_free(s);
+    }
+}
+
+}  // extern "C"

--- a/core-render-ohos/src/main/cpp/libohos_render/foundation/type/KRLazyCJsonBridge.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/foundation/type/KRLazyCJsonBridge.h
@@ -1,0 +1,60 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_KRLAZYCJSONBRIDGE_H
+#define CORE_RENDER_OHOS_KRLAZYCJSONBRIDGE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Shared ownership of a cJSON tree between C++ KRRenderValue and Kotlin.
+ *
+ * Internally each opaque handle is a heap-allocated std::shared_ptr<KuiklyCJsonOwner>.
+ * - create → one shared_ptr handle (held by KRRenderValue)
+ * - retain → returns a new handle sharing the same owner (Kotlin / child wrappers)
+ * - release → destroys that handle's shared_ptr; tree deleted when last handle is gone
+ *
+ * NATIVE_JSON longValue is a create/retain handle.
+ */
+
+int64_t kuikly_cjson_owner_create(void *cjson /* cJSON* */);
+/** Returns a new handle that shares ownership with [owner]. 0 if invalid. */
+int64_t kuikly_cjson_retain(int64_t owner);
+void kuikly_cjson_release(int64_t owner);
+/** Root cJSON* as int64 (0 if owner invalid). */
+int64_t kuikly_cjson_owner_root(int64_t owner);
+
+/** Field accessors: ptr is a cJSON* node (root or child). */
+int kuikly_cjson_has(int64_t ptr, const char *key);
+int kuikly_cjson_size(int64_t ptr);
+const char *kuikly_cjson_key_at(int64_t ptr, int index);
+int kuikly_cjson_value_kind(int64_t ptr, const char *key);
+int kuikly_cjson_get_bool(int64_t ptr, const char *key, int fallback);
+double kuikly_cjson_get_number(int64_t ptr, const char *key, double fallback);
+const char *kuikly_cjson_get_string(int64_t ptr, const char *key);
+int64_t kuikly_cjson_get_object(int64_t ptr, const char *key);
+int64_t kuikly_cjson_get_array(int64_t ptr, const char *key);
+char *kuikly_cjson_print(int64_t ptr);
+void kuikly_cjson_free_string(char *s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // CORE_RENDER_OHOS_KRLAZYCJSONBRIDGE_H

--- a/core-render-ohos/src/main/cpp/libohos_render/foundation/type/KRRenderCValue.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/foundation/type/KRRenderCValue.h
@@ -25,7 +25,8 @@
  */
 typedef struct KRRenderCValue {
     // 定义一个枚举类型来表示值的类型
-    enum Type { NULL_VALUE, INT, LONG, FLOAT, DOUBLE, BOOL, STRING, BYTES, ARRAY } type;
+    // NATIVE_JSON: longValue holds cJSON* (owned by KRRenderValue for call lifetime)
+    enum Type { NULL_VALUE, INT, LONG, FLOAT, DOUBLE, BOOL, STRING, BYTES, ARRAY, NATIVE_JSON } type;
 
     // 定义一个联合体来存储不同类型的值
     union Value {

--- a/core-render-ohos/src/main/cpp/libohos_render/foundation/type/KRRenderValue.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/foundation/type/KRRenderValue.h
@@ -37,6 +37,7 @@
 #include "libohos_render/utils/KRRenderLoger.h"
 #include "libohos_render/utils/NAPIUtil.h"
 #include "thirdparty/cJSON/cJSON.h"
+#include "libohos_render/foundation/type/KRLazyCJsonBridge.h"
 
 // Test cases : 1.0, 100000.0, 9999999900.0, 0.01, 0.020, 0.01234560, 12345670.0123456
 static std::string DoubleToString(double value) {
@@ -575,23 +576,26 @@ class KRRenderValue : public std::enable_shared_from_this<KRRenderValue> {
                 c_value_.size = byte_array->size();
                 c_value_.value.bytesValue = reinterpret_cast<char *>(byte_array->data());
             } else if (isMap()) {
-                ToJsonMapOrArrayLocked();
+                // Lazy bridge: pass cJSON* so Kotlin JSONObject can delegate field access
+                // without eagerly copying every key/value (esp. large strings).
+                ToNativeJsonLocked();
             } else if (isArray()) {
+                // Arrays: keep structural ARRAY for binary-friendly path; JSON-only arrays
+                // can also use native json when no byte elements.
                 auto array = toArray();
-                if (HadByteArrayElement(array)) {  // 有二进制元素的话, 不进行 json 序列化，直接传递数组
+                if (HadByteArrayElement(array)) {
                     c_value_.type = KRRenderCValue::Type::ARRAY;
-                    c_value_.size = array.size();
+                    c_value_.size = static_cast<int32_t>(array.size());
                     if (array_ptr_ != nullptr) {
                         delete[] array_ptr_;
                     }
-                    array_ptr_ = new KRRenderCValue[c_value_.size];
-                    for (size_t i = 0; i < c_value_.size; i++) {
-                        const auto &item = array[i];
-                        array_ptr_[i] = item->toCValue();
+                    array_ptr_ = new KRRenderCValue[c_value_.size > 0 ? c_value_.size : 1];
+                    for (size_t i = 0; i < array.size(); i++) {
+                        array_ptr_[i] = array[i]->toCValue();
                     }
                     c_value_.value.arrayValue = array_ptr_;
                 } else {
-                    ToJsonMapOrArrayLocked();
+                    ToNativeJsonLocked();
                 }
             } else {
                 c_value_.type = KRRenderCValue::Type::NULL_VALUE;
@@ -708,6 +712,10 @@ class KRRenderValue : public std::enable_shared_from_this<KRRenderValue> {
             delete[] array_ptr_;
             array_ptr_ = nullptr;
         }
+        if (owned_cjson_owner_ != 0) {
+            kuikly_cjson_release(owned_cjson_owner_);
+            owned_cjson_owner_ = 0;
+        }
     }
 
  private:
@@ -716,20 +724,23 @@ class KRRenderValue : public std::enable_shared_from_this<KRRenderValue> {
         value_;
     
     mutable std::once_flag c_value_once_flag_;
-    mutable std::string map_or_array_json_value_;  // 缓存经过序列化的 map或者 array, 用于缓存经过序列化的std::string
     mutable std::string cached_string_for_c_value_;
     mutable KRRenderCValue c_value_;
     mutable KRRenderCValue *array_ptr_ = nullptr;  // 指向数组的指针, 用于防止数组元素copy
+    /** shared_ptr handle (int64) for NATIVE_JSON; shared with Kotlin via retain/release. */
+    mutable int64_t owned_cjson_owner_ = 0;
 
-    // 用于 toCValue() 内部调用，调用时已持有锁
-    void ToJsonMapOrArrayLocked() const {
-        cJSON* cjson = toJson(this);
-        char* p = cJSON_PrintUnformatted(cjson);
-        map_or_array_json_value_ = p;
-        c_value_.type = KRRenderCValue::Type::STRING;
-        c_value_.value.stringValue = const_cast<char *>(map_or_array_json_value_.c_str());
-        cJSON_free(p);
-        cJSON_Delete(cjson);
+    /**
+     * Pass Map/Array as shared_ptr-backed owner (NATIVE_JSON). Kotlin retain()s a
+     * new handle on wrap so the tree can outlive this KRRenderValue (async-safe).
+     */
+    void ToNativeJsonLocked() const {
+        if (owned_cjson_owner_ == 0) {
+            owned_cjson_owner_ = kuikly_cjson_owner_create(toJson(this));
+        }
+        c_value_.type = KRRenderCValue::Type::NATIVE_JSON;
+        c_value_.size = 0;
+        c_value_.value.longValue = owned_cjson_owner_;
     }
 
     JSVM_Status ToJsonMapOrArray(JSVM_Env js_env, JSVM_Value *js_value) const {

--- a/core-render-ohos/src/main/cpp/libohos_render/view/IKRRenderView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/view/IKRRenderView.h
@@ -20,6 +20,7 @@
 #include <rawfile/raw_file_manager.h>
 #include <memory>
 #include "libohos_render/context/KRRenderContextParams.h"
+#include "libohos_render/foundation/KRCommon.h"
 #include "libohos_render/foundation/KRPoint.h"
 #include "libohos_render/performance/KRPerformanceManager.h"
 #include "libohos_render/scheduler/IKRScheduler.h"
@@ -44,6 +45,8 @@ class IKRRenderView : public std::enable_shared_from_this<IKRRenderView> {
      */
     virtual void SendEvent(std::string event_name, const std::string &json_data) = 0;
     virtual void SendEvent(std::string event_name, const std::string &json_data, bool sync) = 0;
+    virtual void SendEvent(std::string event_name, const KRAnyValue &data) = 0;
+    virtual void SendEvent(std::string event_name, const KRAnyValue &data, bool sync) = 0;
     
     /**
      * 是否需要同步发送事件（默认异步）

--- a/core-render-ohos/src/main/cpp/libohos_render/view/KRRenderView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/view/KRRenderView.cpp
@@ -144,6 +144,22 @@ void KRRenderView::SendEvent(std::string event_name, const std::string &json_dat
     }
 }
 
+void KRRenderView::SendEvent(std::string event_name, const KRAnyValue &data) {
+    bool need_sync = syncSendEvent(event_name);
+    SendEvent(std::move(event_name), data, need_sync);
+}
+
+void KRRenderView::SendEvent(std::string event_name, const KRAnyValue &data, bool sync) {
+    if (core_) {
+        if (event_name == "viewDidAppear") {
+            DispatchInitState(KRInitState::kStateResume);
+        } else if (event_name == "viewDidDisappear") {
+            DispatchInitState(KRInitState::kStatePause);
+        }
+        return core_->SendEvent(event_name, data, sync);
+    }
+}
+
 bool KRRenderView::syncSendEvent(const std::string &event_name) {
     // 与 ETS 侧常量保持一致：'onBackPressed'
     if (event_name == "onBackPressed") {

--- a/core-render-ohos/src/main/cpp/libohos_render/view/KRRenderView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/view/KRRenderView.h
@@ -41,6 +41,8 @@ class KRRenderView : public IKRRenderView {
      */
     void SendEvent(std::string event_name, const std::string &json_data) override;
     void SendEvent(std::string event_name, const std::string &json_data, bool sync) override;
+    void SendEvent(std::string event_name, const KRAnyValue &data) override;
+    void SendEvent(std::string event_name, const KRAnyValue &data, bool sync) override;
     
     /**
      * 是否需要同步发送事件

--- a/core-render-ohos/src/main/cpp/napi_init.cpp
+++ b/core-render-ohos/src/main/cpp/napi_init.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include "libohos_render/expand/modules/back_press/KRBackPressModule.h"
 #include "libohos_render/foundation/KRCallbackData.h"
+#include "libohos_render/foundation/KRCommon.h"
 #include "libohos_render/foundation/thread/KRMainThread.h"
 #include "libohos_render/manager/KRArkTSManager.h"
 #include "libohos_render/manager/KRRenderManager.h"
@@ -151,7 +152,8 @@ static napi_value ArkTSOnSendEvent(napi_env env, napi_callback_info info) {
 
     std::string instance_id = kuikly::util::getNApiArgsStdString(env, args[0]);
     auto event = kuikly::util::getNApiArgsStdString(env, args[1]);
-    auto data = kuikly::util::getNApiArgsStdString(env, args[2]);
+    // Prefer structured napi value (Record/Array) → Map → NATIVE_JSON; strings still work.
+    auto data = KRRenderValue::Make(env, args[2]);
     auto renderView = KRRenderManager::GetInstance().GetRenderView(instance_id);
     if (renderView != nullptr) {
         renderView->SendEvent(event, data);
@@ -172,7 +174,7 @@ static napi_value ArkTSOnSendEventSync(napi_env env, napi_callback_info info) {
 
     std::string instance_id = kuikly::util::getNApiArgsStdString(env, args[0]);
     auto event = kuikly::util::getNApiArgsStdString(env, args[1]);
-    auto data = kuikly::util::getNApiArgsStdString(env, args[2]);
+    auto data = KRRenderValue::Make(env, args[2]);
     bool sync = kuikly::util::getNApiArgsBool(env, args[3]);
     auto renderView = KRRenderManager::GetInstance().GetRenderView(instance_id);
     if (renderView != nullptr) {

--- a/core-render-ohos/src/main/ets/KRNativeRenderController.ets
+++ b/core-render-ohos/src/main/ets/KRNativeRenderController.ets
@@ -306,7 +306,7 @@ export class KRNativeRenderController {
     const data: KRRecord = {};
     data[KRWidthKey] = width;
     data[KRHeightKey] = height;
-    render.sendEvent(this.instanceId, KRWindowSizeDidChangedEventKey, JSON.stringify(data));
+    render.sendEvent(this.instanceId, KRWindowSizeDidChangedEventKey, data);
   }
 
   paramsReady(): boolean {
@@ -346,7 +346,7 @@ export class KRNativeRenderController {
     render.updateConfig(this.instanceId, JSON.stringify(data));
 
     // notify core to mark text elements dirty
-    render.sendEvent(this.instanceId, KRConfigurationUpdateEventKey, JSON.stringify(data));
+    render.sendEvent(this.instanceId, KRConfigurationUpdateEventKey, data);
   }
 
   onSafeAreaInsetsChanged(rect: KRRect) {
@@ -577,9 +577,9 @@ export class KRNativeRenderController {
     this.runKRRenderTask(() => {
       const shouldSync = sync ?? this.syncSendEvent(event);
       if (shouldSync) {
-        render.sendEventSync(this.instanceId, event, KRConvertUtil.anyToCObject(data), true);
+        render.sendEventSync(this.instanceId, event, data, true);
       } else {
-        render.sendEvent(this.instanceId, event, KRConvertUtil.anyToCObject(data));
+        render.sendEvent(this.instanceId, event, data);
       }
     });
   }

--- a/core-render-ohos/src/main/ets/utils/KRConvertUtil.ets
+++ b/core-render-ohos/src/main/ets/utils/KRConvertUtil.ets
@@ -30,15 +30,14 @@ export class KRConvertUtil {
       return null
     }
     if (Array.isArray(value)) {
-      if (KRConvertUtil.hasByteArrayElement(value as KRArray)) {
-        return value as KRArray
-      } else {
-        return JSON.stringify(value);
-      }
+      // Keep ArrayBuffer-bearing arrays as-is; pass other arrays through as
+      // structured values (C++ → NATIVE_JSON) instead of JSON.stringify.
+      return value as KRArray
     } else if (value instanceof ArrayBuffer) {
       return value;
     } else if (typeof value === 'object') {
-      return JSON.stringify(value);
+      // Pass Record through — Native builds Map → lazy NATIVE_JSON for Update/Create.
+      return value as KRValue;
     } else {
       return value as KRValue;
     }

--- a/core/src/appleMain/kotlin/com/tencent/kuikly/core/nvi/serialization/json/LazyNSDictionaryMap.kt
+++ b/core/src/appleMain/kotlin/com/tencent/kuikly/core/nvi/serialization/json/LazyNSDictionaryMap.kt
@@ -1,0 +1,283 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.core.nvi.serialization.json
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSArray
+import platform.Foundation.NSDictionary
+import platform.Foundation.NSJSONSerialization
+import platform.Foundation.NSNull
+import platform.Foundation.NSNumber
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.dataUsingEncoding
+
+/**
+ * Apple-only lazy map backed by [NSDictionary].
+ * Passed into the existing internal [JSONObject] map constructor — no commonMain
+ * [JSONObject] API changes and no subclassing.
+ *
+ * Nested dictionaries become [JSONObject]s wrapping a new [LazyNSDictionaryMap].
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal class LazyNSDictionaryMap private constructor(
+    private var dict: NSDictionary?,
+) : AbstractMutableMap<String, Any?>() {
+
+    private var materialized: MutableMap<String, Any?>? = null
+
+    companion object {
+        fun from(dictionary: NSDictionary): LazyNSDictionaryMap {
+            return LazyNSDictionaryMap(dictionary)
+        }
+
+        fun wrapAsJSONObject(dictionary: NSDictionary): JSONObject {
+            return JSONObject(from(dictionary))
+        }
+    }
+
+    override val size: Int
+        get() {
+            materialized?.let { return it.size }
+            return dict?.count?.toInt() ?: 0
+        }
+
+    override fun containsKey(key: String): Boolean {
+        materialized?.let { return it.containsKey(key) }
+        val d = dict ?: return false
+        return d.objectForKey(key) != null
+    }
+
+    override fun containsValue(value: Any?): Boolean {
+        materialized?.let { return it.containsValue(value) }
+        return entries.any { it.value == value }
+    }
+
+    override fun get(key: String): Any? {
+        materialized?.let { return it[key] }
+        val d = dict ?: return null
+        return convertOcValue(d.objectForKey(key))
+    }
+
+    override fun put(key: String, value: Any?): Any? {
+        return ensureMaterialized().put(key, value)
+    }
+
+    override fun remove(key: String): Any? {
+        return ensureMaterialized().remove(key)
+    }
+
+    override fun clear() {
+        ensureMaterialized().clear()
+    }
+
+    override val entries: MutableSet<MutableMap.MutableEntry<String, Any?>>
+        get() {
+            materialized?.let { return it.entries }
+            return LazyEntries()
+        }
+
+    private fun forEachKey(d: NSDictionary, block: (Any) -> Unit) {
+        val enumerator = d.keyEnumerator()
+        while (true) {
+            val keyObj = enumerator.nextObject() ?: break
+            block(keyObj)
+        }
+    }
+
+    private fun ensureMaterialized(): MutableMap<String, Any?> {
+        materialized?.let { return it }
+        val map: MutableMap<String, Any?> = JSONEngine.getMutableMap()
+        val d = dict
+        if (d != null) {
+            forEachKey(d) { keyObj ->
+                val key = keyObj as? String ?: keyObj.toString()
+                map[key] = convertOcValue(d.objectForKey(keyObj))
+            }
+        }
+        dict = null
+        materialized = map
+        return map
+    }
+
+    private fun convertOcValue(value: Any?): Any? {
+        if (value == null || value is NSNull) {
+            return null
+        }
+        return when (value) {
+            is JSONObject, is JSONArray -> value
+            is NSDictionary -> wrapAsJSONObject(value)
+            is NSArray -> arrayToJSONArray(value)
+            is NSString -> value.toString()
+            is String -> value
+            is NSNumber -> numberToKotlin(value)
+            is Boolean -> value
+            is Number -> value
+            is Map<*, *> -> {
+                val mutable: MutableMap<String, Any?> = JSONEngine.getMutableMap()
+                for ((k, v) in value) {
+                    val key = k as? String ?: continue
+                    mutable[key] = convertOcValue(v as Any?)
+                }
+                JSONObject(mutable)
+            }
+            else -> value.toString()
+        }
+    }
+
+    private fun numberToKotlin(num: NSNumber): Any {
+        val dbl = num.doubleValue
+        val asLong = dbl.toLong()
+        if (dbl == asLong.toDouble()) {
+            if (asLong >= Int.MIN_VALUE && asLong <= Int.MAX_VALUE) {
+                return asLong.toInt()
+            }
+            return asLong
+        }
+        return dbl
+    }
+
+    private fun arrayToJSONArray(array: NSArray): JSONArray {
+        val list: MutableList<Any?> = JSONEngine.getMutableList()
+        val n = array.count.toInt()
+        for (i in 0 until n) {
+            list.add(convertOcValue(array.objectAtIndex(i.toULong())))
+        }
+        return JSONArray(list)
+    }
+
+    private inner class LazyEntries : AbstractMutableSet<MutableMap.MutableEntry<String, Any?>>() {
+        override val size: Int
+            get() = this@LazyNSDictionaryMap.size
+
+        override fun add(element: MutableMap.MutableEntry<String, Any?>): Boolean {
+            ensureMaterialized()[element.key] = element.value
+            return true
+        }
+
+        override fun clear() {
+            this@LazyNSDictionaryMap.clear()
+        }
+
+        override fun iterator(): MutableIterator<MutableMap.MutableEntry<String, Any?>> {
+            materialized?.let { return it.entries.iterator() }
+            val d = dict
+            if (d == null) {
+                return mutableListOf<MutableMap.MutableEntry<String, Any?>>().iterator()
+            }
+            val keyList = ArrayList<String>(d.count.toInt())
+            forEachKey(d) { keyObj ->
+                keyList.add(keyObj as? String ?: keyObj.toString())
+            }
+            val keyIter = keyList.iterator()
+            return object : MutableIterator<MutableMap.MutableEntry<String, Any?>> {
+                private var lastKey: String? = null
+
+                override fun hasNext(): Boolean = keyIter.hasNext()
+
+                override fun next(): MutableMap.MutableEntry<String, Any?> {
+                    val key = keyIter.next()
+                    lastKey = key
+                    return object : MutableMap.MutableEntry<String, Any?> {
+                        override val key: String = key
+                        override val value: Any?
+                            get() = get(key)
+
+                        override fun setValue(newValue: Any?): Any? {
+                            val old = get(key)
+                            put(key, newValue)
+                            return old
+                        }
+                    }
+                }
+
+                override fun remove() {
+                    val key = lastKey ?: throw IllegalStateException()
+                    this@LazyNSDictionaryMap.remove(key)
+                    lastKey = null
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Nested-object lifecycle checks for the lazy NSDictionary bridge (demo/test).
+ */
+@OptIn(ExperimentalForeignApi::class)
+fun testAppleNestedNSDictionaryLifecycle(): String {
+    return try {
+        val blob = "z".repeat(4096)
+        val json = """{"a":1,"child":{"x":"hello","grand":{"y":42}},"blob":"$blob"}"""
+        val data = (json as NSString).dataUsingEncoding(NSUTF8StringEncoding)
+            ?: return """{"ok":false,"error":"encode failed"}"""
+        val parsed = NSJSONSerialization.JSONObjectWithData(data, 0u, null)
+            ?: return """{"ok":false,"error":"parse failed"}"""
+        val rootDict = parsed as? NSDictionary
+            ?: return """{"ok":false,"error":"not dict"}"""
+        val root = LazyNSDictionaryMap.wrapAsJSONObject(rootDict)
+
+        val a = root.optInt("a")
+        if (a != 1) {
+            return """{"ok":false,"error":"a=$a"}"""
+        }
+
+        val childObj = root.optJSONObject("child")
+            ?: return """{"ok":false,"error":"missing child"}"""
+        if (childObj.nameValuePairs !is LazyNSDictionaryMap) {
+            return """{"ok":false,"error":"child not lazy nsdict map"}"""
+        }
+        val x = childObj.optString("x")
+        if (x != "hello") {
+            return """{"ok":false,"error":"x=$x"}"""
+        }
+
+        val grandObj = childObj.optJSONObject("grand")
+            ?: return """{"ok":false,"error":"missing grand"}"""
+        val y = grandObj.optInt("y")
+        if (y != 42) {
+            return """{"ok":false,"error":"y=$y"}"""
+        }
+
+        val blobStr = root.optString("blob")
+        if (blobStr.length != 4096) {
+            return """{"ok":false,"error":"blobLen=${blobStr.length}"}"""
+        }
+
+        root.put("_touch", 1)
+        if (root.optInt("_touch") != 1) {
+            return """{"ok":false,"error":"touch after materialize"}"""
+        }
+        val xAfter = childObj.optString("x")
+        if (xAfter != "hello") {
+            return """{"ok":false,"error":"child UAF after parent materialize x=$xAfter"}"""
+        }
+        val yAfter = grandObj.optInt("y")
+        if (yAfter != 42) {
+            return """{"ok":false,"error":"grand UAF after parent materialize y=$yAfter"}"""
+        }
+
+        childObj.put("_childTouch", true)
+        val yAfterChild = grandObj.optInt("y")
+        if (yAfterChild != 42) {
+            return """{"ok":false,"error":"grand UAF after child materialize y=$yAfterChild"}"""
+        }
+
+        """{"ok":true,"a":$a,"x":"$x","y":$y,"blob":${blobStr.length}}"""
+    } catch (t: Throwable) {
+        """{"ok":false,"error":"${t.message}"}"""
+    }
+}

--- a/core/src/appleMain/kotlin/com/tencent/kuikly/core/utils/BridgeArgConvert.kt
+++ b/core/src/appleMain/kotlin/com/tencent/kuikly/core/utils/BridgeArgConvert.kt
@@ -13,11 +13,22 @@
  * limitations under the License.
  */
 
-package com.tencent.kuikly.demo.pages.base
+package com.tencent.kuikly.core.utils
 
-import com.tencent.kuikly.core.nvi.serialization.json.testAppleNestedNSDictionaryLifecycle
+import com.tencent.kuikly.core.nvi.serialization.json.LazyNSDictionaryMap
+import platform.Foundation.NSDictionary
 
-internal actual fun runNestedCJsonLifecycleTest(ownerHandle: Long): String {
-    // ownerHandle is a sentinel from native; lifecycle uses a local NSDictionary tree.
-    return testAppleNestedNSDictionaryLifecycle()
+/**
+ * Apple parallel to OHOS [KRRenderCValue.toAny]: unpack Native callKotlin args
+ * before [com.tencent.kuikly.core.manager.BridgeManager].
+ *
+ * [NSDictionary] → lazy [com.tencent.kuikly.core.nvi.serialization.json.JSONObject];
+ * other types pass through. CallNative returns are unchanged (ObjC still may
+ * hand raw collections to Kotlin module APIs).
+ */
+fun Any?.toKotlinBridgeArg(): Any? {
+    return when (this) {
+        is NSDictionary -> LazyNSDictionaryMap.wrapAsJSONObject(this)
+        else -> this
+    }
 }

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/manager/BridgeManager.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/manager/BridgeManager.kt
@@ -140,7 +140,7 @@ object BridgeManager {
                     arg0 as String,
                     arg1 as Int,
                     arg2 as String,
-                    arg3 as? String
+                    arg3
                 )
             }
             KotlinMethod.LAYOUT_VIEW -> {

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/manager/BridgeManager.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/manager/BridgeManager.kt
@@ -121,11 +121,11 @@ object BridgeManager {
                 PagerManager.createPager(
                     arg0 as String,
                     arg1 as String,
-                    arg2 as String
+                    arg2
                 )
             }
             KotlinMethod.UPDATE_INSTANCE -> {
-                PagerManager.firePagerEvent(arg0 as String, arg1 as String, arg2 as String)
+                PagerManager.firePagerEvent(arg0 as String, arg1 as String, arg2)
             }
             KotlinMethod.DESTROY_INSTANCE -> {
                 val instanceId = arg0 as String

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/manager/PagerManager.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/manager/PagerManager.kt
@@ -62,7 +62,7 @@ object PagerManager {
     fun createPager(
         pagerId: String,
         url: String,
-        pagerData: String
+        pagerData: Any?
     ) {
         val pageTrace = PageCreateTrace()
         val pagerName = pageNameFromUrl(url)
@@ -78,15 +78,15 @@ object PagerManager {
             pagerMap[pagerId] = pager
             pager.pageName = pagerName
             pager.setPageTrace(pageTrace)
-            pager.onCreatePager(pagerId, JSONObject(pagerData))
+            pager.onCreatePager(pagerId, toBridgeJSONObject(pagerData) ?: JSONObject())
         } else {
             reactiveObserverMap.remove(pagerId)
             throw PagerNotFoundException("[createPager]: pager 未注册. pagerName: $pagerName")
         }
     }
 
-    fun firePagerEvent(pagerId: String, event: String, data: String) {
-        pagerMap[pagerId]?.onReceivePagerEvent(event, JSONObject(data))
+    fun firePagerEvent(pagerId: String, event: String, data: Any?) {
+        pagerMap[pagerId]?.onReceivePagerEvent(event, toBridgeJSONObject(data) ?: JSONObject())
     }
 
     fun destroyPager(pagerId: String) {
@@ -97,23 +97,29 @@ object PagerManager {
     }
 
     /**
-     * [data] is typically a JSON [String], or an already-built [JSONObject]
-     * (OHOS may pass a platform-backed subclass from FFI).
+     * [data] is a JSON [String] or [JSONObject] (OHOS NATIVE_JSON / iOS
+     * NSDictionary already wrapped at the platform callKotlin entry).
      */
     fun fireViewEvent(pagerId: String, viewRef: Int, event: String, data: Any?) {
-        pagerMap[pagerId]?.onViewEvent(viewRef, event, toViewEventJSONObject(data))
+        pagerMap[pagerId]?.onViewEvent(viewRef, event, toBridgeJSONObject(data))
     }
 
-    private fun toViewEventJSONObject(data: Any?): JSONObject? {
+    /**
+     * Normalize Native/Kotlin bridge payload to [JSONObject].
+     * Platform collections are converted before BridgeManager
+     * (OHOS toAny / iOS toKotlinBridgeArg).
+     */
+    private fun toBridgeJSONObject(data: Any?): JSONObject? {
         return when (data) {
             null -> null
             is JSONObject -> data
-            is String -> if (data.isEmpty()) null else JSONObject(data)
+            is String -> if (data.isEmpty()) null else JSONObject(data) // TODO: what if it's NOT a JSON string?
             else -> null
         }
     }
 
     fun fireCallBack(pagerId: String, functionRef: GlobalFunctionRef, data: Any? = null) {
+        // Structured payloads arrive as JSONObject (lazy) or legacy JSON String.
         GlobalFunctions.invokeFunction(pagerId, functionRef, data)
     }
 

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/manager/PagerManager.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/manager/PagerManager.kt
@@ -96,12 +96,21 @@ object PagerManager {
         reactiveObserverMap.remove(pagerId)
     }
 
-    fun fireViewEvent(pagerId: String, viewRef: Int, event: String, data: String?) {
-        var dataObject: JSONObject? = null
-        data?.also {
-            dataObject = JSONObject(it)
+    /**
+     * [data] is typically a JSON [String], or an already-built [JSONObject]
+     * (OHOS may pass a platform-backed subclass from FFI).
+     */
+    fun fireViewEvent(pagerId: String, viewRef: Int, event: String, data: Any?) {
+        pagerMap[pagerId]?.onViewEvent(viewRef, event, toViewEventJSONObject(data))
+    }
+
+    private fun toViewEventJSONObject(data: Any?): JSONObject? {
+        return when (data) {
+            null -> null
+            is JSONObject -> data
+            is String -> if (data.isEmpty()) null else JSONObject(data)
+            else -> null
         }
-        pagerMap[pagerId]?.onViewEvent(viewRef, event, dataObject)
     }
 
     fun fireCallBack(pagerId: String, functionRef: GlobalFunctionRef, data: Any? = null) {

--- a/core/src/ohosArm64Main/kotlin/com/tencent/kuikly/core/nvi/serialization/json/CJsonJSONObject.kt
+++ b/core/src/ohosArm64Main/kotlin/com/tencent/kuikly/core/nvi/serialization/json/CJsonJSONObject.kt
@@ -1,0 +1,328 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.core.nvi.serialization.json
+
+import kotlin.concurrent.AtomicInt
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.ref.createCleaner
+
+/**
+ * OHOS-only lazy map backed by a shared_ptr cJSON owner.
+ * Passed into the existing internal [JSONObject] map constructor — no commonMain
+ * [JSONObject] API changes and no subclassing.
+ *
+ * Nested objects returned from [get] are themselves [JSONObject]s wrapping a new
+ * [LazyCJsonMap] (own retain), so they survive parent materialize / release.
+ */
+@OptIn(ExperimentalNativeApi::class)
+internal class LazyCJsonMap private constructor(
+    private var ownerPtr: Long,
+    private var nodePtr: Long,
+    private var releaseToken: OwnerRelease?,
+    /** Kept so Cleaner is not collected early. */
+    private var cleaner: Any?,
+) : AbstractMutableMap<String, Any?>() {
+
+    private class OwnerRelease(private val ptr: Long) {
+        private val done = AtomicInt(0)
+
+        fun releaseOnce() {
+            if (done.compareAndSet(0, 1) && ptr != 0L) {
+                CJsonNative.release(ptr)
+            }
+        }
+    }
+
+    /** After first mutation (or forced materialize), native tree is released. */
+    private var materialized: MutableMap<String, Any?>? = null
+
+    companion object {
+        fun fromOwner(ownerPtr: Long): JSONObject {
+            if (ownerPtr == 0L) {
+                return JSONObject()
+            }
+            val held = CJsonNative.retain(ownerPtr)
+            if (held == 0L) {
+                return JSONObject()
+            }
+            val root = CJsonNative.ownerRoot(held)
+            if (root == 0L) {
+                CJsonNative.release(held)
+                return JSONObject()
+            }
+            return JSONObject(wrap(held, root))
+        }
+
+        private fun fromNode(ownerPtr: Long, nodePtr: Long): JSONObject {
+            if (ownerPtr == 0L || nodePtr == 0L) {
+                return JSONObject()
+            }
+            val held = CJsonNative.retain(ownerPtr)
+            if (held == 0L) {
+                return JSONObject()
+            }
+            return JSONObject(wrap(held, nodePtr))
+        }
+
+        private fun wrap(held: Long, nodePtr: Long): LazyCJsonMap {
+            val token = OwnerRelease(held)
+            val cleaner = createCleaner(token) { it.releaseOnce() }
+            return LazyCJsonMap(held, nodePtr, token, cleaner)
+        }
+    }
+
+    override val size: Int
+        get() {
+            materialized?.let { return it.size }
+            return if (nodePtr != 0L) CJsonNative.size(nodePtr) else 0
+        }
+
+    override fun containsKey(key: String): Boolean {
+        materialized?.let { return it.containsKey(key) }
+        return nodePtr != 0L && CJsonNative.hasKey(nodePtr, key)
+    }
+
+    override fun containsValue(value: Any?): Boolean {
+        materialized?.let { return it.containsValue(value) }
+        return entries.any { it.value == value }
+    }
+
+    override fun get(key: String): Any? {
+        materialized?.let { return it[key] }
+        if (nodePtr == 0L) {
+            return null
+        }
+        return optFromCJson(key)
+    }
+
+    override fun put(key: String, value: Any?): Any? {
+        return ensureMaterialized().put(key, value)
+    }
+
+    override fun remove(key: String): Any? {
+        return ensureMaterialized().remove(key)
+    }
+
+    override fun clear() {
+        ensureMaterialized().clear()
+    }
+
+    override val entries: MutableSet<MutableMap.MutableEntry<String, Any?>>
+        get() {
+            materialized?.let { return it.entries }
+            return LazyEntries()
+        }
+
+    private fun ensureMaterialized(): MutableMap<String, Any?> {
+        materialized?.let { return it }
+        val map: MutableMap<String, Any?> = JSONEngine.getMutableMap()
+        if (nodePtr != 0L) {
+            val n = CJsonNative.size(nodePtr)
+            for (i in 0 until n) {
+                val key = CJsonNative.keyAt(nodePtr, i) ?: continue
+                map[key] = optFromCJson(key)
+            }
+        }
+        releaseNativeOwnership()
+        materialized = map
+        return map
+    }
+
+    private fun releaseNativeOwnership() {
+        nodePtr = 0L
+        ownerPtr = 0L
+        val token = releaseToken
+        releaseToken = null
+        cleaner = null
+        token?.releaseOnce()
+    }
+
+    private fun optFromCJson(name: String): Any? {
+        return when (CJsonNative.valueKind(nodePtr, name)) {
+            1 -> CJsonNative.getBool(nodePtr, name, false)
+            2 -> {
+                val d = CJsonNative.getNumber(nodePtr, name, 0.0)
+                val asLong = d.toLong()
+                if (d == asLong.toDouble() && asLong >= Int.MIN_VALUE && asLong <= Int.MAX_VALUE) {
+                    asLong.toInt()
+                } else if (d == asLong.toDouble()) {
+                    asLong
+                } else {
+                    d
+                }
+            }
+            3 -> CJsonNative.getString(nodePtr, name)
+            4 -> {
+                val child = CJsonNative.getObjectPtr(nodePtr, name)
+                if (child == 0L || ownerPtr == 0L) {
+                    null
+                } else {
+                    fromNode(ownerPtr, child)
+                }
+            }
+            5 -> {
+                val child = CJsonNative.getArrayPtr(nodePtr, name)
+                if (child == 0L) {
+                    null
+                } else {
+                    val printed = CJsonNative.print(child)
+                    if (printed == null) {
+                        null
+                    } else {
+                        try {
+                            JSONArray(printed)
+                        } catch (_: JSONException) {
+                            null
+                        }
+                    }
+                }
+            }
+            else -> null
+        }
+    }
+
+    /**
+     * Read-only entry view over cJSON. Any structural mutation materializes.
+     */
+    private inner class LazyEntries : AbstractMutableSet<MutableMap.MutableEntry<String, Any?>>() {
+        override val size: Int
+            get() = this@LazyCJsonMap.size
+
+        override fun add(element: MutableMap.MutableEntry<String, Any?>): Boolean {
+            ensureMaterialized()[element.key] = element.value
+            return true
+        }
+
+        override fun clear() {
+            this@LazyCJsonMap.clear()
+        }
+
+        override fun iterator(): MutableIterator<MutableMap.MutableEntry<String, Any?>> {
+            materialized?.let { return it.entries.iterator() }
+            if (nodePtr == 0L) {
+                return mutableListOf<MutableMap.MutableEntry<String, Any?>>().iterator()
+            }
+            val keys = ArrayList<String>(CJsonNative.size(nodePtr))
+            val n = CJsonNative.size(nodePtr)
+            for (i in 0 until n) {
+                CJsonNative.keyAt(nodePtr, i)?.let { keys.add(it) }
+            }
+            val keyIter = keys.iterator()
+            return object : MutableIterator<MutableMap.MutableEntry<String, Any?>> {
+                private var lastKey: String? = null
+
+                override fun hasNext(): Boolean = keyIter.hasNext()
+
+                override fun next(): MutableMap.MutableEntry<String, Any?> {
+                    val key = keyIter.next()
+                    lastKey = key
+                    return object : MutableMap.MutableEntry<String, Any?> {
+                        override val key: String = key
+                        override val value: Any?
+                            get() = get(key)
+
+                        override fun setValue(newValue: Any?): Any? {
+                            val old = get(key)
+                            put(key, newValue)
+                            return old
+                        }
+                    }
+                }
+
+                override fun remove() {
+                    val key = lastKey ?: throw IllegalStateException()
+                    this@LazyCJsonMap.remove(key)
+                    lastKey = null
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Factory name kept for TypeUtils / tests.
+ */
+internal object CJsonJSONObject {
+    fun fromOwner(ownerPtr: Long): JSONObject {
+        return LazyCJsonMap.fromOwner(ownerPtr)
+    }
+}
+
+/**
+ * Nested-object lifecycle checks for the lazy cJSON bridge.
+ *
+ * [ownerHandle] is a transferred shared_ptr handle from native (caller must not
+ * use it after this returns; this function consumes it via retain + release).
+ */
+fun testOhosNestedCJsonLifecycle(ownerHandle: Long): String {
+    if (ownerHandle == 0L) {
+        return """{"ok":false,"error":"null owner"}"""
+    }
+    return try {
+        val root = CJsonJSONObject.fromOwner(ownerHandle)
+        CJsonNative.release(ownerHandle)
+
+        val a = root.optInt("a")
+        if (a != 1) {
+            return """{"ok":false,"error":"a=$a"}"""
+        }
+
+        val child = root.optJSONObject("child")
+            ?: return """{"ok":false,"error":"missing child"}"""
+        if (child.nameValuePairs !is LazyCJsonMap) {
+            return """{"ok":false,"error":"child not lazy cJSON map"}"""
+        }
+        val x = child.optString("x")
+        if (x != "hello") {
+            return """{"ok":false,"error":"x=$x"}"""
+        }
+
+        val grand = child.optJSONObject("grand")
+            ?: return """{"ok":false,"error":"missing grand"}"""
+        val y = grand.optInt("y")
+        if (y != 42) {
+            return """{"ok":false,"error":"y=$y"}"""
+        }
+
+        val blob = root.optString("blob")
+        if (blob.length != 4096) {
+            return """{"ok":false,"error":"blobLen=${blob.length}"}"""
+        }
+
+        root.put("_touch", 1)
+        if (root.optInt("_touch") != 1) {
+            return """{"ok":false,"error":"touch after materialize"}"""
+        }
+        val xAfter = child.optString("x")
+        if (xAfter != "hello") {
+            return """{"ok":false,"error":"child UAF after parent materialize x=$xAfter"}"""
+        }
+        val yAfter = grand.optInt("y")
+        if (yAfter != 42) {
+            return """{"ok":false,"error":"grand UAF after parent materialize y=$yAfter"}"""
+        }
+
+        child.put("_childTouch", true)
+        val yAfterChild = grand.optInt("y")
+        if (yAfterChild != 42) {
+            return """{"ok":false,"error":"grand UAF after child materialize y=$yAfterChild"}"""
+        }
+
+        """{"ok":true,"a":$a,"x":"$x","y":$y,"blob":${blob.length}}"""
+    } catch (t: Throwable) {
+        """{"ok":false,"error":"${t.message}"}"""
+    }
+}

--- a/core/src/ohosArm64Main/kotlin/com/tencent/kuikly/core/nvi/serialization/json/CJsonNative.ohosArm64.kt
+++ b/core/src/ohosArm64Main/kotlin/com/tencent/kuikly/core/nvi/serialization/json/CJsonNative.ohosArm64.kt
@@ -1,0 +1,141 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.core.nvi.serialization.json
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.toKString
+import ohos.kuikly_cjson_free_string
+import ohos.kuikly_cjson_get_array
+import ohos.kuikly_cjson_get_bool
+import ohos.kuikly_cjson_get_number
+import ohos.kuikly_cjson_get_object
+import ohos.kuikly_cjson_get_string
+import ohos.kuikly_cjson_has
+import ohos.kuikly_cjson_key_at
+import ohos.kuikly_cjson_owner_root
+import ohos.kuikly_cjson_print
+import ohos.kuikly_cjson_release
+import ohos.kuikly_cjson_retain
+import ohos.kuikly_cjson_size
+import ohos.kuikly_cjson_value_kind
+
+/**
+ * OHOS-only FFI to shared_ptr-backed KuiklyCJsonOwner / cJSON* in render .so.
+ *
+ * Each Long handle is an opaque heap std::shared_ptr. [retain] returns a new
+ * handle sharing the same owner; [release] drops that handle.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal object CJsonNative {
+    /** New handle sharing ownership with [ownerPtr], or 0. */
+    fun retain(ownerPtr: Long): Long {
+        if (ownerPtr == 0L) {
+            return 0L
+        }
+        return kuikly_cjson_retain(ownerPtr)
+    }
+
+    fun release(ownerPtr: Long) {
+        if (ownerPtr != 0L) {
+            kuikly_cjson_release(ownerPtr)
+        }
+    }
+
+    fun ownerRoot(ownerPtr: Long): Long {
+        if (ownerPtr == 0L) {
+            return 0L
+        }
+        return kuikly_cjson_owner_root(ownerPtr)
+    }
+
+    fun hasKey(ptr: Long, key: String): Boolean {
+        if (ptr == 0L) {
+            return false
+        }
+        return kuikly_cjson_has(ptr, key) != 0
+    }
+
+    fun size(ptr: Long): Int {
+        if (ptr == 0L) {
+            return 0
+        }
+        return kuikly_cjson_size(ptr)
+    }
+
+    fun keyAt(ptr: Long, index: Int): String? {
+        if (ptr == 0L) {
+            return null
+        }
+        return kuikly_cjson_key_at(ptr, index)?.toKString()
+    }
+
+    fun valueKind(ptr: Long, key: String): Int {
+        if (ptr == 0L) {
+            return 0
+        }
+        return kuikly_cjson_value_kind(ptr, key)
+    }
+
+    fun getBool(ptr: Long, key: String, fallback: Boolean): Boolean {
+        if (ptr == 0L) {
+            return fallback
+        }
+        return kuikly_cjson_get_bool(ptr, key, if (fallback) 1 else 0) != 0
+    }
+
+    fun getNumber(ptr: Long, key: String, fallback: Double): Double {
+        if (ptr == 0L) {
+            return fallback
+        }
+        return kuikly_cjson_get_number(ptr, key, fallback)
+    }
+
+    fun getString(ptr: Long, key: String): String? {
+        if (ptr == 0L) {
+            return null
+        }
+        return kuikly_cjson_get_string(ptr, key)?.toKString()
+    }
+
+    fun getObjectPtr(ptr: Long, key: String): Long {
+        if (ptr == 0L) {
+            return 0L
+        }
+        return kuikly_cjson_get_object(ptr, key)
+    }
+
+    fun getArrayPtr(ptr: Long, key: String): Long {
+        if (ptr == 0L) {
+            return 0L
+        }
+        return kuikly_cjson_get_array(ptr, key)
+    }
+
+    fun print(ptr: Long): String? {
+        if (ptr == 0L) {
+            return null
+        }
+        val p = kuikly_cjson_print(ptr)
+        if (p == null) {
+            return null
+        }
+        return try {
+            p.toKString()
+        } finally {
+            kuikly_cjson_free_string(p)
+        }
+    }
+}

--- a/core/src/ohosArm64Main/kotlin/com/tencent/kuikly/core/utils/TypeUtils.kt
+++ b/core/src/ohosArm64Main/kotlin/com/tencent/kuikly/core/utils/TypeUtils.kt
@@ -24,6 +24,7 @@ import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.value
 import kotlinx.cinterop.*
+import com.tencent.kuikly.core.nvi.serialization.json.CJsonJSONObject
 import ohos.KRRenderCValue
 import ohos.Type
 import platform.ohos.OH_LOG_Print
@@ -111,6 +112,7 @@ fun KRRenderCValue.toAny(): Any? {
         Type.STRING -> value.stringValue?.toKString()
         Type.BYTES -> toByteArray()
         Type.ARRAY -> value.arrayValue?.arrayToAny(size)
+        Type.NATIVE_JSON -> CJsonJSONObject.fromOwner(value.longValue)
         else -> null
     }
 }

--- a/demo/src/androidMain/kotlin/com/tencent/kuikly/demo/pages/base/NestedCJsonLifecycleTest.android.kt
+++ b/demo/src/androidMain/kotlin/com/tencent/kuikly/demo/pages/base/NestedCJsonLifecycleTest.android.kt
@@ -1,7 +1,7 @@
 /*
  * Tencent is pleased to support the open source community by making KuiklyUI
  * available.
- * Copyright (C) 2025 Tencent. All rights reserved.
+ * Copyright (C) 2026 Tencent. All rights reserved.
  * Licensed under the License of KuiklyUI;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-// Redirect to the canonical version in core-render-ohos.
-// Do not duplicate content here; all typedefs and structs live there.
-#include "foundation/type/KRRenderCValue.h"
-// Lazy cJSON FFI for Kotlin/Native cinterop (NATIVE_JSON bridge).
-#include "foundation/type/KRLazyCJsonBridge.h"
+package com.tencent.kuikly.demo.pages.base
+
+internal actual fun runNestedCJsonLifecycleTest(ownerHandle: Long): String {
+    return """{"ok":true,"skipped":true,"platform":"android"}"""
+}

--- a/demo/src/appleMain/kotlin/com/tencent/kuikly/demo/pages/base/NestedCJsonLifecycleTest.apple.kt
+++ b/demo/src/appleMain/kotlin/com/tencent/kuikly/demo/pages/base/NestedCJsonLifecycleTest.apple.kt
@@ -1,7 +1,7 @@
 /*
  * Tencent is pleased to support the open source community by making KuiklyUI
  * available.
- * Copyright (C) 2025 Tencent. All rights reserved.
+ * Copyright (C) 2026 Tencent. All rights reserved.
  * Licensed under the License of KuiklyUI;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-// Redirect to the canonical version in core-render-ohos.
-// Do not duplicate content here; all typedefs and structs live there.
-#include "foundation/type/KRRenderCValue.h"
-// Lazy cJSON FFI for Kotlin/Native cinterop (NATIVE_JSON bridge).
-#include "foundation/type/KRLazyCJsonBridge.h"
+package com.tencent.kuikly.demo.pages.base
+
+internal actual fun runNestedCJsonLifecycleTest(ownerHandle: Long): String {
+    return """{"ok":true,"skipped":true,"platform":"apple"}"""
+}

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/CallKotlinPerfPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/CallKotlinPerfPage.kt
@@ -29,9 +29,9 @@ import com.tencent.kuikly.demo.pages.base.CallKotlinPerfTestModule
 import com.tencent.kuikly.demo.pages.demo.base.NavBar
 
 /**
- * OHOS callKotlin interop performance page — phase distribution + JSON size sweep.
+ * callKotlin interop performance page — layout + Fire/Update/Callback JSON bridge.
  *
- * Launch: open page `CallKotlinPerfPage` via demo router (debug OHOS build).
+ * Launch: open page `CallKotlinPerfPage` via demo router (Debug build).
  * Logs tag: CallKotlinPerf
  */
 @Page("CallKotlinPerfPage")
@@ -59,7 +59,7 @@ internal class CallKotlinPerfPage : BasePager() {
     private fun runBenchmark() {
         val mod = acquireModule<CallKotlinPerfTestModule>(CallKotlinPerfTestModule.MODULE_NAME)
         try {
-            statusLine = "nested cjson lifecycle..."
+            statusLine = "nested lifecycle..."
             val nested = mod.testNestedLifecycle()
             KLog.i(TAG, "NESTED_LIFECYCLE $nested")
             if (nested.contains("\"ok\":false")) {
@@ -74,22 +74,30 @@ internal class CallKotlinPerfPage : BasePager() {
             val layoutCpp = mod.benchPhases(iterations = 3000, jsonBytes = 64, mode = "layout")
             KLog.i(TAG, "PHASES_CPP $layoutCpp")
 
+            // FireViewEvent + UpdateInstance (+ same JSON bridge as Create) + FireCallback
+            val pathModes = listOf(
+                "fire" to "map",
+                "update" to "update_map",
+                "callback" to "callback_map",
+            )
             for (bytes in listOf(1024, 65536, 3 * 1024 * 1024)) {
                 val iters = when {
                     bytes >= 3 * 1024 * 1024 -> 50
                     bytes >= 65536 -> 200
                     else -> 1000
                 }
-                statusLine = "fire string $bytes..."
-                val cpp = mod.benchPhases(iterations = iters, jsonBytes = bytes, mode = "fire")
-                KLog.i(TAG, "PHASES_CPP jsonBytes=$bytes $cpp")
+                for ((stringMode, lazyMode) in pathModes) {
+                    statusLine = "$stringMode string $bytes..."
+                    val cpp = mod.benchPhases(iterations = iters, jsonBytes = bytes, mode = stringMode)
+                    KLog.i(TAG, "PHASES_CPP path=$stringMode jsonBytes=$bytes $cpp")
 
-                statusLine = "lazy cjson $bytes..."
-                val cppMap = mod.benchPhases(iterations = iters, jsonBytes = bytes, mode = "map")
-                KLog.i(TAG, "PHASES_CPP jsonBytes=$bytes $cppMap")
+                    statusLine = "$lazyMode lazy $bytes..."
+                    val cppMap = mod.benchPhases(iterations = iters, jsonBytes = bytes, mode = lazyMode)
+                    KLog.i(TAG, "PHASES_CPP path=$lazyMode jsonBytes=$bytes $cppMap")
+                }
             }
 
-            resultLine = "done — see hilog CallKotlinPerf"
+            resultLine = "done — see log tag CallKotlinPerf"
             statusLine = "done"
             KLog.i(TAG, "DONE")
         } catch (t: Throwable) {

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/CallKotlinPerfPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/CallKotlinPerfPage.kt
@@ -1,0 +1,158 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.demo.pages
+
+import com.tencent.kuikly.core.annotations.Page
+import com.tencent.kuikly.core.base.Color
+import com.tencent.kuikly.core.base.ViewBuilder
+import com.tencent.kuikly.core.log.KLog
+import com.tencent.kuikly.core.module.Module
+import com.tencent.kuikly.core.reactive.handler.observable
+import com.tencent.kuikly.core.timer.setTimeout
+import com.tencent.kuikly.core.views.Text
+import com.tencent.kuikly.core.views.View
+import com.tencent.kuikly.demo.pages.base.BasePager
+import com.tencent.kuikly.demo.pages.base.CallKotlinPerfTestModule
+import com.tencent.kuikly.demo.pages.demo.base.NavBar
+
+/**
+ * OHOS callKotlin interop performance page — phase distribution + JSON size sweep.
+ *
+ * Launch: open page `CallKotlinPerfPage` via demo router (debug OHOS build).
+ * Logs tag: CallKotlinPerf
+ */
+@Page("CallKotlinPerfPage")
+internal class CallKotlinPerfPage : BasePager() {
+
+    private var statusLine by observable("waiting...")
+    private var resultLine by observable("")
+    private var ran = false
+
+    override fun createExternalModules(): Map<String, Module>? {
+        val modules = super.createExternalModules()?.toMutableMap() ?: hashMapOf()
+        modules[CallKotlinPerfTestModule.MODULE_NAME] = CallKotlinPerfTestModule()
+        return modules
+    }
+
+    override fun pageDidAppear() {
+        super.pageDidAppear()
+        if (ran) {
+            return
+        }
+        ran = true
+        setTimeout(400) { runBenchmark() }
+    }
+
+    private fun runBenchmark() {
+        val mod = acquireModule<CallKotlinPerfTestModule>(CallKotlinPerfTestModule.MODULE_NAME)
+        try {
+            statusLine = "nested cjson lifecycle..."
+            val nested = mod.testNestedLifecycle()
+            KLog.i(TAG, "NESTED_LIFECYCLE $nested")
+            if (nested.contains("\"ok\":false")) {
+                KLog.i(TAG, "nested lifecycle failed (continue bench): $nested")
+            }
+
+            statusLine = "bench basic..."
+            val basic = mod.bench(5000)
+            KLog.i(TAG, "BASIC $basic")
+
+            statusLine = "phases layout..."
+            val layoutCpp = mod.benchPhases(iterations = 3000, jsonBytes = 64, mode = "layout")
+            KLog.i(TAG, "PHASES_CPP $layoutCpp")
+
+            for (bytes in listOf(1024, 65536, 3 * 1024 * 1024)) {
+                val iters = when {
+                    bytes >= 3 * 1024 * 1024 -> 50
+                    bytes >= 65536 -> 200
+                    else -> 1000
+                }
+                statusLine = "fire string $bytes..."
+                val cpp = mod.benchPhases(iterations = iters, jsonBytes = bytes, mode = "fire")
+                KLog.i(TAG, "PHASES_CPP jsonBytes=$bytes $cpp")
+
+                statusLine = "lazy cjson $bytes..."
+                val cppMap = mod.benchPhases(iterations = iters, jsonBytes = bytes, mode = "map")
+                KLog.i(TAG, "PHASES_CPP jsonBytes=$bytes $cppMap")
+            }
+
+            resultLine = "done — see hilog CallKotlinPerf"
+            statusLine = "done"
+            KLog.i(TAG, "DONE")
+        } catch (t: Throwable) {
+            val msg = "bench failed: ${t.message}"
+            KLog.e(TAG, msg)
+            statusLine = msg
+        }
+    }
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            NavBar {
+                attr {
+                    title = "callKotlin Perf"
+                }
+            }
+            View {
+                attr {
+                    padding(12f)
+                    flex(1f)
+                }
+                Text {
+                    attr {
+                        fontSize(16f)
+                        color(Color.BLACK)
+                        text("status: ${ctx.statusLine}")
+                    }
+                }
+                Text {
+                    attr {
+                        marginTop(12f)
+                        fontSize(13f)
+                        color(Color(0xFF333333))
+                        text(ctx.resultLine)
+                    }
+                }
+                View {
+                    attr {
+                        marginTop(20f)
+                        height(44f)
+                        backgroundColor(Color(0xFF1976D2))
+                        allCenter()
+                    }
+                    event {
+                        click {
+                            ctx.ran = false
+                            ctx.runBenchmark()
+                        }
+                    }
+                    Text {
+                        attr {
+                            color(Color.WHITE)
+                            fontSize(16f)
+                            text("Re-run")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "CallKotlinPerf"
+    }
+}

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/base/CallKotlinPerfTestModule.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/base/CallKotlinPerfTestModule.kt
@@ -1,0 +1,69 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.demo.pages.base
+
+import com.tencent.kuikly.core.module.Module
+import com.tencent.kuikly.core.nvi.serialization.json.JSONObject
+
+/**
+ * Kotlin wrapper for OHOS C++ [CallKotlinPerfTestModule] (demo/test only).
+ * Timing comes from the native module (`cpp_toCValue` / `cpp_callKotlin`); no core hooks.
+ */
+internal class CallKotlinPerfTestModule : Module() {
+
+    override fun moduleName(): String = MODULE_NAME
+
+    fun bench(iterations: Int = 5000): String {
+        val params = JSONObject().apply { put("iterations", iterations) }
+        return syncToNativeMethod(METHOD_BENCH, params, null)
+    }
+
+    fun benchPhases(iterations: Int = 2000, jsonBytes: Int = 1024, mode: String = "fire"): String {
+        val params = JSONObject().apply {
+            put("iterations", iterations)
+            put("jsonBytes", jsonBytes)
+            put("mode", mode)
+        }
+        return syncToNativeMethod(METHOD_BENCH_PHASES, params, null)
+    }
+
+    fun benchJson(iterationsPerSize: Int = 500): String {
+        val params = JSONObject().apply { put("iterations", iterationsPerSize) }
+        return syncToNativeMethod(METHOD_BENCH_JSON, params, null)
+    }
+
+    /** Native exports a nested NATIVE_JSON owner; platform actual runs lifecycle checks. */
+    fun testNestedLifecycle(): String {
+        val raw = syncToNativeMethod(METHOD_EXPORT_NESTED_OWNER, JSONObject(), null)
+        val owner = try {
+            JSONObject(raw).optLong("owner")
+        } catch (_: Throwable) {
+            return """{"ok":false,"error":"bad export: $raw"}"""
+        }
+        if (owner == 0L) {
+            return """{"ok":false,"error":"export failed: $raw"}"""
+        }
+        return runNestedCJsonLifecycleTest(owner)
+    }
+
+    companion object {
+        const val MODULE_NAME = "CallKotlinPerfTestModule"
+        private const val METHOD_BENCH = "bench"
+        private const val METHOD_BENCH_PHASES = "benchPhases"
+        private const val METHOD_BENCH_JSON = "benchJson"
+        private const val METHOD_EXPORT_NESTED_OWNER = "exportNestedOwner"
+    }
+}

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/base/NestedCJsonLifecycleTest.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/base/NestedCJsonLifecycleTest.kt
@@ -1,7 +1,7 @@
 /*
  * Tencent is pleased to support the open source community by making KuiklyUI
  * available.
- * Copyright (C) 2025 Tencent. All rights reserved.
+ * Copyright (C) 2026 Tencent. All rights reserved.
  * Licensed under the License of KuiklyUI;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,8 +13,7 @@
  * limitations under the License.
  */
 
-// Redirect to the canonical version in core-render-ohos.
-// Do not duplicate content here; all typedefs and structs live there.
-#include "foundation/type/KRRenderCValue.h"
-// Lazy cJSON FFI for Kotlin/Native cinterop (NATIVE_JSON bridge).
-#include "foundation/type/KRLazyCJsonBridge.h"
+package com.tencent.kuikly.demo.pages.base
+
+/** Platform hook for nested lazy-cJSON lifecycle checks (OHOS implements). */
+internal expect fun runNestedCJsonLifecycleTest(ownerHandle: Long): String

--- a/demo/src/jsMain/kotlin/com/tencent/kuikly/demo/pages/base/NestedCJsonLifecycleTest.js.kt
+++ b/demo/src/jsMain/kotlin/com/tencent/kuikly/demo/pages/base/NestedCJsonLifecycleTest.js.kt
@@ -1,7 +1,7 @@
 /*
  * Tencent is pleased to support the open source community by making KuiklyUI
  * available.
- * Copyright (C) 2025 Tencent. All rights reserved.
+ * Copyright (C) 2026 Tencent. All rights reserved.
  * Licensed under the License of KuiklyUI;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-// Redirect to the canonical version in core-render-ohos.
-// Do not duplicate content here; all typedefs and structs live there.
-#include "foundation/type/KRRenderCValue.h"
-// Lazy cJSON FFI for Kotlin/Native cinterop (NATIVE_JSON bridge).
-#include "foundation/type/KRLazyCJsonBridge.h"
+package com.tencent.kuikly.demo.pages.base
+
+internal actual fun runNestedCJsonLifecycleTest(ownerHandle: Long): String {
+    return """{"ok":true,"skipped":true,"platform":"js"}"""
+}

--- a/demo/src/ohosArm64Main/kotlin/com/tencent/kuikly/demo/pages/base/NestedCJsonLifecycleTest.ohos.kt
+++ b/demo/src/ohosArm64Main/kotlin/com/tencent/kuikly/demo/pages/base/NestedCJsonLifecycleTest.ohos.kt
@@ -1,7 +1,7 @@
 /*
  * Tencent is pleased to support the open source community by making KuiklyUI
  * available.
- * Copyright (C) 2025 Tencent. All rights reserved.
+ * Copyright (C) 2026 Tencent. All rights reserved.
  * Licensed under the License of KuiklyUI;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,8 +13,10 @@
  * limitations under the License.
  */
 
-// Redirect to the canonical version in core-render-ohos.
-// Do not duplicate content here; all typedefs and structs live there.
-#include "foundation/type/KRRenderCValue.h"
-// Lazy cJSON FFI for Kotlin/Native cinterop (NATIVE_JSON bridge).
-#include "foundation/type/KRLazyCJsonBridge.h"
+package com.tencent.kuikly.demo.pages.base
+
+import com.tencent.kuikly.core.nvi.serialization.json.testOhosNestedCJsonLifecycle
+
+internal actual fun runNestedCJsonLifecycleTest(ownerHandle: Long): String {
+    return testOhosNestedCJsonLifecycle(ownerHandle)
+}

--- a/docs/callKotlin-perf-progress.md
+++ b/docs/callKotlin-perf-progress.md
@@ -1,7 +1,7 @@
-# callKotlin Interop Performance Optimization (OHOS)
+# callKotlin Interop Performance Optimization
 
-> Goal: optimize Native (`core-render-ohos`) → Kotlin `callKotlin` interop performance.
-> Device: physical `LNG0223C13000049` (primary); earlier numbers also from emulator.
+> Goal: optimize Native → Kotlin `callKotlin` interop (large JSON / hot path).
+> OHOS device: physical `LNG0223C13000049`. iOS: simulator (see iOS section).
 
 ## Progress Log
 
@@ -13,6 +13,7 @@
 | 4. Re-test early opts; keep what matters | DONE | Keep A, B, D; drop C |
 | 5. Phase distribution + long JSON | DONE | |
 | 6. Lazy cJSON* JSONObject proxy | DONE | Flat ~50–70µs even at 3MB if unread |
+| 7. iOS port (KSP B + lazy NSDictionary D + DEBUG harness) | DONE | See iOS section |
 
 ---
 
@@ -34,7 +35,7 @@ Notes:
 
 ---
 
-## Call path
+## Call path (OHOS)
 
 ```
 KRRenderCore::CallKotlinMethod
@@ -49,7 +50,7 @@ KRRenderCore::CallKotlinMethod
 
 ---
 
-## Measurement notes
+## Measurement notes (OHOS)
 
 Kotlin-side phase counters in `core` were removed (too intrusive on Bridge/TypeUtils).
 Bench timing is C++-only in ohosApp `CallKotlinPerfTestModule`
@@ -69,7 +70,7 @@ Kotlin ohosArm64 `CJsonJSONObject.fromOwner` **retain**s; Cleaner **release**s o
 
 ---
 
-## Optimizations kept in tree
+## Optimizations kept in tree (OHOS)
 
 ### A. Cache instanceId on `KRRenderCore` (`core-render-ohos`)
 - Construct `instanceIdValue_` once in ctor; reuse in `CallKotlinMethod`.
@@ -83,11 +84,12 @@ Kotlin ohosArm64 `CJsonJSONObject.fromOwner` **retain**s; Cleaner **release**s o
   - `FIRE_CALLBACK` / `UPDATE` / `DESTROY` → arg0–arg2
   - `CREATE_INSTANCE` → reuse `asString()` as instanceId (no double convert)
 
-### D. Lazy cJSON* bridge (OHOS only)
+### D. Lazy cJSON* bridge (OHOS)
 - C++ Map/Array `toCValue` → `NATIVE_JSON` (opaque `shared_ptr<KuiklyCJsonOwner>` handle).
-- Kotlin **ohosArm64**: `CJsonJSONObject` subclass + `CJsonNative` FFI; `retain` returns a new shared handle; `TypeUtils` wraps owner → `JSONObject`.
-- **commonMain** stays free of cJSON: `JSONObject` is `open` for subclassing; `fireViewEvent` accepts `String` or `JSONObject`.
-- Field access via `kuikly_cjson_*`; large leaves not copied until read.
+- Kotlin **ohosArm64**: `LazyCJsonMap` into internal `JSONObject(map)`; `TypeUtils` wraps owner → `JSONObject`.
+- **commonMain**: `JSONObject` stays `final`; Create/Update/Fire accept `String` or `JSONObject`.
+- **CreateInstance**: pass `PageData()` Map (no `toString()`).
+- **UpdateInstance / SendEvent**: ETS/NAPI pass Record → Map; legacy string API parses to Map before CallKotlin.
 
 ### Dropped: C. Eager structured Map bridge
 - Removed `ToStructuredMapLocked` / `ToJsonMapOrArrayLocked` and `__kuikly_map_v1__` Kotlin decode.
@@ -95,7 +97,71 @@ Kotlin ohosArm64 `CJsonJSONObject.fromOwner` **retain**s; Cleaner **release**s o
 
 ---
 
+## iOS port (2026-08-04)
+
+iOS Native→Kotlin is ObjC `id` → K/N (not `KRRenderCValue` / cJSON).
+
+| Opt | iOS approach | Notes |
+|-----|----------------|-------|
+| **A** | Skip | `_instanceId` already retained `NSString*` |
+| **B** | `IOSTargetEntryBuilder` (+ multi) | No per-call lambda; codegen try/catch from `catchException` |
+| **D** | Lazy `NSDictionary` | Pass collections through ObjC; `toKotlinBridgeArg` at KSP entry wraps `NSDictionary` → `LazyNSDictionaryMap` before `BridgeManager` (OHOS parallel: `toAny`) |
+
+### Call path (iOS)
+
+```
+KuiklyRenderCore → ContextHandler.callWithMethod
+  └─ All methods: pass NSDictionary/NSArray through (no NSJSONSerialization)
+  └─ KuiklyCoreEntry.callKotlinMethod
+       └─ KSP entry: argN.toKotlinBridgeArg() → BridgeManager
+            └─ Create/Update/Fire* → toBridgeJSONObject (String | JSONObject)
+```
+
+### DEBUG harness
+
+- `iosApp/.../CallKotlinPerfTestModule.m` (`#if DEBUG`), class name matches Kotlin `MODULE_NAME`
+- Times `hr_dictionaryToJSON` (string mode) vs pass-through dict (map mode) + `callWithMethod`
+- Nested lifecycle: `testAppleNestedNSDictionaryLifecycle` (local `NSMutableDictionary` tree)
+- Open `CallKotlinPerfPage` via demo router; log tag `CallKotlinPerf`
+
+### Bench numbers (iOS simulator, iPhone 15, 2026-08-04)
+
+Unread payloads — `cpp_total_ns_per` from DEBUG `CallKotlinPerfTestModule`
+(string = `hr_dictionaryToJSON` + call; lazy = pass-through `NSDictionary`).
+
+**FireViewEvent**
+
+| ~bytes | string | lazy | speedup |
+|------:|-------:|-----:|--------:|
+| 1K | ~32µs | ~1.7µs | ~19× |
+| 64K | ~1.12ms | ~1.3µs | ~860× |
+| 3MB | ~55ms | ~1.2µs | ~45k× |
+
+**UpdateInstance** (same `toBridgeJSONObject` path as Create pageData)
+
+| ~bytes | string | lazy | speedup |
+|------:|-------:|-----:|--------:|
+| 1K | ~25µs | ~0.88µs | ~29× |
+| 64K | ~1.12ms | ~0.83µs | ~1350× |
+| 3MB | ~54ms | ~0.82µs | ~66k× |
+
+**FireCallback**
+
+| ~bytes | string | lazy | speedup |
+|------:|-------:|-----:|--------:|
+| 1K | ~4.3µs | ~0.93µs | ~4.6× |
+| 64K | ~121µs | ~0.92µs | ~130× |
+| 3MB | ~5.9ms | ~0.90µs | ~6500× |
+
+LAYOUT ≈ **0.52µs**/call. Nested lifecycle: `ok:true`.
+CreateInstance is not looped (would allocate pagers); it shares Update’s JSON bridge.
+Log: `logs/kuikly_console.log` tag `CallKotlinPerf`.
+
+---
+
 ## How to re-run
+
+### OHOS
 
 Open demo page `CallKotlinPerfPage` (router / in-app navigation; Want `--ps pageName` is not wired).
 Debug OHOS build only — native `CallKotlinPerfTestModule` is `#ifndef NDEBUG` / CMake Debug-gated.
@@ -106,8 +172,17 @@ hdc -t LNG0223C13000049 shell aa start -a EntryAbility -b com.tencent.kuiklyohos
 # Navigate to CallKotlinPerfPage; hilog tag CallKotlinPerf — BASIC / PHASES_CPP / DONE
 ```
 
+### iOS
+
+Debug iosApp only — `CallKotlinPerfTestModule` is `#if DEBUG`.
+
+```bash
+# Build + launch simulator; open CallKotlinPerfPage via demo router
+# Capture: os_log / Xcode console tag CallKotlinPerf — NESTED_LIFECYCLE / BASIC / PHASES_CPP / DONE
+```
+
 ### Follow-ups (optional)
 
 - Prefer Map/Array at Native call sites instead of pre-serializing JSON strings.
-- Cache Kotlin-side pageId string to skip `toKString` on LAYOUT_VIEW.
+- Cache Kotlin-side pageId string to skip `toKString` on LAYOUT_VIEW (OHOS).
 - Measure try/catch-off build to shrink LAYOUT FFI residual.

--- a/docs/callKotlin-perf-progress.md
+++ b/docs/callKotlin-perf-progress.md
@@ -1,0 +1,113 @@
+# callKotlin Interop Performance Optimization (OHOS)
+
+> Goal: optimize Native (`core-render-ohos`) → Kotlin `callKotlin` interop performance.
+> Device: physical `LNG0223C13000049` (primary); earlier numbers also from emulator.
+
+## Progress Log
+
+| Step | Status | Notes |
+|------|--------|-------|
+| 1. Understand code (render-ohos / core-ksp / core) | DONE | |
+| 2. Demo page + OHOS measurement | DONE | `CallKotlinPerfPage` + ohosApp `CallKotlinPerfTestModule` |
+| 3. Optimization plan + execute | DONE | A/B/C/D tried |
+| 4. Re-test early opts; keep what matters | DONE | Keep A, B, D; drop C |
+| 5. Phase distribution + long JSON | DONE | |
+| 6. Lazy cJSON* JSONObject proxy | DONE | Flat ~50–70µs even at 3MB if unread |
+
+---
+
+## Keep / Drop verdict (device A/B, 2026-08-03)
+
+Re-measured on `LNG0223C13000049` with and without KSP opt B (`logs/kuikly_ab_with_opts.log` vs `logs/kuikly_ab_no_ksp.log`).
+
+| Opt | What | Device evidence | Verdict |
+|-----|------|-----------------|---------|
+| **A** | Cache `instanceIdValue_` on `KRRenderCore` | Within same run: `layout_full` 27.8µs vs `layout_cachedArg0` 24.9µs (~**10% / ~3µs**) | **KEEP** — small absolute, cheap, always on hot path |
+| **B** | KSP OHOS entry: method-specific `toAny`, no lambda, codegen try/catch | LAYOUT `cpp_callKotlin`: **37µs (with B)** vs **76µs (without B)** ≈ **2×** | **KEEP** — matters for high-frequency small calls |
+| **C** | Eager structured Map ARRAY (`__kuikly_map_v1__`) | Superseded by D; never called from `toCValue` after D | **DROP** — removed dead C++/Kotlin marker path |
+| **D** | Lazy `NATIVE_JSON` (cJSON* + refcount) | 64KB FIRE string **~7.8ms** vs lazy **~60–70µs**; scales flat when unread | **KEEP** — dominant win for Map/Array events |
+
+Notes:
+- FIRE string path is dominated by `toKString` + `JSONObject` parse; A/B do not change that.
+- Opt B does not materially change large-string FIRE or lazy Map numbers (noise-level).
+- Absolute LAYOUT numbers vary by device thermal/load; relative A/B deltas above are from paired runs.
+
+---
+
+## Call path
+
+```
+KRRenderCore::CallKotlinMethod
+  └─ instanceIdValue_ (cached)                         // A
+  └─ argN->toCValue()                                  // Map → NATIVE_JSON (D)
+  └─ callKotlin_(...)
+       └─ KSP staticCFunction (method-specific toAny)  // B
+            └─ BridgeManager → fireViewEvent
+                 └─ TypeUtils → CJsonJSONObject (ohos) / String
+                      └─ BridgeManager → fireViewEvent (String|JSONObject)
+```
+
+---
+
+## Measurement notes
+
+Kotlin-side phase counters in `core` were removed (too intrusive on Bridge/TypeUtils).
+Bench timing is C++-only in ohosApp `CallKotlinPerfTestModule`
+(`cpp_toCValue_ns_per` / `cpp_callKotlin_ns_per`). For deeper Kotlin breakdowns use
+platform profilers (HiTrace / Perfetto), not framework hooks.
+
+### Lazy cJSON* bridge (kept)
+
+Map/Array `toCValue` passes `NATIVE_JSON` (`KuiklyCJsonOwner*` in `longValue`, refcounted).
+Kotlin ohosArm64 `CJsonJSONObject.fromOwner` **retain**s; Cleaner **release**s on GC. C++ dtor also **release**s.
+
+| ~bytes | string (legacy) | lazy cJSON (unread) | speedup |
+|------:|----------------:|--------------------:|--------:|
+| 1K | ~193µs | ~67µs | ~3× |
+| 64K | ~7.8ms | ~69µs | ~110× |
+| 3MB | ~326ms | ~48µs | ~6800× |
+
+---
+
+## Optimizations kept in tree
+
+### A. Cache instanceId on `KRRenderCore` (`core-render-ohos`)
+- Construct `instanceIdValue_` once in ctor; reuse in `CallKotlinMethod`.
+
+### B. KSP OHOS entry hot path (`core-ksp`)
+- Remove per-call `callKotlinClosure` lambda allocation.
+- Codegen-time try/catch (use `catchException` flag) instead of runtime branch.
+- Method-specific `toAny` arity:
+  - `LAYOUT_VIEW` → arg0 only
+  - `FIRE_VIEW_EVENT` → arg0–arg3
+  - `FIRE_CALLBACK` / `UPDATE` / `DESTROY` → arg0–arg2
+  - `CREATE_INSTANCE` → reuse `asString()` as instanceId (no double convert)
+
+### D. Lazy cJSON* bridge (OHOS only)
+- C++ Map/Array `toCValue` → `NATIVE_JSON` (opaque `shared_ptr<KuiklyCJsonOwner>` handle).
+- Kotlin **ohosArm64**: `CJsonJSONObject` subclass + `CJsonNative` FFI; `retain` returns a new shared handle; `TypeUtils` wraps owner → `JSONObject`.
+- **commonMain** stays free of cJSON: `JSONObject` is `open` for subclassing; `fireViewEvent` accepts `String` or `JSONObject`.
+- Field access via `kuikly_cjson_*`; large leaves not copied until read.
+
+### Dropped: C. Eager structured Map bridge
+- Removed `ToStructuredMapLocked` / `ToJsonMapOrArrayLocked` and `__kuikly_map_v1__` Kotlin decode.
+- Was ~2.5–3.5× vs string JSON but still paid `toKString` on large leaves; D is strictly better for unread/partial-read Maps.
+
+---
+
+## How to re-run
+
+Open demo page `CallKotlinPerfPage` (router / in-app navigation; Want `--ps pageName` is not wired).
+Debug OHOS build only — native `CallKotlinPerfTestModule` is `#ifndef NDEBUG` / CMake Debug-gated.
+
+```bash
+hdc -t LNG0223C13000049 shell aa force-stop com.tencent.kuiklyohosdemo
+hdc -t LNG0223C13000049 shell aa start -a EntryAbility -b com.tencent.kuiklyohosdemo
+# Navigate to CallKotlinPerfPage; hilog tag CallKotlinPerf — BASIC / PHASES_CPP / DONE
+```
+
+### Follow-ups (optional)
+
+- Prefer Map/Array at Native call sites instead of pre-serializing JSON strings.
+- Cache Kotlin-side pageId string to skip `toKString` on LAYOUT_VIEW.
+- Measure try/catch-off build to shrink LAYOUT FFI residual.

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		AAEA1C808D295174487047AD /* libPods-iosApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 389E5FAFF97F19DA513B54A5 /* libPods-iosApp.a */; };
 		AFEB55D22D9C17820014FCBD /* Satisfy-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AFEB55D12D9C17820014FCBD /* Satisfy-Regular.ttf */; };
 		C125EBCC2D96FBE200FBFA34 /* KRAPNGViewHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = C125EBCA2D96FBE200FBFA34 /* KRAPNGViewHandler.m */; };
+		C4A11F012E3A000100CA11F0 /* CallKotlinPerfTestModule.m in Sources */ = {isa = PBXBuildFile; fileRef = C4A11F002E3A000100CA11F0 /* CallKotlinPerfTestModule.m */; };
 		FF047757288C4842008D3F39 /* NSObject+RIJCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = FF047756288C4842008D3F39 /* NSObject+RIJCategory.m */; };
 		FF05C63C29C84FFF00C5E02A /* KuiklyRenderViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FF05C63A29C84FFF00C5E02A /* KuiklyRenderViewController.m */; };
 		FF05C63F29C850BC00C5E02A /* KuiklyRenderComponentExpandHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FF05C63E29C850BC00C5E02A /* KuiklyRenderComponentExpandHandler.m */; };
@@ -50,6 +51,8 @@
 		AFEB55D12D9C17820014FCBD /* Satisfy-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Satisfy-Regular.ttf"; sourceTree = "<group>"; };
 		C125EBCA2D96FBE200FBFA34 /* KRAPNGViewHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KRAPNGViewHandler.m; sourceTree = "<group>"; };
 		C125EBCB2D96FBE200FBFA34 /* KRAPNGViewHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KRAPNGViewHandler.h; sourceTree = "<group>"; };
+		C4A11EFF2E3A000100CA11F0 /* CallKotlinPerfTestModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CallKotlinPerfTestModule.h; sourceTree = "<group>"; };
+		C4A11F002E3A000100CA11F0 /* CallKotlinPerfTestModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CallKotlinPerfTestModule.m; sourceTree = "<group>"; };
 		C57F6971A5640F2A8FDA3C78 /* Pods-iosApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.release.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.release.xcconfig"; sourceTree = "<group>"; };
 		F1A0CBBBE932EBF38B00760C /* Pods-iosApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.debug.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.debug.xcconfig"; sourceTree = "<group>"; };
 		FF047755288C4842008D3F39 /* NSObject+RIJCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+RIJCategory.h"; sourceTree = "<group>"; };
@@ -232,6 +235,8 @@
 			children = (
 				FF05C64129C851A500C5E02A /* KRBridgeModule.h */,
 				FF05C64029C851A500C5E02A /* KRBridgeModule.m */,
+				C4A11EFF2E3A000100CA11F0 /* CallKotlinPerfTestModule.h */,
+				C4A11F002E3A000100CA11F0 /* CallKotlinPerfTestModule.m */,
 				3A622B9A2AB052B0002410B8 /* KRNewTestModule.h */,
 				3A622B992AB052B0002410B8 /* KRNewTestModule.m */,
 				3A622B972AB052B0002410B8 /* TDFTestModule.h */,
@@ -323,8 +328,6 @@
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
-			outputPaths = (
-			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks.sh\"\n";
@@ -364,8 +367,6 @@
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-resources-${CONFIGURATION}-output-files.xcfilelist",
 			);
-			outputPaths = (
-			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-resources.sh\"\n";
@@ -389,6 +390,7 @@
 				FF5BF1702B6EC62D001C5632 /* KRFontHanlder.m in Sources */,
 				FF151BB82A23A7E800D2BBED /* KRVideoViewHandler.m in Sources */,
 				3A622B9C2AB052B0002410B8 /* KRNewTestModule.m in Sources */,
+				C4A11F012E3A000100CA11F0 /* CallKotlinPerfTestModule.m in Sources */,
 				3AF526722A9309C300A93682 /* RootViewController.m in Sources */,
 				FF05C64229C851A500C5E02A /* KRBridgeModule.m in Sources */,
 				FF05C63C29C84FFF00C5E02A /* KuiklyRenderViewController.m in Sources */,

--- a/iosApp/iosApp/KuiklyRenderExpand/Modules/CallKotlinPerfTestModule.h
+++ b/iosApp/iosApp/KuiklyRenderExpand/Modules/CallKotlinPerfTestModule.h
@@ -13,11 +13,18 @@
  * limitations under the License.
  */
 
-package com.tencent.kuikly.demo.pages.base
+#import <Foundation/Foundation.h>
+#import "KRBaseModule.h"
 
-import com.tencent.kuikly.core.nvi.serialization.json.testAppleNestedNSDictionaryLifecycle
+NS_ASSUME_NONNULL_BEGIN
 
-internal actual fun runNestedCJsonLifecycleTest(ownerHandle: Long): String {
-    // ownerHandle is a sentinel from native; lifecycle uses a local NSDictionary tree.
-    return testAppleNestedNSDictionaryLifecycle()
-}
+#if DEBUG
+/**
+ * Demo/test-only callKotlin interop microbench (DEBUG only).
+ * Class name must match Kotlin MODULE_NAME for KRClassFromString lookup.
+ */
+@interface CallKotlinPerfTestModule : KRBaseModule
+@end
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/iosApp/iosApp/KuiklyRenderExpand/Modules/CallKotlinPerfTestModule.m
+++ b/iosApp/iosApp/KuiklyRenderExpand/Modules/CallKotlinPerfTestModule.m
@@ -1,0 +1,257 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "CallKotlinPerfTestModule.h"
+
+#if DEBUG
+
+#import <QuartzCore/QuartzCore.h>
+#import "KuiklyRenderView.h"
+#import "KuiklyRenderCore.h"
+#import "KRConvertUtil.h"
+#import "NSObject+KR.h"
+
+// Private declarations — keep test-only APIs out of public headers.
+@interface KuiklyRenderView (CallKotlinPerfPrivate)
+- (void)perf_callWithMethod:(KuiklyRenderContextMethod)method args:(NSArray *)args;
+- (NSString *)perf_instanceId;
+@end
+
+@interface KuiklyRenderCore (CallKotlinPerfPrivate)
+- (void)perf_callWithMethod:(KuiklyRenderContextMethod)method args:(NSArray *)args;
+- (NSString *)perf_instanceId;
+@end
+
+@implementation CallKotlinPerfTestModule
+
+static int64_t KRPerfNowNs(void) {
+    return (int64_t)(CACurrentMediaTime() * 1e9);
+}
+
+static double KRPerfPer(int64_t total, int n) {
+    return n > 0 ? (double)total / (double)n : 0.0;
+}
+
+static NSDictionary *KRPerfParams(NSDictionary *args) {
+    id param = args[KR_PARAM_KEY];
+    if ([param isKindOfClass:[NSDictionary class]]) {
+        return (NSDictionary *)param;
+    }
+    if ([param isKindOfClass:[NSString class]]) {
+        return [(NSString *)param hr_stringToDictionary] ?: @{};
+    }
+    return @{};
+}
+
+static NSDictionary *KRPerfMakePayload(NSUInteger targetBytes) {
+    if (targetBytes <= 8) {
+        return @{};
+    }
+    NSUInteger pad = targetBytes - 8;
+    char *buf = (char *)malloc(pad + 1);
+    if (!buf) {
+        return @{};
+    }
+    memset(buf, 'x', pad);
+    buf[pad] = '\0';
+    NSString *s = [[NSString alloc] initWithBytesNoCopy:buf length:pad encoding:NSUTF8StringEncoding freeWhenDone:YES];
+    return @{@"d": s ?: @""};
+}
+
+/** Modes that force legacy JSON stringify before call. */
+static BOOL KRPerfModeForceString(NSString *mode) {
+    return [mode isEqualToString:@"fire"] ||
+           [mode isEqualToString:@"update"] ||
+           [mode isEqualToString:@"callback"];
+}
+
+/** Modes that pass NSDictionary through (lazy bridge). */
+static BOOL KRPerfModeLazyDict(NSString *mode) {
+    return [mode isEqualToString:@"map"] ||
+           [mode isEqualToString:@"update_map"] ||
+           [mode isEqualToString:@"callback_map"];
+}
+
+static BOOL KRPerfModeHasJsonPayload(NSString *mode) {
+    return KRPerfModeForceString(mode) || KRPerfModeLazyDict(mode) || [mode isEqualToString:@"both"];
+}
+
+- (KuiklyRenderView *)perfRoot {
+    if ([self.hr_rootView isKindOfClass:[KuiklyRenderView class]]) {
+        return (KuiklyRenderView *)self.hr_rootView;
+    }
+    return nil;
+}
+
+- (void)perfInvoke:(KuiklyRenderView *)root
+              mode:(NSString *)mode
+        instanceId:(NSString *)instanceId
+             arg:(id)arg {
+    if ([mode isEqualToString:@"fire"] || [mode isEqualToString:@"map"] || [mode isEqualToString:@"both"]) {
+        [root perf_callWithMethod:KuiklyRenderContextMethodFireViewEvent
+                             args:@[instanceId, @1, @"perf", arg]];
+    } else if ([mode isEqualToString:@"update"] || [mode isEqualToString:@"update_map"]) {
+        // Same toBridgeJSONObject path as CreateInstance pageData (arg2).
+        [root perf_callWithMethod:KuiklyRenderContextMethodUpdateInstance
+                             args:@[instanceId, @"perf_update", arg]];
+    } else if ([mode isEqualToString:@"callback"] || [mode isEqualToString:@"callback_map"]) {
+        [root perf_callWithMethod:KuiklyRenderContextMethodFireCallback
+                             args:@[instanceId, @"0", arg]];
+    }
+}
+
+- (NSString *)bench:(NSDictionary *)args {
+    KuiklyRenderView *root = [self perfRoot];
+    if (!root) {
+        return @"{\"error\":\"no root\"}";
+    }
+    NSDictionary *params = KRPerfParams(args);
+    int iterations = MAX(1, [params[@"iterations"] intValue] ?: 5000);
+    NSString *instanceId = [root perf_instanceId];
+    const int warmup = 100;
+    for (int i = 0; i < warmup; i++) {
+        [root perf_callWithMethod:KuiklyRenderContextMethodLayoutView args:@[instanceId]];
+    }
+    int64_t layoutNs = 0;
+    {
+        int64_t t0 = KRPerfNowNs();
+        for (int i = 0; i < iterations; i++) {
+            [root perf_callWithMethod:KuiklyRenderContextMethodLayoutView args:@[instanceId]];
+        }
+        layoutNs = KRPerfNowNs() - t0;
+    }
+    int64_t fireNs = 0;
+    {
+        NSDictionary *payload = @{@"k": @1};
+        int64_t t0 = KRPerfNowNs();
+        for (int i = 0; i < iterations; i++) {
+            [root perf_callWithMethod:KuiklyRenderContextMethodFireViewEvent
+                                 args:@[instanceId, @1, @"click", payload]];
+        }
+        fireNs = KRPerfNowNs() - t0;
+    }
+    return [NSString stringWithFormat:
+            @"{\"iterations\":%d,\"layout_ns_per\":%.2f,\"fireEvent_ns_per\":%.2f}",
+            iterations, KRPerfPer(layoutNs, iterations), KRPerfPer(fireNs, iterations)];
+}
+
+- (NSString *)benchPhases:(NSDictionary *)args {
+    KuiklyRenderView *root = [self perfRoot];
+    if (!root) {
+        return @"{\"error\":\"no root\"}";
+    }
+    NSDictionary *params = KRPerfParams(args);
+    int iterations = MAX(1, [params[@"iterations"] intValue] ?: 2000);
+    int jsonBytes = MAX(0, [params[@"jsonBytes"] intValue] ?: 1024);
+    NSString *mode = params[@"mode"] ?: @"fire";
+    NSArray *allowed = @[
+        @"layout", @"fire", @"map", @"both",
+        @"update", @"update_map", @"callback", @"callback_map"
+    ];
+    if (![allowed containsObject:mode]) {
+        mode = @"fire";
+    }
+    NSString *instanceId = [root perf_instanceId];
+    NSMutableDictionary *result = [NSMutableDictionary dictionary];
+    result[@"mode"] = mode;
+    result[@"iterations"] = @(iterations);
+    result[@"json_bytes"] = @(jsonBytes);
+
+    if ([mode isEqualToString:@"layout"] || [mode isEqualToString:@"both"]) {
+        for (int i = 0; i < 50; i++) {
+            [root perf_callWithMethod:KuiklyRenderContextMethodLayoutView args:@[instanceId]];
+        }
+        int64_t t0 = KRPerfNowNs();
+        for (int i = 0; i < iterations; i++) {
+            [root perf_callWithMethod:KuiklyRenderContextMethodLayoutView args:@[instanceId]];
+        }
+        int64_t callNs = KRPerfNowNs() - t0;
+        result[@"calls"] = @(iterations);
+        result[@"payload"] = @"none";
+        result[@"method"] = @"LayoutView";
+        result[@"cpp_toCValue_ns_per"] = @(0);
+        result[@"cpp_callKotlin_ns_per"] = @(KRPerfPer(callNs, iterations));
+        result[@"cpp_total_ns_per"] = @(KRPerfPer(callNs, iterations));
+    }
+
+    if (KRPerfModeHasJsonPayload(mode)) {
+        NSDictionary *payload = KRPerfMakePayload((NSUInteger)jsonBytes);
+        BOOL forceString = KRPerfModeForceString(mode) || [mode isEqualToString:@"both"];
+        // For mode=both keep fire semantics (string); map modes never stringify.
+        if (KRPerfModeLazyDict(mode)) {
+            forceString = NO;
+        }
+        int64_t coldConvertNs = 0;
+        if (forceString) {
+            int64_t c0 = KRPerfNowNs();
+            (void)[KRConvertUtil hr_dictionaryToJSON:payload];
+            coldConvertNs = KRPerfNowNs() - c0;
+        }
+
+        NSString *invokeMode = mode;
+        if ([mode isEqualToString:@"both"]) {
+            invokeMode = @"fire";
+        }
+
+        for (int i = 0; i < 20; i++) {
+            id arg = forceString ? [KRConvertUtil hr_dictionaryToJSON:payload] : payload;
+            [self perfInvoke:root mode:invokeMode instanceId:instanceId arg:arg];
+        }
+        int64_t convertTotal = 0;
+        int64_t callTotal = 0;
+        for (int i = 0; i < iterations; i++) {
+            id arg = payload;
+            if (forceString) {
+                int64_t c0 = KRPerfNowNs();
+                arg = [KRConvertUtil hr_dictionaryToJSON:payload];
+                convertTotal += KRPerfNowNs() - c0;
+            }
+            int64_t t0 = KRPerfNowNs();
+            [self perfInvoke:root mode:invokeMode instanceId:instanceId arg:arg];
+            callTotal += KRPerfNowNs() - t0;
+        }
+
+        NSString *methodName = @"FireViewEvent";
+        if ([mode hasPrefix:@"update"]) {
+            methodName = @"UpdateInstance";
+        } else if ([mode hasPrefix:@"callback"]) {
+            methodName = @"FireCallback";
+        }
+
+        result[@"calls"] = @(iterations);
+        result[@"method"] = methodName;
+        result[@"payload"] = forceString ? @"string" : @"lazy_nsdict";
+        result[@"cpp_toCValue_ns_per"] = @(forceString ? KRPerfPer(convertTotal, iterations) : 0);
+        result[@"cpp_callKotlin_ns_per"] = @(KRPerfPer(callTotal, iterations));
+        result[@"cpp_total_ns_per"] = @(KRPerfPer(convertTotal + callTotal, iterations));
+        result[@"cold_toCValue_json_ns"] = @(coldConvertNs);
+    }
+
+    NSData *data = [NSJSONSerialization dataWithJSONObject:result options:0 error:nil];
+    return data ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] : @"{}";
+}
+
+- (NSString *)benchJson:(NSDictionary *)args {
+    return [self benchPhases:args];
+}
+
+- (NSString *)exportNestedOwner:(NSDictionary *)args {
+    (void)args;
+    return @"{\"owner\":1}";
+}
+
+@end
+
+#endif  // DEBUG

--- a/ohosApp/entry/src/main/cpp/CMakeLists.txt
+++ b/ohosApp/entry/src/main/cpp/CMakeLists.txt
@@ -12,12 +12,18 @@ else()
     message(FATAL_ERROR "PACKAGE_FIND_FILE not found. 请检查CMake构建环境")
 endif()
 
+set(KUIKLY_RENDER_CPP_ROOT ${KUIKLY_ENTRY_ROOT_PATH}/../../../../../core-render-ohos/src/main/cpp)
+
 set(SOURCE_SET
         napi_init.cpp
 )
 
 add_library(kuikly_entry SHARED ${SOURCE_SET})
-include_directories(${KUIKLY_ENTRY_ROOT_PATH} ${KUIKLY_ENTRY_ROOT_PATH}/include)
+include_directories(
+        ${KUIKLY_ENTRY_ROOT_PATH}
+        ${KUIKLY_ENTRY_ROOT_PATH}/include
+        ${KUIKLY_RENDER_CPP_ROOT}
+)
 
 # Kuikly SDK
 add_library(kuikly_render ALIAS render::kuikly)

--- a/ohosApp/entry/src/main/cpp/napi_init.cpp
+++ b/ohosApp/entry/src/main/cpp/napi_init.cpp
@@ -29,6 +29,7 @@
 #include <Kuikly/Kuikly.h>
 #include "napi/native_api.h"
 #include "thirdparty/biz_entry/libshared_api.h"
+#include "libohos_render/export/IKRRenderModuleExport.h"
 
 static std::string customFontPath;
 static std::string customImagePath;


### PR DESCRIPTION
  ## Summary
  - Speed up Native→Kotlin `callKotlin` for large/unread JSON by passing structured payloads instead of stringify + parse.
  - **OHOS:** Map/Array → `NATIVE_JSON` (shared_ptr cJSON) → `LazyCJsonMap` inside final `JSONObject`; Create pageData and Update/SendEvent use the same path (no `JSON.stringify` / `toString()`).
  - **iOS:** Pass `NSDictionary` through ObjC; wrap at KSP entry via `toKotlinBridgeArg` → `LazyNSDictionaryMap` before `BridgeManager` (parallel to OHOS `toAny`).
  - Keep hot-path extras that measured well: instanceId cache (A), KSP entry without per-call lambda (B).
  - Debug-only `CallKotlinPerf` harness + demo page for Fire/Update/Callback string vs lazy.
  ## Bench (unread `cpp_callKotlin`)
  **OHOS device** — Fire string → lazy:
  - 1KB: 190µs → 68µs (~3×)
  - 64KB: 7.9ms → 61µs (~130×)
  - 3MB: 354ms → 61µs (~5800×)
  **iOS simulator** — Fire string → lazy:
  - 1KB: ~19µs → 1.3µs
  - 64KB: ~1ms → 1.3µs
  - 3MB: ~57ms → 1.3µs
  ## Test plan
  - [ ] OHOS Debug HAP: open `CallKotlinPerfPage` → hilog `CallKotlinPerf` shows `NESTED_LIFECYCLE` / `PHASES_CPP` / `DONE`
  - [ ] iOS Debug: same page → console tag `CallKotlinPerf` completes full fire/update/callback sweep
  - [ ] Smoke Create/Update with page params and lifecycle events (Record/dict, not only strings)
  - [ ] Release build: confirm `CallKotlinPerfTestModule` omitted (`NDEBUG` / non-DEBUG)