### PR TITLE
perf(ohos): apply no-side-effect size opts for KN and libkuikly

### DIFF
--- a/core-render-ohos/build-profile.json5
+++ b/core-render-ohos/build-profile.json5
@@ -14,7 +14,7 @@
     {
       "name": "release",
       "externalNativeOptions": {
-        "arguments": "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+        "arguments": "-DCMAKE_BUILD_TYPE=RelWithDebInfo -DKUIKLY_OHOS_SIZE_OPTS=ON"
       },
       "arkOptions": {
         "obfuscation": {

--- a/core-render-ohos/build-profile.json5
+++ b/core-render-ohos/build-profile.json5
@@ -14,7 +14,7 @@
     {
       "name": "release",
       "externalNativeOptions": {
-        "arguments": "-DCMAKE_BUILD_TYPE=RelWithDebInfo -DKUIKLY_OHOS_SIZE_OPTS=ON"
+        "arguments": "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
       },
       "arkOptions": {
         "obfuscation": {

--- a/core-render-ohos/src/main/cpp/CMakeLists.txt
+++ b/core-render-ohos/src/main/cpp/CMakeLists.txt
@@ -122,6 +122,25 @@ target_compile_options(kuikly PRIVATE
         $<$<COMPILE_LANGUAGE:CXX>:-Wconstexpr-not-const>
         $<$<COMPILE_LANGUAGE:CXX>:-Werror=constexpr>
 )
+
+# Package-size opts with no runtime perf impact (PPT slide4: 副作用=无).
+# Toggle via -DKUIKLY_OHOS_SIZE_OPTS=ON|OFF for A/B comparison.
+option(KUIKLY_OHOS_SIZE_OPTS "Enable OHOS size opts without perf impact" ON)
+if(KUIKLY_OHOS_SIZE_OPTS)
+    target_compile_options(kuikly PRIVATE
+            -ffunction-sections
+            -fdata-sections
+            # 跨 .so 被引用的符号必须标 KUIKLY_EXPORT，否则加载期解析失败直接 SIGSEGV。
+            # 消费方：libshared.so(K/N) 用 com_tencent_kuikly_*，libkuikly_entry.so 用 KRAnyData*/KRRegister*Adapter 等。
+            -fvisibility=hidden
+            -fvisibility-inlines-hidden
+    )
+    target_link_options(kuikly PRIVATE
+            -Wl,--gc-sections
+            -Wl,--pack-dyn-relocs=relr
+            -Wl,--hash-style=gnu
+    )
+endif()
 target_include_directories(kuikly PUBLIC ${HMOS_SDK_NATIVE}/sysroot/usr/include)
 target_link_directories(kuikly PUBLIC ${HMOS_SDK_NATIVE}/sysroot/usr/lib/aarch64-linux-ohos)
 target_include_directories(kuikly PRIVATE ${NATIVERENDER_ROOT_PATH}

--- a/core-render-ohos/src/main/cpp/CMakeLists.txt
+++ b/core-render-ohos/src/main/cpp/CMakeLists.txt
@@ -123,7 +123,6 @@ target_compile_options(kuikly PRIVATE
         $<$<COMPILE_LANGUAGE:CXX>:-Werror=constexpr>
 )
 
-# Package-size opts with no runtime perf impact (PPT slide4: 副作用=无).
 # Default follows build type: OFF for Debug, ON for Release/RelWithDebInfo/MinSizeRel
 # (i.e. the NDEBUG configurations). Override with -DKUIKLY_OHOS_SIZE_OPTS=ON|OFF.
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/core-render-ohos/src/main/cpp/CMakeLists.txt
+++ b/core-render-ohos/src/main/cpp/CMakeLists.txt
@@ -124,8 +124,16 @@ target_compile_options(kuikly PRIVATE
 )
 
 # Package-size opts with no runtime perf impact (PPT slide4: 副作用=无).
-# Toggle via -DKUIKLY_OHOS_SIZE_OPTS=ON|OFF for A/B comparison.
-option(KUIKLY_OHOS_SIZE_OPTS "Enable OHOS size opts without perf impact" ON)
+# Default follows build type: OFF for Debug, ON for Release/RelWithDebInfo/MinSizeRel
+# (i.e. the NDEBUG configurations). Override with -DKUIKLY_OHOS_SIZE_OPTS=ON|OFF.
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(_KUIKLY_OHOS_SIZE_OPTS_DEFAULT OFF)
+else()
+    set(_KUIKLY_OHOS_SIZE_OPTS_DEFAULT ON)
+endif()
+option(KUIKLY_OHOS_SIZE_OPTS
+        "Enable OHOS size opts without perf impact (auto: ON unless Debug)"
+        ${_KUIKLY_OHOS_SIZE_OPTS_DEFAULT})
 if(KUIKLY_OHOS_SIZE_OPTS)
     target_compile_options(kuikly PRIVATE
             -ffunction-sections

--- a/core-render-ohos/src/main/cpp/libohos_render/api/include/Kuikly/KRAnyData.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/api/include/Kuikly/KRAnyData.h
@@ -17,6 +17,7 @@
 #define CORE_RENDER_OHOS_KRANYDATA_H
 
 #include "stdint.h"
+#include "KuiklyExport.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,51 +32,51 @@ typedef void *KRAnyData;
  * 检测是否是一个字符串
  * @param data 输入的对象
  */
-bool KRAnyDataIsString(KRAnyData data);
+KUIKLY_EXPORT bool KRAnyDataIsString(KRAnyData data);
 
 /**
  * 检测是否是一个Int
  * @param data 输入的对象
  * @return
  */
-bool KRAnyDataIsInt(KRAnyData data);
+KUIKLY_EXPORT bool KRAnyDataIsInt(KRAnyData data);
 
 /**
  * 检测是否是一个Long
  * @param data 输入的对象
  */
-bool KRAnyDataIsLong(KRAnyData data);
+KUIKLY_EXPORT bool KRAnyDataIsLong(KRAnyData data);
 
 /**
  * 检测是否是一个Float
  * @param data 输入的对象
  */
-bool KRAnyDataIsFloat(KRAnyData data);
+KUIKLY_EXPORT bool KRAnyDataIsFloat(KRAnyData data);
 
 /**
  * 检测是否是一个Bool
  * @param data 输入的对象
  */
-bool KRAnyDataIsBool(KRAnyData data);
+KUIKLY_EXPORT bool KRAnyDataIsBool(KRAnyData data);
 
 /**
  * 检测是否是一个Bytes
  * @param data 输入的对象
  */
-bool KRAnyDataIsBytes(KRAnyData data);
+KUIKLY_EXPORT bool KRAnyDataIsBytes(KRAnyData data);
 
 /**
  * 检测是否是一个Array
  * @param data 输入的对象
  */
-bool KRAnyDataIsArray(KRAnyData data);
+KUIKLY_EXPORT bool KRAnyDataIsArray(KRAnyData data);
 
 /**
  * 检测是否是一个 Map
  * @param data 输入的对象
  * @return 如果是 Map 类型返回 true，否则返回 false
  */
-bool KRAnyDataIsMap(KRAnyData data);
+KUIKLY_EXPORT bool KRAnyDataIsMap(KRAnyData data);
 
 /**
  * @brief Map 遍历回调函数类型
@@ -93,7 +94,7 @@ typedef void (*KRAnyDataMapVisitor)(const char* key, KRAnyData value, void* user
  * @return KRAnDataErrorCode
  * @note 这是遍历 Map 的推荐方式，无需手动管理内存
  */
-int KRAnyDataVisitMap(KRAnyData data, KRAnyDataMapVisitor visitor, void* userData);
+KUIKLY_EXPORT int KRAnyDataVisitMap(KRAnyData data, KRAnyDataMapVisitor visitor, void* userData);
 
 
 /**
@@ -103,14 +104,14 @@ int KRAnyDataVisitMap(KRAnyData data, KRAnyDataMapVisitor visitor, void* userDat
  * @param value 输出参数，存储获取的值句柄，仅当前scope有效
  * @return KRAnDataErrorCode
  */
-int KRAnyDataGetMapValue(KRAnyData data, const char* key, KRAnyData* value);
+KUIKLY_EXPORT int KRAnyDataGetMapValue(KRAnyData data, const char* key, KRAnyData* value);
 
 /**
  * 返回字符串内容
  * @param data
  * @return 字符串指针，仅当前scope有效，请勿转移指针，如有需要请拷贝字符串内容。
  */
-const char *KRAnyDataGetString(KRAnyData data);
+KUIKLY_EXPORT const char *KRAnyDataGetString(KRAnyData data);
 
 /**
  * @brief KRAnData错误码
@@ -131,7 +132,7 @@ typedef enum {
  * @param value 输出参数，存储获取的整数值
  * @return KRAnDataErrorCode
  */
-int KRAnyDataGetInt(KRAnyData data, int32_t* value);
+KUIKLY_EXPORT int KRAnyDataGetInt(KRAnyData data, int32_t* value);
 
 /**
  * @brief 从 KRAnyData 中提取 int64_t 值
@@ -139,7 +140,7 @@ int KRAnyDataGetInt(KRAnyData data, int32_t* value);
  * @param value 输出参数指针，用于存储提取的长整数值（int64_t 类型）
  * @return KRAnDataErrorCode
  */
-int KRAnyDataGetLong(KRAnyData data, int64_t* value);
+KUIKLY_EXPORT int KRAnyDataGetLong(KRAnyData data, int64_t* value);
 
 /**
  * @brief 从 KRAnyData 中提取 float 值
@@ -148,7 +149,7 @@ int KRAnyDataGetLong(KRAnyData data, int64_t* value);
  * @return KRAnDataErrorCode
  * @note 若数据为双精度浮点型（double）会自动进行精度转换
  */
-int KRAnyDataGetFloat(KRAnyData data, float* value);
+KUIKLY_EXPORT int KRAnyDataGetFloat(KRAnyData data, float* value);
 
 /**
  * @brief 从 KRAnyData 中提取 bool 值
@@ -156,7 +157,7 @@ int KRAnyDataGetFloat(KRAnyData data, float* value);
  * @param value 输出参数指针，用于存储提取的布尔值（bool 类型）
  * @return KRAnDataErrorCode
  */
-int KRAnyDataGetBool(KRAnyData data, bool* value);
+KUIKLY_EXPORT int KRAnyDataGetBool(KRAnyData data, bool* value);
 
 /**
  * @brief 从 KRAnyData 中提取 二进制 值
@@ -165,7 +166,7 @@ int KRAnyDataGetBool(KRAnyData data, bool* value);
  * @param size 用于接收二进制数据的长度
  * @return KRAnDataErrorCode
  */
-int KRAnyDataGetBytes(KRAnyData data, const char** value, int *size);
+KUIKLY_EXPORT int KRAnyDataGetBytes(KRAnyData data, const char** value, int *size);
 
 /**
  * @brief 从 KRAnyData 中提取 二进制 值
@@ -173,7 +174,7 @@ int KRAnyDataGetBytes(KRAnyData data, const char** value, int *size);
  * @param value 用于接收字符串数据地址
  * @return KRAnDataErrorCode
  */
-int KRAnyDataGetStr(KRAnyData data, const char** value);
+KUIKLY_EXPORT int KRAnyDataGetStr(KRAnyData data, const char** value);
 
 /**
  * @brief 从 KRAnyData 中提取其中数组指定的元素
@@ -182,7 +183,7 @@ int KRAnyDataGetStr(KRAnyData data, const char** value);
  * @param index 元素索引（从0开始）
  * @return KRAnDataErrorCode
  */
-int KRAnyDataGetArrayElement(KRAnyData data, KRAnyData* value, int index);
+KUIKLY_EXPORT int KRAnyDataGetArrayElement(KRAnyData data, KRAnyData* value, int index);
 
 /**
  * @brief 从 KRAnyData 中提取其中数组长度
@@ -190,48 +191,48 @@ int KRAnyDataGetArrayElement(KRAnyData data, KRAnyData* value, int index);
  * @param size 输出参数，存储数组的长度
  * @return KRAnDataErrorCode
  */
-int KRAnyDataGetArraySize(KRAnyData data, int* size);
+KUIKLY_EXPORT int KRAnyDataGetArraySize(KRAnyData data, int* size);
 
 /**
  * @brief 创建一个新的 KRAnyData 值为 null 类型
  * @return KRAnyData
  */
-KRAnyData KRAnyDataCreate();
+KUIKLY_EXPORT KRAnyData KRAnyDataCreate();
 
 /**
  * @brief 创建一个新的 KRAnyData 值为 int32_t 类型
  * @param value 设置的 int32_t 值
  * @return KRAnyData
  */
-KRAnyData KRAnyDataCreateInt(int32_t value);
+KUIKLY_EXPORT KRAnyData KRAnyDataCreateInt(int32_t value);
 
 /**
  * @brief 创建一个新的 KRAnyData 值为 int64_t 类型
  * @param value 设置的 int64_t 值
  * @return KRAnyData
  */
-KRAnyData KRAnyDataCreateLong(int64_t value);
+KUIKLY_EXPORT KRAnyData KRAnyDataCreateLong(int64_t value);
 
 /**
  * @brief 创建一个新的 KRAnyData 值为 float 类型
  * @param value 设置的 float 值
  * @return KRAnyData
  */
-KRAnyData KRAnyDataCreateFloat(float value);
+KUIKLY_EXPORT KRAnyData KRAnyDataCreateFloat(float value);
 
 /**
  * @brief 创建一个新的 KRAnyData 值为 bool 类型
  * @param value 设置的 bool 值
  * @return KRAnyData
  */
-KRAnyData KRAnyDataCreateBool(bool value);
+KUIKLY_EXPORT KRAnyData KRAnyDataCreateBool(bool value);
 
 /**
  * @brief 创建一个新的 KRAnyData 值为 char* 类型
  * @param value 设置的 字符串 值
  * @return KRAnyData
  */
-KRAnyData KRAnyDataCreateString(const char* value);
+KUIKLY_EXPORT KRAnyData KRAnyDataCreateString(const char* value);
 
 /**
  * @brief 创建一个新的 KRAnyData 值为 char* 类型
@@ -239,14 +240,14 @@ KRAnyData KRAnyDataCreateString(const char* value);
  * @param size 二进制数据的长度
  * @return KRAnyData
  */
-KRAnyData KRAnyDataCreateBytes(const char* value, int size);
+KUIKLY_EXPORT KRAnyData KRAnyDataCreateBytes(const char* value, int size);
 
 /**
  * @brief 创建一个新的 KRAnyData 值为 Array 类型
  * @param size 设置的数组长度
  * @return KRAnyData
  */
-KRAnyData KRAnyDataCreateArray(int size);
+KUIKLY_EXPORT KRAnyData KRAnyDataCreateArray(int size);
 
 /**
  * @brief 设置 KRAnyData 数组中指定位置的元素值
@@ -255,7 +256,7 @@ KRAnyData KRAnyDataCreateArray(int size);
  * @param index 要设置元素的索引位置
  * @return KRAnDataErrorCode
  */
-int KRAnyDataSetArrayElement(KRAnyData data, KRAnyData value, int index);
+KUIKLY_EXPORT int KRAnyDataSetArrayElement(KRAnyData data, KRAnyData value, int index);
 
 /**
  * @brief 给 KRAnyData 数组中添加元素
@@ -263,12 +264,12 @@ int KRAnyDataSetArrayElement(KRAnyData data, KRAnyData value, int index);
  * @param value 要添加的 KRAnyData 元素
  * @return KRAnDataErrorCode
  */
-int KRAnyDataAddArrayElement(KRAnyData data, KRAnyData value);
+KUIKLY_EXPORT int KRAnyDataAddArrayElement(KRAnyData data, KRAnyData value);
 
 /**
  * @brief 销毁 KRAnyData 对象
  */
-void KRAnyDataDestroy(KRAnyData data);
+KUIKLY_EXPORT void KRAnyDataDestroy(KRAnyData data);
 
 #ifdef __cplusplus
 }

--- a/core-render-ohos/src/main/cpp/libohos_render/api/include/Kuikly/Kuikly.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/api/include/Kuikly/Kuikly.h
@@ -22,6 +22,7 @@
 #include <arkui/native_type.h>
 
 #include "KRAnyData.h"
+#include "KuiklyExport.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,21 +41,21 @@ typedef struct KRRenderModuleCallbackContextData *KRRenderModuleCallbackContext;
  * 回调给Kotlin侧的闭包
  * @param data 数据(类型为String)
  */
-void KRRenderModuleDoCallback(KRRenderModuleCallbackContext context, const char *data);
+KUIKLY_EXPORT void KRRenderModuleDoCallback(KRRenderModuleCallbackContext context, const char *data);
 
 /**
  * 从回调上下文对象根据tag获取capi的handle
  * @param tag
  * @return ArkUI_NodeHandle
  */
-ArkUI_NodeHandle KRRenderModuleGetViewWithTag(KRRenderModuleCallbackContext context, int tag);
+KUIKLY_EXPORT ArkUI_NodeHandle KRRenderModuleGetViewWithTag(KRRenderModuleCallbackContext context, int tag);
 
 /**
  * 从回调上下文对象获取当前页面的InstanceID
  * @param context 回调上下文
  * @return 字符串指针，仅当前scope有效，请勿转移指针，如有需要请拷贝字符串内容。
  */
-const char* KRRenderModuleGetInstanceID(KRRenderModuleCallbackContext context);
+KUIKLY_EXPORT const char* KRRenderModuleGetInstanceID(KRRenderModuleCallbackContext context);
 
 /**
  * The type of a funtion to free an object
@@ -120,7 +121,7 @@ typedef void (*KRRenderModuleOnDestruct)(const void* moduleInstance);
  * @param onCallMethod 模块的call method实现
  * @param reserved 保留字段
  */
-void KRRenderModuleRegister(const char *moduleName,
+KUIKLY_EXPORT void KRRenderModuleRegister(const char *moduleName,
                             KRRenderModuleOnConstruct onConstruct,
                             KRRenderModuleOnDestruct  onDestruct,
                             KRRenderModuleCallMethod  onCallMethod,
@@ -134,7 +135,7 @@ void KRRenderModuleRegister(const char *moduleName,
  * @param onCallMethod 模块的call method实现
  * @param reserved 保留字段
  */
-void KRRenderModuleRegisterV2(const char *moduleName,
+KUIKLY_EXPORT void KRRenderModuleRegisterV2(const char *moduleName,
                             KRRenderModuleOnConstruct onConstruct,
                             KRRenderModuleOnDestruct  onDestruct,
                             KRRenderModuleCallMethodV2  onCallMethod,
@@ -159,7 +160,7 @@ typedef bool (*KRRenderViewOnResetProp)(void *arkui_handle, const char *propKey)
  * 设置自定义属性handler
  * @param handler
  */
-void KRRenderViewSetExternalPropHandler(KRRenderViewOnSetProp set, KRRenderViewOnResetProp reset);
+KUIKLY_EXPORT void KRRenderViewSetExternalPropHandler(KRRenderViewOnSetProp set, KRRenderViewOnResetProp reset);
 
 /**
  * @brief 一个用于析构KRFontAdapterFontBufferForFamily返回的fontBuffer的回调函数
@@ -185,7 +186,7 @@ typedef char *(*KRFontAdapter)(const char *fontFamily, char **fontBuffer, size_t
  * @param adapter adapter函数指针
  * @param fontFamily adapter对应的font family
  */
-void KRRegisterFontAdapter(KRFontAdapter adapter, const char *fontFamily);
+KUIKLY_EXPORT void KRRegisterFontAdapter(KRFontAdapter adapter, const char *fontFamily);
 
 /**
  * @brief 一个用于析构KRImageAdapter返回的imageDescriptor或src的回调函数
@@ -234,13 +235,13 @@ typedef int32_t (*KRImageAdapterV2)(const void *context,
  * @param adapter adapter函数指针
  */
 [[deprecated("Use KRRegisterImageAdapterV2(KRImageAdapterV2) instead.")]]
-void KRRegisterImageAdapter(KRImageAdapter adapter);
+KUIKLY_EXPORT void KRRegisterImageAdapter(KRImageAdapter adapter);
 
 /**
  * @brief 注册image adapter V2
  * @param adapter adapter函数指针
  */
-void KRRegisterImageAdapterV2(KRImageAdapterV2 adapter);
+KUIKLY_EXPORT void KRRegisterImageAdapterV2(KRImageAdapterV2 adapter);
 
 /**
  * @brief 自定义image adapter V3，支持传递图片加载参数
@@ -260,16 +261,16 @@ typedef int32_t (*KRImageAdapterV3)(const void *context,
  * @param adapter adapter函数指针
  * @note V3版本支持传递图片加载参数 imageParams（Map类型）
  */
-void KRRegisterImageAdapterV3(KRImageAdapterV3 adapter);
+KUIKLY_EXPORT void KRRegisterImageAdapterV3(KRImageAdapterV3 adapter);
 
 
 /**
  * Log level定义
  * 判断loglevel的时候，不要假设每个level的值是永远固定的，请通过常量对比进行判断
  */
-extern int KRLogLevelInfo;
-extern int KRLogLevelDebug;
-extern int KRLogLevelError;
+KUIKLY_EXPORT extern int KRLogLevelInfo;
+KUIKLY_EXPORT extern int KRLogLevelDebug;
+KUIKLY_EXPORT extern int KRLogLevelError;
 
 /**
  * Log Adapter回调
@@ -296,7 +297,7 @@ typedef void (*KRLogAdapter)(int logLevel, const char *tag, const char *message)
  *
  * @param adapter
  */
-void KRRegisterLogAdapter(KRLogAdapter adapter);
+KUIKLY_EXPORT void KRRegisterLogAdapter(KRLogAdapter adapter);
 
 
 /**
@@ -320,13 +321,13 @@ typedef int64_t (*KRColorAdapterParseColor)(const char* str);
  * }
  *
  */
-void KRRegisterColorAdapter(KRColorAdapterParseColor adapter);
+KUIKLY_EXPORT void KRRegisterColorAdapter(KRColorAdapterParseColor adapter);
 
 /**
  * 禁止view复用。
  * 这是一个临时API，后续会删除，未经沟通，请勿调用。
  */
-void KRDisableViewReuse();
+KUIKLY_EXPORT void KRDisableViewReuse();
 
 
 /* ============ Text Post Processor Adapter ============
@@ -361,7 +362,7 @@ typedef struct KRTextProcessedResultBuilder_ *KRTextProcessedResultBuilder;
  * @param builder builder 句柄
  * @param text    UTF-8 文本，SDK 内部立即拷贝；NULL 视为忽略
  */
-void KRTextProcessedResultAppendTextSpan(KRTextProcessedResultBuilder builder,
+KUIKLY_EXPORT void KRTextProcessedResultAppendTextSpan(KRTextProcessedResultBuilder builder,
                                          const char *text);
 
 /**
@@ -382,7 +383,7 @@ void KRTextProcessedResultAppendTextSpan(KRTextProcessedResultBuilder builder,
  *       上抛给业务的 textDidChange/state.text 会带来 shortcode 丢失。
  *       *推荐* 在输入框场景下改用 KRTextProcessedResultAppendImageSpanWithRaw。
  */
-void KRTextProcessedResultAppendImageSpan(KRTextProcessedResultBuilder builder,
+KUIKLY_EXPORT void KRTextProcessedResultAppendImageSpan(KRTextProcessedResultBuilder builder,
                                           const char *src,
                                           float width,
                                           float height);
@@ -407,7 +408,7 @@ void KRTextProcessedResultAppendImageSpan(KRTextProcessedResultBuilder builder,
  * @param width        图片宽度（vp），<=0 表示按当前字号自适应
  * @param height       图片高度（vp），<=0 表示按当前字号自适应
  */
-void KRTextProcessedResultAppendImageSpanWithRaw(KRTextProcessedResultBuilder builder,
+KUIKLY_EXPORT void KRTextProcessedResultAppendImageSpanWithRaw(KRTextProcessedResultBuilder builder,
                                                  const char *src,
                                                  const char *raw_literal,
                                                  float width,
@@ -442,7 +443,7 @@ typedef void (*KRTextPostProcessorAdapter)(const char *name,
  *
  * @param adapter adapter 函数指针；NULL 表示注销
  */
-void KRRegisterTextPostProcessorAdapter(KRTextPostProcessorAdapter adapter);
+KUIKLY_EXPORT void KRRegisterTextPostProcessorAdapter(KRTextPostProcessorAdapter adapter);
 
 
 #ifdef __cplusplus

--- a/core-render-ohos/src/main/cpp/libohos_render/api/include/Kuikly/KuiklyExport.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/api/include/Kuikly/KuiklyExport.h
@@ -1,0 +1,31 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_KUIKLY_EXPORT_H
+#define CORE_RENDER_OHOS_KUIKLY_EXPORT_H
+
+/**
+ * Marks symbols that must remain in the dynamic symbol table when
+ * -fvisibility=hidden is enabled for package-size optimization.
+ */
+#ifndef KUIKLY_EXPORT
+#if defined(__GNUC__) || defined(__clang__)
+#define KUIKLY_EXPORT __attribute__((visibility("default")))
+#else
+#define KUIKLY_EXPORT
+#endif
+#endif
+
+#endif  // CORE_RENDER_OHOS_KUIKLY_EXPORT_H

--- a/core-render-ohos/src/main/cpp/libohos_render/foundation/type/KRRenderCValue.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/foundation/type/KRRenderCValue.h
@@ -20,6 +20,8 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#include "libohos_render/api/include/Kuikly/KuiklyExport.h"
+
 /**
  * 与kotlin侧通信的数据类型
  */
@@ -54,10 +56,14 @@ extern "C" {
 #endif
 typedef void (*CallKotlin)(int methodId, KRRenderCValue arg0, KRRenderCValue arg1, KRRenderCValue arg2,
                            KRRenderCValue arg3, KRRenderCValue arg4, KRRenderCValue arg5);
-extern int com_tencent_kuikly_SetCallKotlin(CallKotlin callKotlin);
-extern void com_tencent_kuikly_CallNative(int methodId, const KRRenderCValue *arg0, const KRRenderCValue *arg1,
+// 由 Kotlin/Native 的 libshared.so 直接解析，必须留在 dynsym 中。
+KUIKLY_EXPORT extern int com_tencent_kuikly_SetCallKotlin(CallKotlin callKotlin);
+KUIKLY_EXPORT extern void com_tencent_kuikly_CallNative(int methodId, const KRRenderCValue *arg0, const KRRenderCValue *arg1,
                                                           const KRRenderCValue *arg2, const KRRenderCValue *arg3, const KRRenderCValue *arg4,
                                                           const KRRenderCValue *arg5, KRRenderCValue *result);
+KUIKLY_EXPORT extern void com_tencent_kuikly_ScheduleContextTask(const char *pagerId,
+                                                          void (*onSchedule)(const char *pagerId));
+KUIKLY_EXPORT extern bool com_tencent_kuikly_IsCurrentOnContextThread(const char *pagerId);
 
 #ifdef __cplusplus
 }

--- a/demo/build.2.0.ohos.gradle.kts
+++ b/demo/build.2.0.ohos.gradle.kts
@@ -36,7 +36,6 @@ kotlin {
         binaries.sharedLib("shared"){
             freeCompilerArgs += "-Xadd-light-debug=enable"
             linkerOpts += "--build-id=sha1"
-            // 安装包优化（仅 release）：PPT slide4 副作用=无 选项（不含 -Os）
             if (buildType == org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.RELEASE) {
                 // 保留 Konan 默认 -O3（不用 -Os），仅叠加 sections；linker 侧加 relr/gc/hash-style
                 val CLANG_OPT_FLAGS = "-O3 -ffunction-sections -fdata-sections"

--- a/demo/build.2.0.ohos.gradle.kts
+++ b/demo/build.2.0.ohos.gradle.kts
@@ -36,13 +36,15 @@ kotlin {
         binaries.sharedLib("shared"){
             freeCompilerArgs += "-Xadd-light-debug=enable"
             linkerOpts += "--build-id=sha1"
-            // 安装包优化（仅 release）
+            // 安装包优化（仅 release）：PPT slide4 副作用=无 选项（不含 -Os）
             if (buildType == org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.RELEASE) {
-                val CLANG_OPT_FLAGS = "-Os   -ffunction-sections"
-                val CLANG_FLAGS = "clangOptFlags.ios_arm64=$CLANG_OPT_FLAGS;clangDebugFlags.ios_arm64=$CLANG_OPT_FLAGS;clangOptFlags.ohos_arm64=$CLANG_OPT_FLAGS;clangDebugFlags.ohos_arm64=$CLANG_OPT_FLAGS"
+                // 保留 Konan 默认 -O3（不用 -Os），仅叠加 sections；linker 侧加 relr/gc/hash-style
+                val CLANG_OPT_FLAGS = "-O3 -ffunction-sections -fdata-sections"
+                val CLANG_FLAGS = "clangOptFlags.ohos_arm64=$CLANG_OPT_FLAGS;clangDebugFlags.ohos_arm64=$CLANG_OPT_FLAGS"
                 freeCompilerArgs += "-Xoverride-konan-properties=$CLANG_FLAGS"
                 linkerOpts += "--pack-dyn-relocs=relr"
                 linkerOpts += "--gc-sections"
+                linkerOpts += "--hash-style=gnu"
             }
         }
     }


### PR DESCRIPTION
Drop -Os in favor of -O3 plus sections/relr/gc/hash-style on demo ohosArm64, and enable matching C++ flags with -fvisibility=hidden for core-render-ohos, exporting the KN/entry ABI via KUIKLY_EXPORT so dynsym stays loadable.