### PR TITLE
feat(ios): add LLVM PGO and Machine Outliner packaging workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,11 @@ proto/**/*.kt
 /core-ksp/bin/
 .build
 
+## LLVM PGO / Machine Outliner local artifacts
+/demo/llvmProfile/*.profdata
+/demo/llvmProfile/profraw/*.profraw
+/iosApp/components/LLVMCompileRT/*.a
+
 ## Profiler / tool logs
 /logs/
 /iosApp/logs/

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -20,6 +20,69 @@ repositories {
     mavenLocal()
 }
 
+/**
+ * LLVM PGO / Machine Outliner 开关，由环境变量 LLVM_PGO_TYPE 控制：
+ * - LLVMPGO: 插装编译，运行时生成 .profraw
+ * - MachineOutliner: 使用 demo/llvmProfile/real_ios.profdata 做 PGO + outlining
+ * - 未设置 / 其他: 普通编译
+ *
+ * 详见 docs/DevGuide/machine-outliner-pgo-guide.md
+ */
+val llvmPgoType = System.getenv("LLVM_PGO_TYPE").orEmpty()
+val enableLlvmPgoInstrument = llvmPgoType == "LLVMPGO"
+val enableMachineOutliner = llvmPgoType == "MachineOutliner"
+val iosProfdataFile = project.file("llvmProfile/real_ios.profdata")
+
+fun buildAppleClangOverrideProperties(): String? {
+    val optFlags = when {
+        enableLlvmPgoInstrument -> {
+            // 插装必须跑 LLVM passes；不能沿用 Debug 默认的 -disable-llvm-passes。
+            // 关闭 value profiling（LLVM16 正确开关是 -disable-vp；
+            // -enable-value-profiling=false 是空操作会被忽略）。否则 __llvm_prf_data
+            // 里会残留 NumValueSites>0，而运行时 dump 不写 VP 段，导致 profraw 自相矛盾、
+            // llvm-profdata merge 报 "truncated profile data"。
+            "-Os -ffunction-sections " +
+                "-fprofile-instrument=llvm " +
+                "-fprofile-instrument-path=/fake/default_ios.profraw " +
+                "-mllvm -disable-vp"
+        }
+        enableMachineOutliner -> {
+            // 开源 KN/LLVM16 仅稳定支持 enable-machine-outliner；
+            // 参考文档中的 *-threshold 等为内部 LLVM 扩展，此处不默认启用。
+            val outliner =
+                "-Os -ffunction-sections -mllvm -enable-machine-outliner=always"
+            if (iosProfdataFile.exists()) {
+                logger.lifecycle("[LLVM_PGO] 使用 profdata: ${iosProfdataFile.absolutePath}")
+                "$outliner -fprofile-instrument-use-path=${iosProfdataFile.absolutePath}"
+            } else {
+                logger.warn(
+                    "[LLVM_PGO] MachineOutliner 已开启，但未找到 ${iosProfdataFile.path}；" +
+                        "仍启用 outlining（无 PGO use）。完整 PGO 请见 docs/DevGuide/machine-outliner-pgo-guide.md"
+                )
+                outliner
+            }
+        }
+        else -> return null
+    }
+    // Debug 构建走 clangDebugFlags，Release 走 clangOptFlags。
+    // PGO 插装时还需覆盖 clangFlags，去掉 -disable-llvm-passes，否则插装 pass 不会执行。
+    val appleSuffixes = listOf("ios_arm64", "ios_x64", "ios_simulator_arm64")
+    val props = mutableListOf<String>()
+    for (suffix in appleSuffixes) {
+        props += "clangOptFlags.$suffix=$optFlags"
+        props += "clangDebugFlags.$suffix=$optFlags"
+        if (enableLlvmPgoInstrument || enableMachineOutliner) {
+            props += "clangFlags.$suffix=-cc1 -emit-obj -x ir"
+        }
+    }
+    return props.joinToString(";")
+}
+
+val appleClangOverrideProperties = buildAppleClangOverrideProperties()
+if (appleClangOverrideProperties != null) {
+    logger.lifecycle("[LLVM_PGO] LLVM_PGO_TYPE=$llvmPgoType，已启用 Kotlin/Native clang 优化参数覆盖")
+}
+
 kotlin {
 
     // target
@@ -141,9 +204,29 @@ kotlin {
         framework {
             isStatic = true
             baseName = "shared"
+            if (appleClangOverrideProperties != null) {
+                freeCompilerArgs += "-Xoverride-konan-properties=$appleClangOverrideProperties"
+            }
         }
         license = "MIT"
         extraSpecAttributes["resources"] = "['src/commonMain/assets/**']"
+    }
+}
+
+// cocoapods framework 二进制创建之后，再给所有 Apple Native binary 挂上 PGO 参数（含非 pod 产物）。
+if (appleClangOverrideProperties != null) {
+    kotlin.targets.withType<KotlinNativeTarget>().configureEach {
+        if (!konanTarget.family.isAppleFamily) return@configureEach
+        compilations.configureEach {
+            compilerOptions.configure {
+                freeCompilerArgs.add("-Xoverride-konan-properties=$appleClangOverrideProperties")
+            }
+        }
+        binaries.configureEach {
+            if ("-Xoverride-konan-properties=$appleClangOverrideProperties" !in freeCompilerArgs) {
+                freeCompilerArgs += "-Xoverride-konan-properties=$appleClangOverrideProperties"
+            }
+        }
     }
 }
 

--- a/demo/llvmProfile/README.md
+++ b/demo/llvmProfile/README.md
@@ -1,0 +1,10 @@
+# llvmProfile
+
+本目录存放 iOS PGO 数据：
+
+| 文件 | 说明 |
+|------|------|
+| `profraw/*.profraw` | 插装 App 运行后从设备/模拟器导出的原始 profile |
+| `real_ios.profdata` | `merge_profraw.sh` 合并后的产物，MachineOutliner 编译读取 |
+
+详见 [machine-outliner-pgo-guide.md](../../docs/DevGuide/machine-outliner-pgo-guide.md)。

--- a/docs/DevGuide/kuikly-perf-guidelines.md
+++ b/docs/DevGuide/kuikly-perf-guidelines.md
@@ -21,7 +21,7 @@
 1. 启用--pack-dyn-relocs=relr
 2. 启用gc-sections，function-sections，data-sections
 3. 使用Os选项（Oz效果更佳，但对性能影响偏大一些）
-4. 启用-mllvm -enable-machine-outiner=always 提取重复指令，这个对性能影响偏大一些，使用时要多加关注
+4. 启用-mllvm -enable-machine-outiner=always 提取重复指令，这个对性能影响偏大一些，使用时要多加关注。**更推荐先用 LLVM PGO 采集运行时频次，再在 Machine Outliner 中按热度 outlining**，可显著降低对热路径的误伤；完整流程与本仓库 `demo`/`iosApp` 落地见 [iOS Machine Outliner + PGO 指引](./machine-outliner-pgo-guide.md)。
 ```kotlin
 kotlin {
     targets.all {

--- a/docs/DevGuide/kuikly-perf-guidelines.md
+++ b/docs/DevGuide/kuikly-perf-guidelines.md
@@ -113,7 +113,7 @@ target_link_options(kuikly PRIVATE
 
 经验证以下选项对于 Kotlin Native 产物的减少也有较明显帮助（如在鸿蒙上 Kuikly Demo 产物大小下降 40%，有的业务下降 50%），但**这些选项更容易对性能产生影响**，使用前请做好专项验证：
 1. 使用 `-Os`（`-Oz` 效果更佳，但对性能影响通常更大）
-2. 启用 `-mllvm -enable-machine-outliner=always` 提取重复指令
+2. 启用 `-mllvm -enable-machine-outliner=always` 提取重复指令。**更推荐先用 LLVM PGO 采集运行时频次，再在 Machine Outliner 中按热度 outlining**，可显著降低对热路径的误伤；完整流程与本仓库 `demo`/`iosApp` 落地见 [iOS Machine Outliner + PGO 指引](./machine-outliner-pgo-guide.md)。
 
 示例：
 

--- a/docs/DevGuide/machine-outliner-pgo-guide.md
+++ b/docs/DevGuide/machine-outliner-pgo-guide.md
@@ -1,0 +1,232 @@
+# iOS Machine Outliner + PGO 安装包优化指引
+
+> 通过 LLVM PGO 收集 Kotlin/Native 运行时调用频次，再用 Machine Outliner 按热度做指令抽离，减小 `shared.framework` / IPA 体积。  
+> 本指引已在本仓库 `demo` + `iosApp` 落地，可直接按下方脚本跑通。
+
+:::warning 注意
+Machine Outliner 会改变代码布局，**可能影响热路径性能**。上线前务必做体积对比与性能回归。插装包仅用于数据采集，不要发给用户。
+:::
+
+## 1. 原理与模式
+
+| `LLVM_PGO_TYPE` | 模式 | 行为 |
+|-----------------|------|------|
+| `LLVMPGO` | PGO 插装 | Kotlin/Native 加 `-fprofile-instrument=llvm`，链接 `LLVMCompileRT`，运行生成 `.profraw` |
+| `MachineOutliner` | PGO + Outliner | 若存在 `real_ios.profdata` 则做 PGO use；并启用 `-enable-machine-outliner=always` |
+| 未设置 | 普通编译 | 不改 clang 参数，不链 profile runtime |
+
+```mermaid
+flowchart LR
+  A["LLVMPGO 插装编译"] --> B["真机/模拟器跑核心业务"]
+  B --> C["导出 .profraw"]
+  C --> D["llvm-profdata merge"]
+  D --> E["real_ios.profdata"]
+  E --> F["MachineOutliner 优化编译"]
+  F --> G["对比体积 + 性能回归"]
+```
+
+## 2. 工程落点（本仓库）
+
+| 组件 | 路径 | 说明 |
+|------|------|------|
+| K/N 编译开关 | [`demo/build.gradle.kts`](../../demo/build.gradle.kts) | 读 `LLVM_PGO_TYPE`，覆盖 `clangOptFlags` / `clangDebugFlags` / `clangFlags`；插装侧带 `-mllvm -disable-vp` |
+| Profile 数据 | [`demo/llvmProfile/`](../../demo/llvmProfile/) | `profraw/` 原始数据，`real_ios.profdata` 合并结果 |
+| Profile Runtime Pod | [`iosApp/components/LLVMCompileRT/`](../../iosApp/components/LLVMCompileRT/) | 提供与 KN 同版本的 `libclang_rt.profile_ios.a` / `iossim`（由 setup 脚本从 LLVM16 compiler-rt 编译） |
+| Pod 条件依赖 | [`iosApp/Podfile`](../../iosApp/Podfile) | 仅 `LLVMPGO` 时 `pod 'LLVMCompileRT'` |
+| 运行时落盘 | [`iosApp/iosApp/iOSApp.swift`](../../iosApp/iosApp/iOSApp.swift) | 设置 `LLVM_PROFILE_FILE`，定时 / 进后台调用 `__llvm_profile_write_file` |
+| 脚本 | [`iosApp/scripts/`](../../iosApp/scripts/) | 编译 runtime、插装构建、merge、优化构建 |
+
+## 3. 一键脚本流程
+
+在仓库根目录执行：
+
+### 步骤 1：准备 profile runtime
+
+```bash
+bash iosApp/scripts/setup_llvm_compile_rt.sh
+```
+
+用 Kotlin/Native 自带的 LLVM16 clang，从 compiler-rt 16.0.0 源码编译完整的 `libclang_rt.profile_*.a` 到 `LLVMCompileRT`（**不要**直接拷 Xcode clang17 的 profile runtime，ABI / raw profile 版本不匹配）。
+
+### 步骤 2：打插装包
+
+```bash
+# 模拟器 Debug（便于采集）
+bash iosApp/scripts/build_pgo_instrumented.sh --simulator
+
+# 或真机
+bash iosApp/scripts/build_pgo_instrumented.sh --device
+```
+
+脚本会：`LLVM_PGO_TYPE=LLVMPGO` → `pod install`（引入 LLVMCompileRT）→ `xcodebuild`。
+
+### 步骤 3：运行并采集
+
+1. 安装并启动 App，**尽量走完核心页面与高频交互**（路由、列表滚动、关键业务页）。
+2. 切到后台或杀掉 App，触发 profile 落盘。
+3. 日志中应出现：`[LLVM_PGO] LLVM_PROFILE_FILE=.../Documents/kuikly_%m.profraw`。
+
+**模拟器导出：**
+
+```bash
+BUNDLE_ID=$(plutil -extract CFBundleIdentifier raw \
+  "$(ls -td ~/Library/Developer/Xcode/DerivedData/iosApp-*/Build/Products/Debug-iphonesimulator/iosApp.app | head -1)/Info.plist")
+SIM_ID="<你的模拟器 UDID>"
+DATA_CONTAINER=$(xcrun simctl get_app_container "$SIM_ID" "$BUNDLE_ID" data)
+mkdir -p demo/llvmProfile/profraw
+cp "$DATA_CONTAINER"/Documents/*.profraw demo/llvmProfile/profraw/
+```
+
+**真机：** 通过 Xcode Devices 窗口下载 Container，或从 App 沙盒 `Documents` 拷出 `.profraw`。
+
+### 步骤 4：合并 profdata
+
+```bash
+bash iosApp/scripts/merge_profraw.sh
+# 或指定目录：
+# bash iosApp/scripts/merge_profraw.sh /path/to/profraw_dir
+```
+
+产物：`demo/llvmProfile/real_ios.profdata`。
+
+### 步骤 5：优化编译
+
+```bash
+bash iosApp/scripts/build_machine_outliner.sh --device
+```
+
+`LLVM_PGO_TYPE=MachineOutliner`，**不再**链接 LLVMCompileRT，按 profdata 做 PGO + Machine Outliner。
+
+### 步骤 6：验证
+
+```bash
+# 对比 shared.framework 体积（路径随配置变化）
+ls -lh demo/build/cocoapods/framework/shared.framework/shared
+# 或对比最终 .app / IPA
+```
+
+- 记录优化前后二进制 size（**优先对比 `strip` 后的体积**；见 [§7.5](#75-体积对比与回归)）。
+- 在真机做启动、滚动、动画等性能回归。
+- 确认 Gradle 日志出现 `[LLVM_PGO] 使用 profdata: ...`（有 PGO use）或「仍启用 outlining（无 PGO use）」告警。
+
+## 4. 编译参数说明
+
+### 4.1 插装（`LLVMPGO`）
+
+```text
+-Os -ffunction-sections
+-fprofile-instrument=llvm
+-fprofile-instrument-path=/fake/default_ios.profraw
+-mllvm -disable-vp
+```
+
+运行时由 `LLVM_PROFILE_FILE` 覆盖输出路径。`-disable-vp` 关闭 Value Profiling（见 [§7](#7-常见问题)）；**不要**写 `-enable-value-profiling=false`，在 LLVM16 上会被静默忽略。
+
+### 4.2 优化（`MachineOutliner`）
+
+```text
+-Os -ffunction-sections
+-fprofile-instrument-use-path=<repo>/demo/llvmProfile/real_ios.profdata   # 若文件存在
+-mllvm -enable-machine-outliner=always
+```
+
+同时覆盖 `clangFlags.ios_*` 为 `-cc1 -emit-obj -x ir`（去掉 Debug 默认的 `-disable-llvm-passes`，否则插装 / PGO use / Outliner 相关 LLVM pass 不会执行）。若 `real_ios.profdata` 不存在，Gradle 会告警并**仍启用 outlining（无 PGO use）**。
+
+Debug / Release 分别走 Konan 的 `clangDebugFlags` / `clangOptFlags`，本仓库对 `ios_arm64` / `ios_x64` / `ios_simulator_arm64` 均已覆盖。
+
+> 注：部分内部 LLVM / KN 分支还支持 `machine-outliner-block-count-threshold`、`hot-callsite-threshold`、`mergeFunctions` 等扩展；开源 KN（LLVM16）会报 `Unknown command line argument` / `Unknown binary option`，本仓库**不默认启用**。
+
+## 5. 手动命令（不走脚本时）
+
+```bash
+# 插装
+export LLVM_PGO_TYPE=LLVMPGO
+bash ./gradlew :demo:generateDummyFramework
+cd iosApp && pod install
+# 再按需 xcodebuild ...
+
+# 优化
+export LLVM_PGO_TYPE=MachineOutliner
+# 确保 demo/llvmProfile/real_ios.profdata 已存在
+bash ./gradlew :demo:syncFramework \
+  -Pkotlin.native.cocoapods.platform=iphoneos \
+  -Pkotlin.native.cocoapods.archs=arm64 \
+  -Pkotlin.native.cocoapods.configuration=Release
+```
+
+> `pod install` **必须**在对应 `LLVM_PGO_TYPE` 下执行：Podfile 在 install 时根据环境变量决定是否引入 `LLVMCompileRT`。
+
+## 6. 业务工程接入建议
+
+1. 在业务 KMP 模块的 `build.gradle.kts` 复用本仓库 `demo` 中的 `LLVM_PGO_TYPE` 分支逻辑。
+2. 宿主 iOS 工程增加 `LLVMCompileRT` 私有 pod（或同等链接 `libclang_rt.profile_*.a`）。
+3. 在 App 启动最早阶段设置 `LLVM_PROFILE_FILE`，退出/进后台写 profile。
+4. 用**接近线上的核心路径**采集；profile 过旧或覆盖不足会误导 inline / outliner。
+5. 优化包与插装包使用同一 Kotlin/Native 大版本；merge 时优先用 `~/.konan/dependencies` 下与 KN 匹配的 `llvm-profdata`。
+
+## 7. 常见问题
+
+> 以下条目来自本仓库在模拟器上打通「插装 → dump → merge → MachineOutliner」时踩过的坑。核心原则：**插装侧（KN LLVM16）↔ profile runtime ↔ `llvm-profdata` 三者必须同版本、同 ABI。**
+
+### 7.1 Profile Runtime / 链接
+
+| 现象 | 原因与处理 |
+|------|------------|
+| 链接失败：`___llvm_profile_*` undefined | 未在 `LLVM_PGO_TYPE=LLVMPGO` 下 `pod install`，或未跑 `setup_llvm_compile_rt.sh` |
+| 大量其它符号 undefined（像 CocoaPods 链接参数被冲掉） | `LLVMCompileRT` podspec 的 `OTHER_LDFLAGS` **必须含 `$(inherited)`**，否则会覆盖宿主已有 linker flags |
+| 找不到 `libclang_rt.profile_*.a` | path pod **不会**拷贝到 `Pods/LLVMCompileRT`；链接路径用 `$(SRCROOT)/components/LLVMCompileRT/...`，不要写 `$(PODS_ROOT)/LLVMCompileRT/...` |
+| 运行崩溃在 `__llvm_profile_instrument_target` | 用了 **Xcode clang17** 的 `libclang_rt.profile_*.a`，与 KN **LLVM16** 插装的 value-profiling ABI 不匹配。必须用本仓库 setup 脚本从 **compiler-rt 16.0.0** 编出的完整 runtime |
+| 链接缺 `_lprofGetVPDataReader` / `_lprofSetupValueProfiler` 等 | 曾为避崩把 `InstrProfilingValue.o` 从 `.a` 里删掉 / stub。即便插装侧已 `-disable-vp`，runtime 仍需保留该目标文件以解析上述符号 |
+| 链接缺 `_lprofGetHostName` | 手动编 compiler-rt 时未定义 `COMPILER_RT_HAS_UNAME`（以及 Darwin 上常用的 `COMPILER_RT_HAS_FCNTL_LCK` / `ATOMICS`）。setup 脚本已补齐 |
+
+### 7.2 Value Profiling（VP）与 `truncated profile data`
+
+**VP（Value Profiling）**：除函数/基本块执行次数外，额外记录「间接调用实际跳到谁」「memop 常见长度」等动态值。会生成 `__llvm_prf_vals` / `__llvm_prf_vnds`，并在 `__llvm_prf_data` 里留下 `NumValueSites`。
+
+| 现象 | 原因与处理 |
+|------|------------|
+| `llvm-profdata merge` 报 `truncated profile data` | **写出文件自相矛盾**：data 记录里 `NumValueSites > 0`，但 `.profraw` 只有 header+data+counters+names、**没有 VP payload**。常见根因是插装侧 VP 没真正关掉 |
+| 写了 `-mllvm -enable-value-profiling=false` 仍有 `__llvm_prf_vals` | 该 flag 名在 **LLVM16 上无效，会被静默忽略**。正确开关是 **`-mllvm -disable-vp`**（本仓库 `demo/build.gradle.kts` 已使用） |
+| 如何确认 VP 已关闭 | 对插装后的 `shared` 跑 `otool -l … \| rg '__llvm_prf'`：应只剩 `__llvm_prf_cnts` / `__llvm_prf_data` / `__llvm_prf_names`，**不应**再有 `vals` / `vnds` |
+
+Machine Outliner 主要依赖「热/冷」计数；关掉 VP 不影响本指引主路径，还能让 dump / merge 稳定。
+
+### 7.3 Dump / Merge 工具
+
+| 现象 | 原因与处理 |
+|------|------------|
+| 没有 `.profraw` | 未链上 LLVM16 profile runtime；或进程被强杀未走落盘逻辑；看日志里 `[LLVM_PGO]` 的路径与 `write_file` 返回值 |
+| `.profraw` 体积成倍变大 | App 内定时 dump 可能对同一路径 **多次 append**；`llvm-profdata merge` 能吃拼接 raw，但导出前可先清 Documents 或只保留一份 |
+| Xcode 的 `llvm-profdata` 报 raw version mismatch（如 v8 vs v10） | KN 插装产出 **raw format version 8**；Xcode 17 工具期望更新版本。**必须用** `~/.konan/dependencies/llvm-16.0.0-*/bin/llvm-profdata` |
+| 用本机新版 clang 随便生成一份 seed `.profdata` 给 KN | format / 版本不兼容，PGO use 无效或报错。应用本仓库插装包真实跑出来的 profile 再 merge |
+
+### 7.4 Kotlin/Native / Gradle 编译
+
+| 现象 | 原因与处理 |
+|------|------------|
+| framework 无 `__llvm_prf_*` section | Debug 未覆盖 `clangFlags`，仍带 `-disable-llvm-passes`，插装 pass 未执行。确认 Gradle 有 `[LLVM_PGO]` 日志，必要时 `--rerun-tasks` |
+| `Unknown command line argument: -machine-outliner-block-count-threshold=...`（或同类 threshold） | 多为**内部 LLVM 扩展**；开源 KN/LLVM16 只稳定支持 `-enable-machine-outliner=always`。本仓库已去掉内部 threshold |
+| `Unknown binary option 'mergeFunctions'` | 开源 KN 2.1.21 不支持；不要加 `-Xbinary=mergeFunctions=true` |
+| Release MachineOutliner 链接 `Java heap space` | Outliner + 大 bitcode 极吃内存。提高 Gradle / Kotlin daemon 堆（实践约 `-Xmx10g`），构建前 `./gradlew --stop` |
+| `real_ios.profdata` 缺失时以为「没开 Outliner」 | 当前逻辑是：缺 profdata 时 **仍启用 outlining（无 PGO use）**，并打 warn。看日志区分「无 PGO」与「有 PGO use」 |
+
+### 7.5 体积对比与回归
+
+| 现象 | 原因与处理 |
+|------|------------|
+| unstripped 变大、以为优化失败 | Outliner 后符号/调试信息可能变多。**以 `strip` 后的二进制为准**再对比 |
+| 「体积完全没变」 | 先确认链接是否成功；失败时拷贝的可能仍是 baseline。核对 `BUILD SUCCESSFUL` 与二进制 md5 / mtime |
+| 有 PGO use 后 stripped 收益略小于裸 `always` | 符合预期：profile 让 outliner 对热路径更保守，用一点体积换性能安全 |
+| 性能回退明显 | 优先保证走完整 PGO use（不要长期裸 `always`）；必要时去掉 `enable-machine-outliner=always` 只保留 PGO use；上线前做启动 / 滚动 / 动画回归 |
+| Bundle ID / 安装错包 | 工程里 Bundle ID 可能被改过（如 `...luoyibu` / `...db`）。安装前用 `plutil` 读实际 `CFBundleIdentifier`，不要写死 |
+
+### 7.6 模式混用
+
+| 现象 | 原因与处理 |
+|------|------------|
+| 优化包仍链着 LLVMCompileRT | `pod install` **必须**在对应 `LLVM_PGO_TYPE` 下执行；MachineOutliner / 普通包不应引入该 pod |
+| 插装包与优化包 LLVM 大版本不一致 | profile 与 PGO use 可能对不上。插装、merge、优化使用同一套 KN / LLVM16 工具链 |
+
+## 8. 与其它安装包优化的关系
+
+本能力与 [Kuikly安装包优化指引](./kuikly-perf-guidelines.md) 中的 `-Os` / `function-sections` / 符号 internal 化等正交，可叠加。裸开 Machine Outliner（无 PGO）对冷路径更激进，**更建议本指引的「先 PGO 再 Outliner」**，用频次保护热路径。

--- a/docs/DevGuide/machine-outliner-pgo-guide.md
+++ b/docs/DevGuide/machine-outliner-pgo-guide.md
@@ -31,9 +31,9 @@ flowchart LR
 |------|------|------|
 | K/N 编译开关 | [`demo/build.gradle.kts`](../../demo/build.gradle.kts) | 读 `LLVM_PGO_TYPE`，覆盖 `clangOptFlags` / `clangDebugFlags` / `clangFlags`；插装侧带 `-mllvm -disable-vp` |
 | Profile 数据 | [`demo/llvmProfile/`](../../demo/llvmProfile/) | `profraw/` 原始数据，`real_ios.profdata` 合并结果 |
-| Profile Runtime Pod | [`iosApp/components/LLVMCompileRT/`](../../iosApp/components/LLVMCompileRT/) | 提供与 KN 同版本的 `libclang_rt.profile_ios.a` / `iossim`（由 setup 脚本从 LLVM16 compiler-rt 编译） |
+| Profile Runtime Pod | [`iosApp/components/LLVMCompileRT/`](../../iosApp/components/LLVMCompileRT/) | 提供与 KN 同版本的 `libclang_rt.profile_ios.a` / `iossim`（iossim 为 arm64+x86_64 fat；由 setup 脚本从 LLVM16 compiler-rt 编译） |
 | Pod 条件依赖 | [`iosApp/Podfile`](../../iosApp/Podfile) | 仅 `LLVMPGO` 时 `pod 'LLVMCompileRT'` |
-| 运行时落盘 | [`iosApp/iosApp/iOSApp.swift`](../../iosApp/iosApp/iOSApp.swift) | 设置 `LLVM_PROFILE_FILE`，定时 / 进后台调用 `__llvm_profile_write_file` |
+| 运行时落盘 | [`iosApp/iosApp/iOSApp.swift`](../../iosApp/iosApp/iOSApp.swift) | 仅 `#if LLVM_PGO_INSTRUMENT`：设置 profile 路径，定时 / 进后台调用 `__llvm_profile_write_file` |
 | 脚本 | [`iosApp/scripts/`](../../iosApp/scripts/) | 编译 runtime、插装构建、merge、优化构建 |
 
 ## 3. 一键脚本流程
@@ -46,7 +46,7 @@ flowchart LR
 bash iosApp/scripts/setup_llvm_compile_rt.sh
 ```
 
-用 Kotlin/Native 自带的 LLVM16 clang，从 compiler-rt 16.0.0 源码编译完整的 `libclang_rt.profile_*.a` 到 `LLVMCompileRT`（**不要**直接拷 Xcode clang17 的 profile runtime，ABI / raw profile 版本不匹配）。
+用 Kotlin/Native 自带的 LLVM16 clang，从 compiler-rt 16.0.0 源码编译完整的 `libclang_rt.profile_*.a` 到 `LLVMCompileRT`（**不要**直接拷 Xcode clang17 的 profile runtime，ABI / raw profile 版本不匹配）。`iossim` 会编 arm64 + x86_64 再用 `lipo` 合成 fat，以覆盖 `ios_simulator_arm64` / `ios_x64`。
 
 ### 步骤 2：打插装包
 
@@ -58,7 +58,7 @@ bash iosApp/scripts/build_pgo_instrumented.sh --simulator
 bash iosApp/scripts/build_pgo_instrumented.sh --device
 ```
 
-脚本会：`LLVM_PGO_TYPE=LLVMPGO` → `pod install`（引入 LLVMCompileRT）→ `xcodebuild`。
+脚本会：`LLVM_PGO_TYPE=LLVMPGO` → `pod install`（引入 LLVMCompileRT）→ `xcodebuild`，并传入 `SWIFT_ACTIVE_COMPILATION_CONDITIONS=LLVM_PGO_INSTRUMENT` 打开 App 侧落盘逻辑。普通包 / MachineOutliner 包**不要**传该宏，不会挂 3s 定时器。
 
 ### 步骤 3：运行并采集
 
@@ -178,6 +178,7 @@ bash ./gradlew :demo:syncFramework \
 | 运行崩溃在 `__llvm_profile_instrument_target` | 用了 **Xcode clang17** 的 `libclang_rt.profile_*.a`，与 KN **LLVM16** 插装的 value-profiling ABI 不匹配。必须用本仓库 setup 脚本从 **compiler-rt 16.0.0** 编出的完整 runtime |
 | 链接缺 `_lprofGetVPDataReader` / `_lprofSetupValueProfiler` 等 | 曾为避崩把 `InstrProfilingValue.o` 从 `.a` 里删掉 / stub。即便插装侧已 `-disable-vp`，runtime 仍需保留该目标文件以解析上述符号 |
 | 链接缺 `_lprofGetHostName` | 手动编 compiler-rt 时未定义 `COMPILER_RT_HAS_UNAME`（以及 Darwin 上常用的 `COMPILER_RT_HAS_FCNTL_LCK` / `ATOMICS`）。setup 脚本已补齐 |
+| Intel 模拟器链接 `symbol(s) not found for architecture x86_64` | 旧版 runtime 只有 arm64 slice。setup 脚本已对 `libclang_rt.profile_iossim.a` 做 arm64+x86_64 `lipo`；请重跑 `setup_llvm_compile_rt.sh` |
 
 ### 7.2 Value Profiling（VP）与 `truncated profile data`
 
@@ -197,8 +198,9 @@ Machine Outliner 主要依赖「热/冷」计数；关掉 VP 不影响本指引�
 |------|------------|
 | 没有 `.profraw` | 未链上 LLVM16 profile runtime；或进程被强杀未走落盘逻辑；看日志里 `[LLVM_PGO]` 的路径与 `write_file` 返回值 |
 | `.profraw` 体积成倍变大 | App 内定时 dump 可能对同一路径 **多次 append**；`llvm-profdata merge` 能吃拼接 raw，但导出前可先清 Documents 或只保留一份 |
-| Xcode 的 `llvm-profdata` 报 raw version mismatch（如 v8 vs v10） | KN 插装产出 **raw format version 8**；Xcode 17 工具期望更新版本。**必须用** `~/.konan/dependencies/llvm-16.0.0-*/bin/llvm-profdata` |
+| Xcode 的 `llvm-profdata` 报 raw version mismatch（如 v8 vs v10） | KN 插装产出 **raw format version 8**；Xcode 17 工具期望更新版本。**必须用** `~/.konan/dependencies/llvm-16.0.0-*-macos-*/bin/llvm-profdata`（`merge_profraw.sh` 优先 glob 匹配；命中非 16 会 warn） |
 | 用本机新版 clang 随便生成一份 seed `.profdata` 给 KN | format / 版本不兼容，PGO use 无效或报错。应用本仓库插装包真实跑出来的 profile 再 merge |
+| 正式包里每 3s 打 `[LLVM_PGO]` 日志 / 空转定时器 | 落盘逻辑已用 `#if LLVM_PGO_INSTRUMENT` 包起来；只有 `build_pgo_instrumented.sh` 会传该编译条件。普通 / MachineOutliner 包不要手动加该宏 |
 
 ### 7.4 Kotlin/Native / Gradle 编译
 

--- a/docs/sidebar/zh.ts
+++ b/docs/sidebar/zh.ts
@@ -100,7 +100,7 @@ export const zhSidebar = sidebar({
                                 {
                                     text: "性能优化",
                                     collapsible: true,
-                                    children: ["kuikly-perf-guidelines.md", "android-start-guide.md", "turboDisplay.md"]
+                                    children: ["kuikly-perf-guidelines.md", "machine-outliner-pgo-guide.md", "android-start-guide.md", "turboDisplay.md"]
                                 }
                             ]
                         },

--- a/iosApp/Podfile
+++ b/iosApp/Podfile
@@ -2,6 +2,13 @@
 #use_frameworks!
 source 'https://cdn.cocoapods.org/'
 
+def pod_llvm_compile_rt
+  # 仅 PGO 插装包需要 profile runtime；MachineOutliner / 普通包不要链接。
+  if ENV['LLVM_PGO_TYPE'] == 'LLVMPGO'
+    pod 'LLVMCompileRT', :path => './components/LLVMCompileRT'
+  end
+end
+
 target 'iosApp' do
   platform :ios, '14.1'
   pod 'SDWebImage', '~> 5.20.1'
@@ -9,6 +16,8 @@ target 'iosApp' do
   pod 'demo', :path => '../demo'
   pod 'WMPlayer', "~> 5.0" # 第三方播放器库
   pod 'libpag', "~> 4.3.21"
+
+  pod_llvm_compile_rt
 end
 
 

--- a/iosApp/components/LLVMCompileRT/LLVMCompileRT.podspec
+++ b/iosApp/components/LLVMCompileRT/LLVMCompileRT.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+  s.name         = 'LLVMCompileRT'
+  s.version      = '1.0.0'
+  s.summary      = 'LLVM Clang Profile Runtime，用于 KuiklyUI demo 的 LLVM PGO 插装链接'
+  s.description  = <<-DESC
+    提供 libclang_rt.profile_ios.a / libclang_rt.profile_iossim.a，
+    仅在 LLVM_PGO_TYPE=LLVMPGO 插装包中引入，供运行时写出 .profraw。
+    请先执行 iosApp/scripts/setup_llvm_compile_rt.sh 从 Xcode 工具链拷贝静态库。
+  DESC
+  s.homepage     = 'https://github.com/Tencent-TDS/KuiklyUI'
+  s.license      = { :type => 'MIT' }
+  s.author       = { 'KuiklyUI' => '' }
+  s.platform     = :ios, '14.1'
+  s.source       = { :path => '.' }
+  s.source_files = 'empty.m'
+  s.preserve_paths = [
+    'libclang_rt.profile_ios.a',
+    'libclang_rt.profile_iossim.a',
+  ]
+  # path pod 不会拷贝到 Pods/LLVMCompileRT；宿主 SRCROOT=iosApp。
+  # 必须带 $(inherited)，否则会覆盖 CocoaPods 注入的 -l/-framework 导致大量 undefined。
+  s.user_target_xcconfig = {
+    'OTHER_LDFLAGS[sdk=iphoneos*]' => '$(inherited) -force_load $(SRCROOT)/components/LLVMCompileRT/libclang_rt.profile_ios.a',
+    'OTHER_LDFLAGS[sdk=iphonesimulator*]' => '$(inherited) -force_load $(SRCROOT)/components/LLVMCompileRT/libclang_rt.profile_iossim.a',
+  }
+end

--- a/iosApp/components/LLVMCompileRT/LLVMCompileRT.podspec
+++ b/iosApp/components/LLVMCompileRT/LLVMCompileRT.podspec
@@ -3,9 +3,9 @@ Pod::Spec.new do |s|
   s.version      = '1.0.0'
   s.summary      = 'LLVM Clang Profile Runtime，用于 KuiklyUI demo 的 LLVM PGO 插装链接'
   s.description  = <<-DESC
-    提供 libclang_rt.profile_ios.a / libclang_rt.profile_iossim.a，
+    提供 libclang_rt.profile_ios.a / libclang_rt.profile_iossim.a（iossim 为 arm64+x86_64 fat），
     仅在 LLVM_PGO_TYPE=LLVMPGO 插装包中引入，供运行时写出 .profraw。
-    请先执行 iosApp/scripts/setup_llvm_compile_rt.sh 从 Xcode 工具链拷贝静态库。
+    请先执行 iosApp/scripts/setup_llvm_compile_rt.sh（优先工具链自带同版本库，否则从 compiler-rt 源码编译）。
   DESC
   s.homepage     = 'https://github.com/Tencent-TDS/KuiklyUI'
   s.license      = { :type => 'MIT' }

--- a/iosApp/components/LLVMCompileRT/README.md
+++ b/iosApp/components/LLVMCompileRT/README.md
@@ -3,7 +3,7 @@
 LLVM Clang Profile Runtime 静态库，仅用于 `LLVM_PGO_TYPE=LLVMPGO` 插装包。产物：
 
 - `libclang_rt.profile_ios.a`（真机）
-- `libclang_rt.profile_iossim.a`（模拟器）
+- `libclang_rt.profile_iossim.a`（模拟器，arm64 + x86_64 fat）
 
 **必须与 Kotlin/Native 插装所用的 LLVM 大版本一致**（本仓库 demo 对应 KN 自带的 LLVM16）。不要直接使用本机 Xcode（clang17+）自带的 `libclang_rt.profile_*.a`，否则会因 ABI / raw profile version 不匹配导致运行崩溃或 `llvm-profdata merge` 失败。
 

--- a/iosApp/components/LLVMCompileRT/README.md
+++ b/iosApp/components/LLVMCompileRT/README.md
@@ -1,0 +1,21 @@
+# LLVMCompileRT
+
+LLVM Clang Profile Runtime 静态库，仅用于 `LLVM_PGO_TYPE=LLVMPGO` 插装包。产物：
+
+- `libclang_rt.profile_ios.a`（真机）
+- `libclang_rt.profile_iossim.a`（模拟器）
+
+**必须与 Kotlin/Native 插装所用的 LLVM 大版本一致**（本仓库 demo 对应 KN 自带的 LLVM16）。不要直接使用本机 Xcode（clang17+）自带的 `libclang_rt.profile_*.a`，否则会因 ABI / raw profile version 不匹配导致运行崩溃或 `llvm-profdata merge` 失败。
+
+准备方式（优先顺序）：
+
+1. **优先使用工具链自带库**：若 Kotlin/Native / 同版本 LLVM 工具链已附带 `libclang_rt.profile_ios*.a`，直接拷到本目录。
+2. **否则按对应版本从源码编译**：用与插装同版本的 clang，从同版本 compiler-rt 源码编出完整 profile runtime：
+
+```bash
+bash iosApp/scripts/setup_llvm_compile_rt.sh
+```
+
+该脚本使用 KN 自带的 LLVM16 clang，从 compiler-rt 16.0.0 源码编译到本目录。
+
+详见 [machine-outliner-pgo-guide.md](../../../docs/DevGuide/machine-outliner-pgo-guide.md)。

--- a/iosApp/components/LLVMCompileRT/empty.m
+++ b/iosApp/components/LLVMCompileRT/empty.m
@@ -1,0 +1,2 @@
+// Placeholder so CocoaPods accepts the pod; linking is done via OTHER_LDFLAGS.
+void LLVMCompileRT_placeholder(void) {}

--- a/iosApp/components/LLVMCompileRT/empty.m
+++ b/iosApp/components/LLVMCompileRT/empty.m
@@ -1,2 +1,17 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Placeholder so CocoaPods accepts the pod; linking is done via OTHER_LDFLAGS.
 void LLVMCompileRT_placeholder(void) {}

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		B7E41A032F00100100AAAA03 /* KRLLVMProfileDump.m in Sources */ = {isa = PBXBuildFile; fileRef = B7E41A022F00100100AAAA02 /* KRLLVMProfileDump.m */; };
+		B7E41A062F00100100AAAA06 /* KRLLVMProfileStub.m in Sources */ = {isa = PBXBuildFile; fileRef = B7E41A052F00100100AAAA05 /* KRLLVMProfileStub.m */; };
 		3A622B9B2AB052B0002410B8 /* TDFTestModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A622B982AB052B0002410B8 /* TDFTestModule.m */; };
 		3A622B9C2AB052B0002410B8 /* KRNewTestModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A622B992AB052B0002410B8 /* KRNewTestModule.m */; };
 		3AF526722A9309C300A93682 /* RootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AF526712A9309C300A93682 /* RootViewController.m */; };
@@ -35,6 +37,9 @@
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		B7E41A012F00100100AAAA01 /* KRLLVMProfileDump.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KRLLVMProfileDump.h; sourceTree = "<group>"; };
+		B7E41A022F00100100AAAA02 /* KRLLVMProfileDump.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KRLLVMProfileDump.m; sourceTree = "<group>"; };
+		B7E41A052F00100100AAAA05 /* KRLLVMProfileStub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KRLLVMProfileStub.m; sourceTree = "<group>"; };
 		389E5FAFF97F19DA513B54A5 /* libPods-iosApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iosApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A622B972AB052B0002410B8 /* TDFTestModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TDFTestModule.h; sourceTree = "<group>"; };
 		3A622B982AB052B0002410B8 /* TDFTestModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDFTestModule.m; sourceTree = "<group>"; };
@@ -148,6 +153,9 @@
 				FF047745288C47A7008D3F39 /* Vendor */,
 				058557BA273AAA24004C7B11 /* Assets.xcassets */,
 				7555FF82242A565900829871 /* ContentView.swift */,
+				B7E41A012F00100100AAAA01 /* KRLLVMProfileDump.h */,
+				B7E41A022F00100100AAAA02 /* KRLLVMProfileDump.m */,
+				B7E41A052F00100100AAAA05 /* KRLLVMProfileStub.m */,
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
@@ -323,8 +331,6 @@
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
-			outputPaths = (
-			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks.sh\"\n";
@@ -364,8 +370,6 @@
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-resources-${CONFIGURATION}-output-files.xcfilelist",
 			);
-			outputPaths = (
-			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-resources.sh\"\n";
@@ -380,6 +384,8 @@
 			files = (
 				FFBD31B829015A0200D555DE /* UINavigationController+FDFullscreenPopGesture.m in Sources */,
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
+				B7E41A032F00100100AAAA03 /* KRLLVMProfileDump.m in Sources */,
+				B7E41A062F00100100AAAA06 /* KRLLVMProfileStub.m in Sources */,
 				FF0DD45329EC211B0024F7FF /* KRRouterHandler.m in Sources */,
 				FF047757288C4842008D3F39 /* NSObject+RIJCategory.m in Sources */,
 				C125EBCC2D96FBE200FBFA34 /* KRAPNGViewHandler.m in Sources */,

--- a/iosApp/iosApp/KRLLVMProfileDump.h
+++ b/iosApp/iosApp/KRLLVMProfileDump.h
@@ -13,10 +13,15 @@
  * limitations under the License.
  */
 
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
+#import <Foundation/Foundation.h>
 
-#import "KuiklyRenderViewController.h"
-#import "RootViewController.h"
-#import "KRLLVMProfileDump.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void KRLLVMProfileSetFilename(const char *path);
+void KRLLVMProfileDump(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/iosApp/iosApp/KRLLVMProfileDump.m
+++ b/iosApp/iosApp/KRLLVMProfileDump.m
@@ -1,0 +1,79 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <errno.h>
+#import <stdio.h>
+#import <stdlib.h>
+#import <string.h>
+#import "KRLLVMProfileDump.h"
+
+extern int __llvm_profile_write_file(void);
+extern void __llvm_profile_set_filename(const char *Name);
+extern void __llvm_profile_initialize_file(void);
+extern uint64_t __llvm_profile_get_size_for_buffer(void);
+extern int __llvm_profile_write_buffer(char *Buffer);
+
+void KRLLVMProfileSetFilename(const char *path) {
+    if (path == NULL) {
+        return;
+    }
+    NSString *nsPath = [NSString stringWithUTF8String:path];
+    NSString *dir = [nsPath stringByDeletingLastPathComponent];
+    [[NSFileManager defaultManager] createDirectoryAtPath:dir
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:nil];
+    setenv("LLVM_PROFILE_FILE", path, 1);
+    __llvm_profile_set_filename(path);
+    __llvm_profile_initialize_file();
+    NSLog(@"[LLVM_PGO] set_filename => %s", path);
+}
+
+void KRLLVMProfileDump(void) {
+    // 先尝试 runtime 原生 write_file（与插装同版本的 compiler-rt 时更可靠）
+    errno = 0;
+    int rc = __llvm_profile_write_file();
+    NSLog(@"[LLVM_PGO] __llvm_profile_write_file => %d errno=%d (%s)", rc, errno, strerror(errno));
+    if (rc == 0) {
+        return;
+    }
+
+    // 回退：buffer API
+    uint64_t size = __llvm_profile_get_size_for_buffer();
+    NSLog(@"[LLVM_PGO] profile buffer size=%llu", (unsigned long long)size);
+    if (size > 0 && size < 512ull * 1024ull * 1024ull) {
+        char *buf = (char *)malloc((size_t)size);
+        if (buf != NULL) {
+            int wrc = __llvm_profile_write_buffer(buf);
+            NSLog(@"[LLVM_PGO] write_buffer => %d", wrc);
+            if (wrc == 0) {
+                const char *path = getenv("LLVM_PROFILE_FILE");
+                if (path != NULL) {
+                    FILE *fp = fopen(path, "wb");
+                    if (fp != NULL) {
+                        size_t n = fwrite(buf, 1, (size_t)size, fp);
+                        fclose(fp);
+                        NSLog(@"[LLVM_PGO] fwrite => %zu/%llu path=%s", n, (unsigned long long)size, path);
+                        free(buf);
+                        return;
+                    }
+                    NSLog(@"[LLVM_PGO] fopen failed errno=%d (%s) path=%s", errno, strerror(errno), path);
+                }
+            }
+            free(buf);
+        }
+    }
+}

--- a/iosApp/iosApp/KRLLVMProfileStub.m
+++ b/iosApp/iosApp/KRLLVMProfileStub.m
@@ -1,3 +1,18 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #import <Foundation/Foundation.h>
 #import <stdint.h>
 

--- a/iosApp/iosApp/KRLLVMProfileStub.m
+++ b/iosApp/iosApp/KRLLVMProfileStub.m
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+#import <stdint.h>
+
+__attribute__((weak)) int __llvm_profile_write_file(void) {
+    return 0;
+}
+
+__attribute__((weak)) void __llvm_profile_set_filename(const char *Name) {
+    (void)Name;
+}
+
+__attribute__((weak)) void __llvm_profile_initialize_file(void) {
+}
+
+__attribute__((weak)) uint64_t __llvm_profile_get_size_for_buffer(void) {
+    return 0;
+}
+
+__attribute__((weak)) int __llvm_profile_write_buffer(char *Buffer) {
+    (void)Buffer;
+    return -1;
+}

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -14,6 +14,8 @@
  */
 
 import SwiftUI
+
+#if LLVM_PGO_INSTRUMENT
 import UIKit
 
 enum LLVMProfileBootstrap {
@@ -69,10 +71,13 @@ final class LLVMProfileAppDelegate: NSObject, UIApplicationDelegate {
         LLVMProfileBootstrap.writeIfAvailable()
     }
 }
+#endif
 
 @main
 struct iOSApp: App {
+#if LLVM_PGO_INSTRUMENT
     @UIApplicationDelegateAdaptor(LLVMProfileAppDelegate.self) var appDelegate
+#endif
 
     var body: some Scene {
         WindowGroup {

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -14,12 +14,69 @@
  */
 
 import SwiftUI
+import UIKit
+
+enum LLVMProfileBootstrap {
+    static var profilePath: String {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        return docs.appendingPathComponent("kuikly_ios.profraw").path
+    }
+
+    static func configure() {
+        KRLLVMProfileSetFilename(profilePath)
+        NSLog("[LLVM_PGO] configured path=%@", profilePath)
+    }
+
+    static func writeIfAvailable() {
+        KRLLVMProfileDump()
+        let path = profilePath
+        let exists = FileManager.default.fileExists(atPath: path)
+        var size: UInt64 = 0
+        if exists, let attrs = try? FileManager.default.attributesOfItem(atPath: path) {
+            size = (attrs[.size] as? NSNumber)?.uint64Value ?? 0
+        }
+        NSLog("[LLVM_PGO] file exists=%@ size=%llu path=%@", exists ? "YES" : "NO", size, path)
+    }
+}
+
+final class LLVMProfileAppDelegate: NSObject, UIApplicationDelegate {
+    private var dumpTimer: Timer?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        LLVMProfileBootstrap.configure()
+        // 定时落盘：不依赖 SwiftUI onReceive
+        dumpTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { _ in
+            LLVMProfileBootstrap.writeIfAvailable()
+        }
+        if let dumpTimer {
+            RunLoop.main.add(dumpTimer, forMode: .common)
+        }
+        // 立即异步写一次
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            LLVMProfileBootstrap.writeIfAvailable()
+        }
+        return true
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        LLVMProfileBootstrap.writeIfAvailable()
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        LLVMProfileBootstrap.writeIfAvailable()
+    }
+}
 
 @main
 struct iOSApp: App {
-	var body: some Scene {
-		WindowGroup {
-			ContentView()
-		}
-	}
+    @UIApplicationDelegateAdaptor(LLVMProfileAppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
 }

--- a/iosApp/scripts/build_machine_outliner.sh
+++ b/iosApp/scripts/build_machine_outliner.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# PGO + Machine Outliner 优化包构建：LLVM_PGO_TYPE=MachineOutliner
+# 需要先存在 demo/llvmProfile/real_ios.profdata
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+IOS_APP="$REPO_ROOT/iosApp"
+PROFDATA="$REPO_ROOT/demo/llvmProfile/real_ios.profdata"
+MODE="device"
+CONFIGURATION="${CONFIGURATION:-Release}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --simulator) MODE="simulator" ;;
+    --device) MODE="device" ;;
+    --debug) CONFIGURATION="Debug" ;;
+    *)
+      echo "未知参数: $arg" >&2
+      echo "用法: $0 [--device|--simulator] [--debug]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -f "$PROFDATA" ]]; then
+  echo "error: 缺少 $PROFDATA" >&2
+  echo "请先构建插装包、采集 .profraw，并运行 iosApp/scripts/merge_profraw.sh" >&2
+  exit 1
+fi
+
+export LLVM_PGO_TYPE=MachineOutliner
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
+cd "$REPO_ROOT"
+bash ./gradlew :demo:generateDummyFramework --console=plain
+
+cd "$IOS_APP"
+# MachineOutliner 模式不引入 LLVMCompileRT
+pod install
+
+if [[ "$MODE" == "simulator" ]]; then
+  DEST='generic/platform=iOS Simulator'
+else
+  DEST='generic/platform=iOS'
+fi
+
+echo "==> Building iosApp ($CONFIGURATION, $MODE) with LLVM_PGO_TYPE=$LLVM_PGO_TYPE"
+xcodebuild -workspace iosApp.xcworkspace -scheme iosApp \
+  -destination "$DEST" \
+  -configuration "$CONFIGURATION" \
+  build
+
+echo "BUILD SUCCEEDED (MachineOutliner)。请对比 shared.framework / App 体积并做性能回归。"

--- a/iosApp/scripts/build_pgo_instrumented.sh
+++ b/iosApp/scripts/build_pgo_instrumented.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# PGO 插装包构建：LLVM_PGO_TYPE=LLVMPGO
+# 默认打模拟器 Debug；真机请传 --device。
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+IOS_APP="$REPO_ROOT/iosApp"
+MODE="simulator"
+CONFIGURATION="${CONFIGURATION:-Debug}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --device) MODE="device" ;;
+    --release) CONFIGURATION="Release" ;;
+    --simulator) MODE="simulator" ;;
+    *)
+      echo "未知参数: $arg" >&2
+      echo "用法: $0 [--simulator|--device] [--release]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+bash "$IOS_APP/scripts/setup_llvm_compile_rt.sh"
+
+export LLVM_PGO_TYPE=LLVMPGO
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
+cd "$REPO_ROOT"
+bash ./gradlew :demo:generateDummyFramework --console=plain
+
+cd "$IOS_APP"
+pod install
+
+if [[ "$MODE" == "simulator" ]]; then
+  DEST='generic/platform=iOS Simulator'
+else
+  DEST='generic/platform=iOS'
+fi
+
+echo "==> Building iosApp ($CONFIGURATION, $MODE) with LLVM_PGO_TYPE=$LLVM_PGO_TYPE"
+xcodebuild -workspace iosApp.xcworkspace -scheme iosApp \
+  -destination "$DEST" \
+  -configuration "$CONFIGURATION" \
+  build
+
+echo "BUILD SUCCEEDED (instrumented). 运行 App 执行核心业务后，从沙盒导出 .profraw，再执行 merge_profraw.sh"

--- a/iosApp/scripts/build_pgo_instrumented.sh
+++ b/iosApp/scripts/build_pgo_instrumented.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # PGO 插装包构建：LLVM_PGO_TYPE=LLVMPGO
 # 默认打模拟器 Debug；真机请传 --device。
+# 通过 SWIFT_ACTIVE_COMPILATION_CONDITIONS=LLVM_PGO_INSTRUMENT 打开 App 侧落盘逻辑；
+# 普通 / MachineOutliner 包不传该宏，不会挂定时器。
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -34,15 +36,22 @@ cd "$IOS_APP"
 pod install
 
 if [[ "$MODE" == "simulator" ]]; then
+  # generic/platform=iOS Simulator 可能编出含 x86_64 的 universal；profile runtime 已 lipo 成 fat。
+  # 仍显式指定 ARCHS=arm64，避免在 Apple Silicon 上无谓编 x86_64。
   DEST='generic/platform=iOS Simulator'
+  ARCHS_OVERRIDE=(ARCHS=arm64 ONLY_ACTIVE_ARCH=NO)
 else
   DEST='generic/platform=iOS'
+  ARCHS_OVERRIDE=(ARCHS=arm64)
 fi
 
 echo "==> Building iosApp ($CONFIGURATION, $MODE) with LLVM_PGO_TYPE=$LLVM_PGO_TYPE"
 xcodebuild -workspace iosApp.xcworkspace -scheme iosApp \
   -destination "$DEST" \
   -configuration "$CONFIGURATION" \
+  "${ARCHS_OVERRIDE[@]}" \
+  SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) LLVM_PGO_INSTRUMENT' \
+  GCC_PREPROCESSOR_DEFINITIONS='$(inherited) LLVM_PGO_INSTRUMENT=1' \
   build
 
 echo "BUILD SUCCEEDED (instrumented). 运行 App 执行核心业务后，从沙盒导出 .profraw，再执行 merge_profraw.sh"

--- a/iosApp/scripts/merge_profraw.sh
+++ b/iosApp/scripts/merge_profraw.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# 将收集到的 .profraw 合并为 demo/llvmProfile/real_ios.profdata
+# 优先使用 Kotlin/Native 自带的 llvm-profdata（与 KN LLVM 版本更匹配）。
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+OUT_DIR="$REPO_ROOT/demo/llvmProfile"
+OUT_FILE="$OUT_DIR/real_ios.profdata"
+PROFRAW_DIR="${1:-$OUT_DIR/profraw}"
+
+mkdir -p "$OUT_DIR" "$PROFRAW_DIR"
+
+shopt -s nullglob
+PROFRAW_FILES=("$PROFRAW_DIR"/*.profraw)
+if [[ ${#PROFRAW_FILES[@]} -eq 0 ]]; then
+  echo "error: 在 $PROFRAW_DIR 下未找到 .profraw 文件。" >&2
+  echo "用法: $0 [profraw目录]" >&2
+  exit 1
+fi
+
+find_llvm_profdata() {
+  local candidates=(
+    "$HOME/.konan/dependencies/llvm-16.0.0-aarch64-macos-essentials-65/bin/llvm-profdata"
+    "$HOME/.konan/dependencies/llvm-19-aarch64-macos-essentials-79/bin/llvm-profdata"
+  )
+  local c
+  for c in "${candidates[@]}"; do
+    if [[ -x "$c" ]]; then
+      echo "$c"
+      return 0
+    fi
+  done
+  # 回退：任意 konan llvm-profdata / xcrun
+  local found
+  found="$(find "$HOME/.konan/dependencies" -name llvm-profdata -type f 2>/dev/null | head -1 || true)"
+  if [[ -n "$found" ]]; then
+    echo "$found"
+    return 0
+  fi
+  if command -v llvm-profdata >/dev/null 2>&1; then
+    command -v llvm-profdata
+    return 0
+  fi
+  if xcrun --find llvm-profdata >/dev/null 2>&1; then
+    xcrun --find llvm-profdata
+    return 0
+  fi
+  return 1
+}
+
+PROFDATA_BIN="$(find_llvm_profdata)" || {
+  echo "error: 找不到 llvm-profdata" >&2
+  exit 1
+}
+
+echo "Using: $PROFDATA_BIN"
+echo "Input: ${PROFRAW_FILES[*]}"
+"$PROFDATA_BIN" merge -output="$OUT_FILE" "${PROFRAW_FILES[@]}"
+echo "Wrote: $OUT_FILE ($(du -h "$OUT_FILE" | awk '{print $1}'))"

--- a/iosApp/scripts/merge_profraw.sh
+++ b/iosApp/scripts/merge_profraw.sh
@@ -19,21 +19,18 @@ if [[ ${#PROFRAW_FILES[@]} -eq 0 ]]; then
 fi
 
 find_llvm_profdata() {
-  local candidates=(
-    "$HOME/.konan/dependencies/llvm-16.0.0-aarch64-macos-essentials-65/bin/llvm-profdata"
-    "$HOME/.konan/dependencies/llvm-19-aarch64-macos-essentials-79/bin/llvm-profdata"
-  )
-  local c
-  for c in "${candidates[@]}"; do
-    if [[ -x "$c" ]]; then
-      echo "$c"
-      return 0
-    fi
-  done
-  # 回退：任意 konan llvm-profdata / xcrun
+  # 优先：与插装同大版本的 KN LLVM16（glob，避免写死 essentials hash 后缀）
+  local llvm16
+  llvm16="$(ls -d "$HOME"/.konan/dependencies/llvm-16.0.0-*-macos-*/bin/llvm-profdata 2>/dev/null | sort -V | tail -1 || true)"
+  if [[ -n "$llvm16" && -x "$llvm16" ]]; then
+    echo "$llvm16"
+    return 0
+  fi
+
+  # 回退：任意 konan llvm-profdata / PATH / xcrun（可能与 LLVM16 不一致，调用方需 warn）
   local found
-  found="$(find "$HOME/.konan/dependencies" -name llvm-profdata -type f 2>/dev/null | head -1 || true)"
-  if [[ -n "$found" ]]; then
+  found="$(find "$HOME/.konan/dependencies" -name llvm-profdata -type f 2>/dev/null | sort -V | tail -1 || true)"
+  if [[ -n "$found" && -x "$found" ]]; then
     echo "$found"
     return 0
   fi
@@ -52,6 +49,15 @@ PROFDATA_BIN="$(find_llvm_profdata)" || {
   echo "error: 找不到 llvm-profdata" >&2
   exit 1
 }
+
+case "$PROFDATA_BIN" in
+  */llvm-16.0.0-*/bin/llvm-profdata) ;;
+  *)
+    echo "warning: 未命中 KN LLVM16 的 llvm-profdata，当前使用: $PROFDATA_BIN" >&2
+    echo "         插装产物为 LLVM16 raw profile；版本不匹配可能导致 merge 失败或静默损坏。" >&2
+    echo "         请先执行一次 iOS 构建以下载 ~/.konan/dependencies/llvm-16.0.0-*-macos-*。" >&2
+    ;;
+esac
 
 echo "Using: $PROFDATA_BIN"
 echo "Input: ${PROFRAW_FILES[*]}"

--- a/iosApp/scripts/setup_llvm_compile_rt.sh
+++ b/iosApp/scripts/setup_llvm_compile_rt.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# 用 Kotlin/Native 自带的 LLVM16 clang 从 compiler-rt 16.0.0 源码编译完整的
+# profile runtime（libclang_rt.profile_ios*.a）。
+#
+# 为什么不直接拷 Xcode 的 libclang_rt.profile_*.a：
+#   Xcode(clang17) 的 profile runtime 与 KN(LLVM16) 插装生成的 __llvm_prf_* ABI
+#   不一致（value-profiling 结构、raw profile version=8 vs 10），运行/合并都会出错。
+#   因此这里用与插装同版本的 LLVM16 源码构建，保证 ABI 完全匹配。
+#
+# 说明：插装侧已用 `-mllvm -disable-vp` 关闭 value profiling，但 runtime 仍需保留
+#   InstrProfilingValue.c 以解析 lprofGetVPDataReader / lprofSetupValueProfiler 等符号，
+#   否则 InstrProfilingFile.c / InstrProfilingMergeFile.c 链接会缺符号。
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="$ROOT/components/LLVMCompileRT"
+mkdir -p "$DEST"
+
+# --- 1. 定位 KN LLVM16 工具链 ---
+KONAN_LLVM="$(ls -d "$HOME"/.konan/dependencies/llvm-16.0.0-*-macos-*/ 2>/dev/null | sort -V | tail -1 || true)"
+if [[ -z "${KONAN_LLVM}" || ! -x "${KONAN_LLVM}bin/clang" ]]; then
+  echo "error: 未找到 KN LLVM16 clang（~/.konan/dependencies/llvm-16.0.0-*-macos-*）。" >&2
+  echo "       请先执行一次 iOS 构建以下载 Kotlin/Native LLVM 依赖。" >&2
+  exit 1
+fi
+CLANG="${KONAN_LLVM}bin/clang"
+AR="${KONAN_LLVM}bin/llvm-ar"
+RANLIB="${KONAN_LLVM}bin/llvm-ranlib"
+[[ -x "$AR" ]] || AR="ar"
+[[ -x "$RANLIB" ]] || RANLIB="ranlib"
+echo "Using clang: $CLANG"
+
+# --- 2. 定位/获取 compiler-rt 16.0.0 源码 ---
+CRT_SRC="${COMPILER_RT_SRC:-/tmp/compiler-rt-16.0.0.src}"
+if [[ ! -d "$CRT_SRC/lib/profile" ]]; then
+  echo "compiler-rt 源码不存在，尝试下载 llvmorg-16.0.0 ..."
+  TARBALL="/tmp/compiler-rt-16.0.0.src.tar.xz"
+  URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.0/compiler-rt-16.0.0.src.tar.xz"
+  curl -fL "$URL" -o "$TARBALL"
+  tar -C /tmp -xf "$TARBALL"
+  CRT_SRC="/tmp/compiler-rt-16.0.0.src"
+fi
+if [[ ! -d "$CRT_SRC/lib/profile" ]]; then
+  echo "error: 找不到 compiler-rt profile 源码：$CRT_SRC/lib/profile" >&2
+  exit 1
+fi
+echo "Using compiler-rt src: $CRT_SRC"
+
+PROF="$CRT_SRC/lib/profile"
+INC="$CRT_SRC/include"
+
+# Darwin 目标需要的 profile 源文件（排除 Linux/Fuchsia/Windows/Other 与 gcov）。
+SOURCES=(
+  InstrProfiling.c
+  InstrProfilingBuffer.c
+  InstrProfilingFile.c
+  InstrProfilingInternal.c
+  InstrProfilingMerge.c
+  InstrProfilingMergeFile.c
+  InstrProfilingNameVar.c
+  InstrProfilingPlatformDarwin.c
+  InstrProfilingUtil.c
+  InstrProfilingValue.c
+  InstrProfilingVersionVar.c
+  InstrProfilingWriter.c
+)
+
+build_lib() {
+  local out="$1"; shift
+  local target="$1"; shift
+  local sdk="$1"; shift
+  local work; work="$(mktemp -d)"
+  echo "==> Building $(basename "$out")  target=$target"
+  for src in "${SOURCES[@]}"; do
+    # 这些 feature 宏正常由 compiler-rt CMake 自动探测；手动编译需显式打开，
+    # 否则 lprofGetHostName / lprofLockFd 等 Darwin 可用实现不会被编入，链接缺符号。
+    "$CLANG" -c -O2 -fPIC \
+      -target "$target" -isysroot "$sdk" \
+      -I"$INC" -I"$PROF" \
+      -DCOMPILER_RT_HAS_ATOMICS=1 \
+      -DCOMPILER_RT_HAS_UNAME=1 \
+      -DCOMPILER_RT_HAS_FCNTL_LCK=1 \
+      "$PROF/$src" -o "$work/${src%.c}.o"
+  done
+  rm -f "$out"
+  "$AR" cru "$out" "$work"/*.o
+  "$RANLIB" "$out"
+  rm -rf "$work"
+}
+
+SIM_SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+IOS_SDK="$(xcrun --sdk iphoneos --show-sdk-path)"
+
+build_lib "$DEST/libclang_rt.profile_iossim.a" "arm64-apple-ios14.1-simulator" "$SIM_SDK"
+build_lib "$DEST/libclang_rt.profile_ios.a"    "arm64-apple-ios14.1"           "$IOS_SDK"
+
+ls -lh "$DEST"/libclang_rt.profile_*.a
+echo "Done. LLVMCompileRT（LLVM16 完整 profile runtime）已就绪: $DEST"

--- a/iosApp/scripts/setup_llvm_compile_rt.sh
+++ b/iosApp/scripts/setup_llvm_compile_rt.sh
@@ -91,8 +91,17 @@ build_lib() {
 SIM_SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
 IOS_SDK="$(xcrun --sdk iphoneos --show-sdk-path)"
 
-build_lib "$DEST/libclang_rt.profile_iossim.a" "arm64-apple-ios14.1-simulator" "$SIM_SDK"
-build_lib "$DEST/libclang_rt.profile_ios.a"    "arm64-apple-ios14.1"           "$IOS_SDK"
+# iossim 需要 arm64 + x86_64 双 slice：demo/build.gradle.kts 覆盖了 ios_simulator_arm64
+# 与 ios_x64；Intel Mac 上 --simulator 会链 x86_64，单 arm64 库会报 symbol not found。
+SIM_ARM64_A="$DEST/libclang_rt.profile_iossim_arm64.a"
+SIM_X64_A="$DEST/libclang_rt.profile_iossim_x86_64.a"
+build_lib "$SIM_ARM64_A" "arm64-apple-ios14.1-simulator" "$SIM_SDK"
+build_lib "$SIM_X64_A"   "x86_64-apple-ios14.1-simulator" "$SIM_SDK"
+rm -f "$DEST/libclang_rt.profile_iossim.a"
+lipo -create "$SIM_ARM64_A" "$SIM_X64_A" -output "$DEST/libclang_rt.profile_iossim.a"
+rm -f "$SIM_ARM64_A" "$SIM_X64_A"
+
+build_lib "$DEST/libclang_rt.profile_ios.a" "arm64-apple-ios14.1" "$IOS_SDK"
 
 ls -lh "$DEST"/libclang_rt.profile_*.a
-echo "Done. LLVMCompileRT（LLVM16 完整 profile runtime）已就绪: $DEST"
+echo "Done. LLVMCompileRT（LLVM16 完整 profile runtime，iossim 为 arm64+x86_64 fat）已就绪: $DEST"


### PR DESCRIPTION
## Summary
- Wire `demo`/`iosApp` for LLVM PGO instrumentation (`LLVM_PGO_TYPE=LLVMPGO`), profraw → profdata merge, then Machine Outliner rebuild (`MachineOutliner`, optional `-fprofile-instrument-use-path`).
- Add KN-matched LLVM16 profile runtime setup (`LLVMCompileRT` + scripts), App-side dump hooks, and DevGuide docs covering pitfalls (ABI / VP / strip comparison).
- Measured Release `iosArm64` `shared` after `strip -S -x`: baseline 70.27 MiB → outliner-only 68.24 MiB (−2.89%) → outliner+PGO-use 68.99 MiB (−1.82%).

## Test plan
- [ ] `bash iosApp/scripts/setup_llvm_compile_rt.sh`
- [ ] `bash iosApp/scripts/build_pgo_instrumented.sh --simulator`，模拟器跑核心路径后导出 `.profraw`
- [ ] `bash iosApp/scripts/merge_profraw.sh` 得到 `demo/llvmProfile/real_ios.profdata`
- [ ] `bash iosApp/scripts/build_machine_outliner.sh --device`（或 `linkPodReleaseFrameworkIosArm64`），确认 Gradle 日志出现 `使用 profdata:`
- [ ] 对比 strip 后 `shared` / 安装包体积，并做启动 / 滚动 / 动画性能回归
- [ ] 确认非 `LLVMPGO` 构建不链接 `LLVMCompileRT`