### PR TITLE
fix(iOS) Bridge 参数丢失导致 fireViewEvent JSONException 崩溃

### DIFF
--- a/core-render-ios/Extension/Category/KRConvertUtil.m
+++ b/core-render-ios/Extension/Category/KRConvertUtil.m
@@ -609,17 +609,24 @@ const NSString *lineargradientPrefix = @"linear-gradient(";
 
 + (NSString *)hr_dictionaryToJSON:(NSDictionary *)dict {
     NSError *parseError = nil;
+    NSString *reason = nil;
     NSString *jsonString = nil;
     @try {
         NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict
                                                            options:NSJSONWritingFragmentsAllowed
                                                              error:&parseError];
         jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+        reason = parseError.localizedDescription;
     } @catch (NSException *exception) {
         // 捕获并打印异常信息
         NSString *assertReason = [NSString stringWithFormat:@"%s exception:%@ reason:%@ userinfo:%@", __FUNCTION__, exception.name, exception.reason,exception.userInfo];
         [KRLogModule logError:assertReason];
+        reason = assertReason;
         NSAssert(false, assertReason);
+    }
+    if (!jsonString) {
+        [KRLogModule logError:[NSString stringWithFormat:@"%s JSON serialization failed, reason: %@, dict: %@", __FUNCTION__, reason ?: @"unknown", dict]];
+        jsonString = @"{}";
     }
     return jsonString;
 }

--- a/core-render-ios/Handler/KuiklyRenderFrameworkContextHandler.m
+++ b/core-render-ios/Handler/KuiklyRenderFrameworkContextHandler.m
@@ -101,9 +101,7 @@
     NSMutableArray * arguments = [[NSMutableArray alloc] initWithCapacity:6];
     for (id arg in args) {
         id ele = [KRConvertUtil nativeObjectToKotlinObject:arg];
-        if (ele) {
-            [arguments addObject:ele];
-        }
+        [arguments addObject:ele ?: [NSNull null]];
     }
     [_coreEntryInstance callKotlinMethodMethodId:(int32_t)method
                                             arg0:KRSafeArrayIndex(arguments, 0)


### PR DESCRIPTION
修复 iOS 端 KRTextAreaView.textViewDidChange: 触发事件时，桥接层参数丢失导致 Kotlin 侧 PagerManager.fireViewEvent 抛出 JSONException: End of input 崩溃的问题。
### 崩溃信息
```
com.tencent.kuikly.core.nvi.serialization.json.JSONException: End of input
pageName: PersonalAiIntroductionPage
```
符号化堆栈（从底到顶）
```
-[KRTextAreaView textViewDidChange:]                                  (KRTextAreaView.m:316)
__45-[KuiklyRenderCore p_initViewMethodRegisters]_block_invoke_5     (KuiklyRenderCore.m:304)
+[KuiklyRenderThreadManager performOnContextQueueWithBlock:sync:]     (KuiklyRenderThreadManager.m:34)
__45-[KuiklyRenderCore p_initViewMethodRegisters]_block_invoke_6     (KuiklyRenderCore.m:305)
-[KuiklyRenderFrameworkContextHandler callWithMethod:args:]           (KuiklyRenderFrameworkContextHandler.m:105)
objc2kotlin_kfun:KuiklyCoreEntry#callKotlinMethod
kfun:KuiklyCoreEntry#callKotlinMethod                                 (KuiklyCoreEntry.kt:53)
kfun:BridgeManager#callKotlinMethod                                   (BridgeManager.kt:127)
kfun:PagerManager#fireViewEvent                                       (PagerManager.kt:89) ← 崩溃点
kfun:JSONObject#<init>(String)                                        (JSONObject.kt:35)
kfun:JSONEngine#parse                                                 (JSONEngine.kt:21)
kfun:JSONTokener#nextValue                                            (JSONTokener.kt:22)
kfun:JSONTokener.syntaxError#internal                                 (JSONTokener.kt:80)
kfun:JSONException#<init>(String)                                     (JSONException.kt:8)
```
### 根因分析
1.`KRConvertUtil` - `hr_dictionaryToJSON`: 序列化失败时返回 nil
```
+ (NSString *)hr_dictionaryToJSON:(NSDictionary *)dict {
    NSString *jsonString = nil;
    @try {
        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict ...];
        jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
    } @catch ...
    return jsonString;  // ← 序列化失败时 jsonData 为 nil，jsonString 为 nil
}
```
2.`KuiklyRenderFrameworkContextHandler` `callWithMethod:args:` 静默丢弃 nil 参数导致索引错位
```
NSMutableArray * arguments = [[NSMutableArray alloc] initWithCapacity:6];
for (id arg in args) {
    id ele = [KRConvertUtil nativeObjectToKotlinObject:arg];
    if (ele) {           // ← nil 元素被静默跳过！
        [arguments addObject:ele];
    }
}
```
当 `nativeObjectToKotlinObject:` 返回 nil 时，该参数被静默丢弃，导致后续参数索引整体前移：
```
预期: arguments[0]=instanceId, [1]=tag, [2]=eventName, [3]=eventData
实际: arguments[0]=instanceId, [1]=tag, [2]=eventName  (eventData 丢失!)
→ KRSafeArrayIndex(arguments, 3) 返回 nil
→ Kotlin 侧 arg3 为 null
→ arg3 as? String 返回 null 或空字符串
→ fireViewEvent 收到无效 data → JSONObject 解析崩溃
```
如果前序参数（arg0/arg1/arg2）转换失败，后续参数会错位到错误的位置，可能导致类型强转崩溃（arg0 as String、arg1 as Int 等）。
```
NSJSONSerialization 序列化失败
  → hr_dictionaryToJSON 返回 nil
    → nativeObjectToKotlinObject 返回 nil
      → callWithMethod:args: 丢弃 nil 参数，索引错位
        → Kotlin 侧 eventData 为 null 或空字符串
          → fireViewEvent 中 JSONObject("") → JSONException: End of input 💥
```
### 修复方案
Fix 1：`KRConvertUtil` - `hr_dictionaryToJSON: `序列化失败时返回空 JSON 对象而非 nil
```
// 修改前
return jsonString;

// 修改后
if (!jsonString) {
        [KRLogModule logError:[NSString stringWithFormat:@"%s JSON 序列化失败, error: %@, dict: %@", __FUNCTION__, parseError, dict]];
        jsonString = @"{}";
 }
return jsonString;
```
Fix 2：`KuiklyRenderFrameworkContextHandler` -` callWithMethod:args:` 用 NSNull 占位保持参数对齐
```
// 修改前
if (ele) {
    [arguments addObject:ele];
}

// 修改后
[arguments addObject:ele ?: [NSNull null]];
```