### PR TITLE
fix(ohos): add statusCode to network response callback

### DIFF
--- a/core-render-ohos/src/main/ets/modules/KRNetworkModule.ets
+++ b/core-render-ohos/src/main/ets/modules/KRNetworkModule.ets
@@ -92,6 +92,7 @@ export class KRNetworkModule extends KuiklyRenderBaseModule {
             resultObject['data'] = '';
             resultObject['errorMsg'] = JSON.stringify(err);
             resultObject['success'] = '0';
+            resultObject['statusCode'] = response ? response.responseCode.toString() : '-1000';
           } else {
             if (binaryMode) {
               if (response.result instanceof ArrayBuffer) {
@@ -104,6 +105,7 @@ export class KRNetworkModule extends KuiklyRenderBaseModule {
             }
             resultObject['errorMsg'] = '';
             resultObject['success'] = '1';
+            resultObject['statusCode'] = response.responseCode.toString();
           }
 
           if (binaryMode) {
@@ -123,6 +125,7 @@ export class KRNetworkModule extends KuiklyRenderBaseModule {
           let resultObject: Record<string, string> = {};
           resultObject['errorMsg'] = errmsg;
           resultObject['success'] = "0";
+          resultObject['statusCode'] = '-1000';
           callback(resultObject);
         });
       }


### PR DESCRIPTION
## Summary
- OHOS `KRNetworkModule` 的 HTTP 回调中缺少 `statusCode` 字段，导致 `NetworkResponse.statusCode` 始终为 `null`
- 在三处回调路径中添加 `response.responseCode`：
  - 成功：取 `response.responseCode`
  - HTTP 错误（err 非空）：优先取 `response.responseCode`，无 response 时返回 `-1000`
  - 网络异常（catch）：固定 `-1000`（对齐 Android 端 `STATE_CODE_UNKNOWN`）

## Test plan
- [ ] 在 OHOS App 中发起 HTTP 请求，验证 `NetworkResponse.statusCode` 正常返回状态码
- [ ] 请求一个返回 4xx/5xx 的 URL，验证错误回调中 statusCode 不为 null
- [ ] 请求一个不存在的域名，验证异常回调中 statusCode 为 -1000