### PR TITLE
fix(iOS): KRCalendarModule set 操作在特定日期条件下 timeInMillis 返回 0

### DIFF
--- a/core-render-ios/Extension/Modules/KRCalendarModule.m
+++ b/core-render-ios/Extension/Modules/KRCalendarModule.m
@@ -91,9 +91,31 @@
                 break;
             }
         }
+        // 修复：对 day 做 clamp，避免超出目标月份的天数上限导致 NSDateFormatter 解析失败返回 nil
+        // 原理：set 操作是逐步串行执行的，每次只修改一个字段。当 set YEAR 或 set MONTH 时，
+        // 原 day 值保持不变，可能超出新 year/month 组合的合法天数范围。
+        // 例如：初始为 7月31日，set MONTH=5（June），此时 day=31 但 6月只有30天，
+        // 拼出 "2004-06-31" 后 NSDateFormatter 解析失败返回 nil，导致 timeInMillis() 返回 0。
+        // 此行为与 Java Calendar 的 lenient 模式对齐：超出天数自动截取为该月最大天数。
+        NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+        gregorianCalendar.timeZone = [NSTimeZone timeZoneWithName:@"Asia/Shanghai"];
+        NSDateComponents *tempComponents = [[NSDateComponents alloc] init];
+        tempComponents.year = year;
+        tempComponents.month = month;
+        tempComponents.day = 1;
+        NSDate *tempDate = [gregorianCalendar dateFromComponents:tempComponents];
+        if (tempDate) {
+            NSRange dayRange = [gregorianCalendar rangeOfUnit:NSCalendarUnitDay inUnit:NSCalendarUnitMonth forDate:tempDate];
+            if (day > (NSInteger)dayRange.length) {
+                day = dayRange.length;
+            }
+        }
         NSString *dateString = [NSString stringWithFormat:@"%04ld-%02ld-%02ld %02ld:%02ld:%02ld.%03ld",
                                 year, month, day, hour, minute, second, millisecond];
-        return [self dateFromString:dateString format:@"YYYY-MM-dd HH:mm:ss.SSS"];
+        // 修复：YYYY 是 ISO week-based year，在年末年初（如 12月31日）可能与 calendar year 不一致
+        // 例如 2024-12-31 的 YYYY 可能解析为 2025（因为该日属于 2025 年第一周），导致日期偏移
+        // 改为 yyyy（calendar year）确保年份始终与实际日历年一致
+        return [self dateFromString:dateString format:@"yyyy-MM-dd HH:mm:ss.SSS"];
     }
     
     if (![opt isEqualToString:@"add"]) {
@@ -161,7 +183,10 @@
         NSInteger maxDayCount = [self.localCalendar rangeOfUnit:NSCalendarUnitDay inUnit:NSCalendarUnitMonth forDate:[self dateFromString:[NSString stringWithFormat:@"%04ld-%02ld", year, month] format:@"yyyy-MM"]].length;
         day = MIN(day, maxDayCount);
         NSString *dateString = [NSString stringWithFormat:@"%04ld-%02ld-%02ld %@", year, month, day, [self stringFromDate:originDate format:@"HH:mm:ss.SSS"]];
-        date = [self dateFromString:dateString format:@"YYYY-MM-dd HH:mm:ss.SSS"];
+        // 修复：YYYY 是 ISO week-based year，在年末年初（如 12月31日）可能与 calendar year 不一致
+        // 例如 2024-12-31 的 YYYY 可能解析为 2025（因为该日属于 2025 年第一周），导致日期偏移
+        // 改为 yyyy（calendar year）确保年份始终与实际日历年一致
+        date = [self dateFromString:dateString format:@"yyyy-MM-dd HH:mm:ss.SSS"];
     }
     
     return date;

--- a/core-render-ios/Extension/Modules/KRCalendarModule.m
+++ b/core-render-ios/Extension/Modules/KRCalendarModule.m
@@ -22,6 +22,16 @@
     return [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierChinese];
 }
 
+- (NSCalendar *)gregorianCalendar {
+    static NSCalendar *_gregorianCalendar = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+        _gregorianCalendar.timeZone = [NSTimeZone timeZoneWithName:@"Asia/Shanghai"];
+    });
+    return _gregorianCalendar;
+}
+
 - (NSDate *)dateFromString:(NSString *)dateString format:(NSString *)format {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     formatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
@@ -97,8 +107,7 @@
         // 例如：初始为 7月31日，set MONTH=5（June），此时 day=31 但 6月只有30天，
         // 拼出 "2004-06-31" 后 NSDateFormatter 解析失败返回 nil，导致 timeInMillis() 返回 0。
         // 此行为与 Java Calendar 的 lenient 模式对齐：超出天数自动截取为该月最大天数。
-        NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
-        gregorianCalendar.timeZone = [NSTimeZone timeZoneWithName:@"Asia/Shanghai"];
+        NSCalendar *gregorianCalendar = [self gregorianCalendar];
         NSDateComponents *tempComponents = [[NSDateComponents alloc] init];
         tempComponents.year = year;
         tempComponents.month = month;
@@ -109,6 +118,9 @@
             if (day > (NSInteger)dayRange.length) {
                 day = dayRange.length;
             }
+        } else {
+            // month 极端越界时 dateFromComponents 可能返回 nil，保底 clamp day 到 28（所有月份的安全下限）
+            day = MIN(day, 28);
         }
         NSString *dateString = [NSString stringWithFormat:@"%04ld-%02ld-%02ld %02ld:%02ld:%02ld.%03ld",
                                 year, month, day, hour, minute, second, millisecond];


### PR DESCRIPTION
### 问题描述
iOS 端使用 `KRCalendarModule` 进行 set 操作后调用 timeInMillis() 时，在特定日期条件下返回 0，导致依赖时间戳的业务逻辑异常。

### 复现步骤
1. 在每月 29/30/31 号打开使用了 CalendarModule set 操作的页面
2. 对 Calendar 实例执行以下操作序列：
```
calendar.set(ICalendar.Field.YEAR, 2004)
calendar.set(ICalendar.Field.MONTH, 5)        // June（0-based）
calendar.set(ICalendar.Field.DAY_OF_MONTH, 5)
val result = calendar.timeInMillis()           // 返回 0！
```
3. `timeInMillis()` 返回 0 而非正确的时间戳
**触发条件**： `newCalendarInstance`() 创建时系统日期的 DAY 大于 set MONTH 后目标月份的天数上限。例如：
- 今天 7月31日，set MONTH 到 6月（30天）、4月（30天）、11月（30天）、2月（28/29天）
- 今天 3月30日，set MONTH 到 2月（28/29天）
**平台差异**： Android 不会复现，因为 Java Calendar 的 set 是延迟计算（lenient 模式）。

### 根因分析
`calcDate:operation:` 方法中 set 操作的实现是逐步串行的：每次 set 将当前日期解构为各字段 → 修改目标字段 → 拼成日期字符串 → 用 NSDateFormatter 解析回 NSDate。
当执行 set(MONTH, 5) 时，处理流程如下：
```
当前内部状态：2004-07-31（上一步 set YEAR=2004 后，day 仍保留初始的 31）
↓ 修改 month 为 5+1=6
↓ 拼接字符串："2004-06-31"
↓ NSDateFormatter 解析
↓ 6月只有30天，"06-31" 是非法日期 → 解析返回 nil
```
一旦 date 变为 nil，后续的 set 操作` [self stringFromDate:nil ...]` 返回 nil，.integerValue = 0，拼出 "0000-00-00..." → 继续解析失败 → Calendar 实例被永久污染，无法恢复。
此外，最终 `dateFromString:format: `使用的格式是 @"YYYY-MM-dd HH:mm:ss.SSS"，其中 YYYY 是 ISO week-based year 而非 calendar year，在年末年初场景下也可能导致解析偏差。

### 修复方案
1. set 操作后对 day 做 clamp：在拼接日期字符串之前，通过 NSCalendar 计算目标 year/month 的实际天数上限，将 day 限制在合法范围内，模拟 Java Calendar 的 lenient 行为。
2. YYYY → yyyy：将 dateFromString:format: 中的格式从 YYYY（week-based year）修正为 yyyy（calendar year）。