### PR TITLE
feat: 新增 Android/iOS 零依赖 APNG 适配器参考实现

### DIFF
--- a/androidApp/src/main/java/com/tencent/kuikly/android/demo/adapter/KRAPNGViewAdapterLite.kt
+++ b/androidApp/src/main/java/com/tencent/kuikly/android/demo/adapter/KRAPNGViewAdapterLite.kt
@@ -1,0 +1,192 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.android.demo.adapter
+
+import android.content.Context
+import android.graphics.BitmapFactory
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import android.widget.ImageView
+import com.tencent.kuikly.core.render.android.adapter.IAPNGView
+import com.tencent.kuikly.core.render.android.adapter.IAPNGViewAnimationListener
+import com.tencent.kuikly.core.render.android.adapter.IKRAPNGViewAdapter
+import java.io.File
+import java.nio.ByteBuffer
+import java.util.zip.CRC32
+
+/**
+ * 零第三方依赖的 APNG 宿主适配器（参考实现）。
+ *
+ * 与 [KRAPNGViewAdapter]（依赖 APNG4Android 库）不同，本实现不引入任何第三方库：
+ * 手工解析 APNG 块结构（IHDR/acTL/fcTL/IDAT/fdAT），逐帧重建标准 PNG 交给
+ * BitmapFactory 解码，Handler 按帧延时切帧，只依赖 Android 稳定 API。
+ *
+ * 适用边界：仅支持「全帧」APNG（每帧尺寸=画布尺寸、offset=0、blend/dispose=0），
+ * 这类文件覆盖了大多数图标/加载动效场景（常见导出工具默认产出全帧）。
+ * 解析失败或不含动画帧时降级为静态图显示，不崩溃。
+ *
+ * 使用：在 Application.onCreate 注册
+ *   KuiklyRenderAdapterManager.krAPNGViewAdapter = KRAPNGViewAdapterLite()
+ */
+class KRAPNGViewAdapterLite : IKRAPNGViewAdapter {
+    override fun createAPNGView(context: Context): IAPNGView = KRAPNGLiteImageView(context)
+}
+
+private class KRAPNGLiteImageView(context: Context) : IAPNGView {
+
+    private class Frame(val png: ByteArray, val delayMs: Long)
+
+    private val imageView = ImageView(context)
+    private val handler = Handler(Looper.getMainLooper())
+    private var frames: List<Frame> = emptyList()
+    private var numPlays = 0 // acTL num_plays：0=无限
+    private var repeatCount = 0 // Kuikly repeatCount：0=不限制（回退到文件 num_plays），N=播 N 次
+    private var frameIndex = 0
+    private var playedLoops = 0
+    private var playing = false
+    private val listeners = arrayListOf<IAPNGViewAnimationListener>()
+
+    private val tick = object : Runnable {
+        override fun run() {
+            if (!playing || frames.isEmpty()) return
+            val f = frames[frameIndex]
+            imageView.setImageBitmap(BitmapFactory.decodeByteArray(f.png, 0, f.png.size))
+            frameIndex++
+            if (frameIndex >= frames.size) {
+                playedLoops++
+                val limit = if (repeatCount > 0) repeatCount else numPlays
+                if (limit > 0 && playedLoops >= limit) {
+                    // 播完停在最末帧并保持显示
+                    playing = false
+                    frameIndex = frames.size - 1
+                    listeners.toList().forEach { it.onAnimationEnd(imageView) }
+                    return
+                }
+                frameIndex = 0
+            }
+            handler.postDelayed(this, frames[frameIndex.coerceAtMost(frames.size - 1)].delayMs)
+        }
+    }
+
+    override fun setFilePath(filePath: String) {
+        frames = try {
+            parseApng(File(filePath).readBytes())
+        } catch (t: Throwable) {
+            emptyList()
+        }
+        if (frames.isEmpty()) {
+            // 解析失败/非动画：降级为静态图兜底（普通 PNG 也能正常显示）
+            imageView.setImageBitmap(BitmapFactory.decodeFile(filePath))
+        }
+    }
+
+    override fun asView(): View = imageView
+
+    override fun setRepeatCount(count: Int) {
+        repeatCount = count
+    }
+
+    override fun playAnimation() {
+        if (frames.isEmpty()) return
+        handler.removeCallbacks(tick)
+        frameIndex = 0
+        playedLoops = 0
+        playing = true
+        handler.post(tick)
+    }
+
+    override fun stopAnimation() {
+        playing = false
+        handler.removeCallbacks(tick)
+    }
+
+    override fun addAnimationListener(listener: IAPNGViewAnimationListener) {
+        if (!listeners.contains(listener)) listeners.add(listener)
+    }
+
+    override fun removeAnimationListener(listener: IAPNGViewAnimationListener) {
+        listeners.remove(listener)
+    }
+
+    override fun setKRProp(propKey: String, value: Any): Boolean = false
+
+    // ---------- 极简 APNG 解析（仅支持全帧：offset=0、blend/dispose=0） ----------
+
+    private fun chunk(type: String, body: ByteArray): ByteArray {
+        val crc = CRC32()
+        crc.update(type.toByteArray(Charsets.US_ASCII))
+        crc.update(body)
+        val out = ByteBuffer.allocate(12 + body.size)
+        out.putInt(body.size)
+        out.put(type.toByteArray(Charsets.US_ASCII))
+        out.put(body)
+        out.putInt(crc.value.toInt())
+        return out.array()
+    }
+
+    private fun parseApng(data: ByteArray): List<Frame> {
+        val sig = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
+        if (data.size < 8 || !data.copyOfRange(0, 8).contentEquals(sig)) return emptyList()
+        val buf = ByteBuffer.wrap(data)
+        buf.position(8) // 跳过 PNG 签名
+        var ihdr: ByteArray? = null
+        var pendingDelayMs = 40L
+        var pendingFirstFrame = false
+        val result = arrayListOf<Frame>()
+        while (buf.remaining() >= 12) {
+            val len = buf.int
+            if (len < 0 || buf.remaining() < len + 4) break // 截断文件，止损
+            val typeBytes = ByteArray(4)
+            buf.get(typeBytes)
+            val type = String(typeBytes, Charsets.US_ASCII)
+            val body = ByteArray(len)
+            buf.get(body)
+            buf.int // crc 跳过
+            when (type) {
+                "IHDR" -> ihdr = body
+                "acTL" -> numPlays = ByteBuffer.wrap(body).getInt(4)
+                "fcTL" -> {
+                    val dn = ByteBuffer.wrap(body).getShort(20).toInt()
+                    val dd = ByteBuffer.wrap(body).getShort(22).toInt()
+                    // 规范：delay_den=0 按 100 计
+                    pendingDelayMs = (dn * 1000L / (if (dd == 0) 100 else dd)).coerceAtLeast(10)
+                    pendingFirstFrame = result.isEmpty()
+                }
+                "IDAT" -> {
+                    // fcTL 之后的 IDAT = 动画首帧（首帧参与动画的常见结构）
+                    if (pendingFirstFrame && ihdr != null) {
+                        result.add(Frame(rebuildPng(ihdr!!, body), pendingDelayMs))
+                        pendingFirstFrame = false
+                    }
+                }
+                "fdAT" -> {
+                    if (ihdr != null && body.size >= 4) {
+                        // fdAT 数据前 4 字节为序号，其后为 IDAT 数据
+                        result.add(Frame(rebuildPng(ihdr!!, body.copyOfRange(4, body.size)), pendingDelayMs))
+                    }
+                }
+                "IEND" -> break
+            }
+        }
+        return result
+    }
+
+    private fun rebuildPng(ihdr: ByteArray, idat: ByteArray): ByteArray {
+        val sig = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
+        return sig + chunk("IHDR", ihdr) + chunk("IDAT", idat) + chunk("IEND", ByteArray(0))
+    }
+}

--- a/androidApp/src/main/java/com/tencent/kuikly/android/demo/adapter/KRAPNGViewAdapterLite.kt
+++ b/androidApp/src/main/java/com/tencent/kuikly/android/demo/adapter/KRAPNGViewAdapterLite.kt
@@ -29,17 +29,21 @@ import java.nio.ByteBuffer
 import java.util.zip.CRC32
 
 /**
- * 零第三方依赖的 APNG 宿主适配器（参考实现）。
+ * Zero-dependency APNG host adapter (reference implementation).
  *
- * 与 [KRAPNGViewAdapter]（依赖 APNG4Android 库）不同，本实现不引入任何第三方库：
- * 手工解析 APNG 块结构（IHDR/acTL/fcTL/IDAT/fdAT），逐帧重建标准 PNG 交给
- * BitmapFactory 解码，Handler 按帧延时切帧，只依赖 Android 稳定 API。
+ * Unlike [KRAPNGViewAdapter] (which relies on the APNG4Android library), this
+ * implementation pulls in no third-party dependency: it parses the APNG chunk
+ * structure (IHDR/acTL/fcTL/IDAT/fdAT) by hand, rebuilds each frame as a
+ * standard PNG for BitmapFactory to decode, and switches frames on a Handler
+ * using per-frame delays — stable Android APIs only.
  *
- * 适用边界：仅支持「全帧」APNG（每帧尺寸=画布尺寸、offset=0、blend/dispose=0），
- * 这类文件覆盖了大多数图标/加载动效场景（常见导出工具默认产出全帧）。
- * 解析失败或不含动画帧时降级为静态图显示，不崩溃。
+ * Scope: only "full-frame" APNG files are supported (every frame matches the
+ * canvas size, offset = 0, blend/dispose = 0). Most export tools produce
+ * full-frame output by default, which covers typical icon/loading animations.
+ * On parse failure or missing animation frames, falls back to displaying a
+ * static image instead of crashing.
  *
- * 使用：在 Application.onCreate 注册
+ * Usage: register in Application.onCreate
  *   KuiklyRenderAdapterManager.krAPNGViewAdapter = KRAPNGViewAdapterLite()
  */
 class KRAPNGViewAdapterLite : IKRAPNGViewAdapter {
@@ -53,8 +57,8 @@ private class KRAPNGLiteImageView(context: Context) : IAPNGView {
     private val imageView = ImageView(context)
     private val handler = Handler(Looper.getMainLooper())
     private var frames: List<Frame> = emptyList()
-    private var numPlays = 0 // acTL num_plays：0=无限
-    private var repeatCount = 0 // Kuikly repeatCount：0=不限制（回退到文件 num_plays），N=播 N 次
+    private var numPlays = 0 // acTL num_plays: 0 = loop forever
+    private var repeatCount = 0 // Kuikly repeatCount: 0 = fall back to file num_plays, N = play N times
     private var frameIndex = 0
     private var playedLoops = 0
     private var playing = false
@@ -70,7 +74,7 @@ private class KRAPNGLiteImageView(context: Context) : IAPNGView {
                 playedLoops++
                 val limit = if (repeatCount > 0) repeatCount else numPlays
                 if (limit > 0 && playedLoops >= limit) {
-                    // 播完停在最末帧并保持显示
+                    // Finished: hold on the last frame
                     playing = false
                     frameIndex = frames.size - 1
                     listeners.toList().forEach { it.onAnimationEnd(imageView) }
@@ -89,7 +93,8 @@ private class KRAPNGLiteImageView(context: Context) : IAPNGView {
             emptyList()
         }
         if (frames.isEmpty()) {
-            // 解析失败/非动画：降级为静态图兜底（普通 PNG 也能正常显示）
+            // Parse failure or non-animated image: fall back to a static bitmap
+            // (plain PNG files also render correctly this way) instead of crashing.
             imageView.setImageBitmap(BitmapFactory.decodeFile(filePath))
         }
     }
@@ -124,7 +129,7 @@ private class KRAPNGLiteImageView(context: Context) : IAPNGView {
 
     override fun setKRProp(propKey: String, value: Any): Boolean = false
 
-    // ---------- 极简 APNG 解析（仅支持全帧：offset=0、blend/dispose=0） ----------
+    // ---------- Minimal APNG parser (full-frame only: offset = 0, blend/dispose = 0) ----------
 
     private fun chunk(type: String, body: ByteArray): ByteArray {
         val crc = CRC32()
@@ -142,32 +147,33 @@ private class KRAPNGLiteImageView(context: Context) : IAPNGView {
         val sig = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
         if (data.size < 8 || !data.copyOfRange(0, 8).contentEquals(sig)) return emptyList()
         val buf = ByteBuffer.wrap(data)
-        buf.position(8) // 跳过 PNG 签名
+        buf.position(8) // skip PNG signature
         var ihdr: ByteArray? = null
         var pendingDelayMs = 40L
         var pendingFirstFrame = false
         val result = arrayListOf<Frame>()
         while (buf.remaining() >= 12) {
             val len = buf.int
-            if (len < 0 || buf.remaining() < len + 4) break // 截断文件，止损
+            if (len < 0 || buf.remaining() < len + 4) break // truncated file, bail out
             val typeBytes = ByteArray(4)
             buf.get(typeBytes)
             val type = String(typeBytes, Charsets.US_ASCII)
             val body = ByteArray(len)
             buf.get(body)
-            buf.int // crc 跳过
+            buf.int // skip crc
             when (type) {
                 "IHDR" -> ihdr = body
                 "acTL" -> numPlays = ByteBuffer.wrap(body).getInt(4)
                 "fcTL" -> {
                     val dn = ByteBuffer.wrap(body).getShort(20).toInt()
                     val dd = ByteBuffer.wrap(body).getShort(22).toInt()
-                    // 规范：delay_den=0 按 100 计
+                    // Spec: delay_den = 0 means 100; clamp to >= 10ms to avoid a zero-delay spin
                     pendingDelayMs = (dn * 1000L / (if (dd == 0) 100 else dd)).coerceAtLeast(10)
                     pendingFirstFrame = result.isEmpty()
                 }
                 "IDAT" -> {
-                    // fcTL 之后的 IDAT = 动画首帧（首帧参与动画的常见结构）
+                    // IDAT following a fcTL is the first animation frame (the common layout
+                    // where the default image is part of the animation)
                     if (pendingFirstFrame && ihdr != null) {
                         result.add(Frame(rebuildPng(ihdr!!, body), pendingDelayMs))
                         pendingFirstFrame = false
@@ -175,7 +181,7 @@ private class KRAPNGLiteImageView(context: Context) : IAPNGView {
                 }
                 "fdAT" -> {
                     if (ihdr != null && body.size >= 4) {
-                        // fdAT 数据前 4 字节为序号，其后为 IDAT 数据
+                        // fdAT payload: 4-byte sequence number followed by IDAT data
                         result.add(Frame(rebuildPng(ihdr!!, body.copyOfRange(4, body.size)), pendingDelayMs))
                     }
                 }

--- a/androidApp/src/main/java/com/tencent/kuikly/android/demo/adapter/KRAPNGViewAdapterLite.kt
+++ b/androidApp/src/main/java/com/tencent/kuikly/android/demo/adapter/KRAPNGViewAdapterLite.kt
@@ -57,8 +57,7 @@ private class KRAPNGLiteImageView(context: Context) : IAPNGView {
     private val imageView = ImageView(context)
     private val handler = Handler(Looper.getMainLooper())
     private var frames: List<Frame> = emptyList()
-    private var numPlays = 0 // acTL num_plays: 0 = loop forever
-    private var repeatCount = 0 // Kuikly repeatCount: 0 = fall back to file num_plays, N = play N times
+    private var repeatCount = 0 // Kuikly repeatCount: 0 = loop forever (DSL contract), N = play N times
     private var frameIndex = 0
     private var playedLoops = 0
     private var playing = false
@@ -72,8 +71,7 @@ private class KRAPNGLiteImageView(context: Context) : IAPNGView {
             frameIndex++
             if (frameIndex >= frames.size) {
                 playedLoops++
-                val limit = if (repeatCount > 0) repeatCount else numPlays
-                if (limit > 0 && playedLoops >= limit) {
+                if (repeatCount > 0 && playedLoops >= repeatCount) {
                     // Finished: hold on the last frame
                     playing = false
                     frameIndex = frames.size - 1
@@ -150,8 +148,21 @@ private class KRAPNGLiteImageView(context: Context) : IAPNGView {
         buf.position(8) // skip PNG signature
         var ihdr: ByteArray? = null
         var pendingDelayMs = 40L
-        var pendingFirstFrame = false
+        var hasPendingFrame = false
+        // Per spec, one frame's data may span multiple consecutive IDAT/fdAT
+        // chunks, so accumulate into a pending buffer and flush it as one PNG
+        // when the next fcTL (or IEND) arrives.
+        var pendingIdat = java.io.ByteArrayOutputStream()
         val result = arrayListOf<Frame>()
+
+        fun flushFrame() {
+            val frameData = pendingIdat.toByteArray()
+            if (!hasPendingFrame || frameData.isEmpty() || ihdr == null) return
+            result.add(Frame(rebuildPng(ihdr!!, frameData), pendingDelayMs))
+            pendingIdat = java.io.ByteArrayOutputStream()
+            hasPendingFrame = false
+        }
+
         while (buf.remaining() >= 12) {
             val len = buf.int
             if (len < 0 || buf.remaining() < len + 4) break // truncated file, bail out
@@ -163,31 +174,25 @@ private class KRAPNGLiteImageView(context: Context) : IAPNGView {
             buf.int // skip crc
             when (type) {
                 "IHDR" -> ihdr = body
-                "acTL" -> numPlays = ByteBuffer.wrap(body).getInt(4)
                 "fcTL" -> {
+                    flushFrame()
                     val dn = ByteBuffer.wrap(body).getShort(20).toInt()
                     val dd = ByteBuffer.wrap(body).getShort(22).toInt()
                     // Spec: delay_den = 0 means 100; clamp to >= 10ms to avoid a zero-delay spin
                     pendingDelayMs = (dn * 1000L / (if (dd == 0) 100 else dd)).coerceAtLeast(10)
-                    pendingFirstFrame = result.isEmpty()
+                    hasPendingFrame = true
                 }
-                "IDAT" -> {
-                    // IDAT following a fcTL is the first animation frame (the common layout
-                    // where the default image is part of the animation)
-                    if (pendingFirstFrame && ihdr != null) {
-                        result.add(Frame(rebuildPng(ihdr!!, body), pendingDelayMs))
-                        pendingFirstFrame = false
-                    }
-                }
-                "fdAT" -> {
-                    if (ihdr != null && body.size >= 4) {
-                        // fdAT payload: 4-byte sequence number followed by IDAT data
-                        result.add(Frame(rebuildPng(ihdr!!, body.copyOfRange(4, body.size)), pendingDelayMs))
-                    }
+                // IDAT following a fcTL is the first animation frame (the common layout
+                // where the default image is part of the animation)
+                "IDAT" -> if (hasPendingFrame) pendingIdat.write(body)
+                // fdAT payload: 4-byte sequence number followed by IDAT data
+                "fdAT" -> if (hasPendingFrame && body.size >= 4) {
+                    pendingIdat.write(body, 4, body.size - 4)
                 }
                 "IEND" -> break
             }
         }
+        flushFrame()
         return result
     }
 

--- a/docs/API/components/apng.md
+++ b/docs/API/components/apng.md
@@ -143,3 +143,13 @@ internal class TestPage : BasePager() {
 - 开始播放动画方法：`startAnimating` --> `startAPNGAnimating`
 - 结束播放动画方法：`stopAnimating` --> `stopAPNGAnimating`
 
+## 零第三方依赖参考实现
+
+Demo 工程中的适配器（Android 基于 APNG4Android、iOS 基于 SDWebImage）均依赖第三方解码库。如果业务不希望引入这类依赖，可使用仓库内置的零依赖参考实现：手工解析 APNG 块结构（`IHDR`/`acTL`/`fcTL`/`IDAT`/`fdAT`），逐帧重建标准 PNG 交系统解码器（`BitmapFactory`/`UIImage`），按帧延时调度播放：
+
+- **Android**：[KRAPNGViewAdapterLite.kt](https://github.com/Tencent-TDS/KuiklyUI/blob/main/androidApp/src/main/java/com/tencent/kuikly/android/demo/adapter/KRAPNGViewAdapterLite.kt)，注册方式 `KuiklyRenderAdapterManager.krAPNGViewAdapter = KRAPNGViewAdapterLite()`
+- **iOS**：[KRAPNGViewHandlerLite.h](https://github.com/Tencent-TDS/KuiklyUI/blob/main/iosApp/iosApp/KuiklyRenderExpand/Handlers/KRAPNGViewHandlerLite.h)，业务启动时调用 `[KRAPNGViewHandlerLite registerToKuikly]` 注册
+
+> 适用边界：仅支持「全帧」APNG（每帧尺寸 = 画布尺寸、offset = 0、blend/dispose = 0，常见导出工具默认产出全帧），覆盖图标/加载动效等大多数场景；解析失败或不含动画帧时降级为静态图显示。若需支持局部帧/帧合成（blend/dispose）的复杂 APNG，请使用第三方解码库适配器。
+
+

--- a/iosApp/iosApp/KuiklyRenderExpand/Handlers/KRAPNGViewHandlerLite.h
+++ b/iosApp/iosApp/KuiklyRenderExpand/Handlers/KRAPNGViewHandlerLite.h
@@ -1,0 +1,43 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import "KRAPNGView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * 零第三方依赖的 APNG 宿主适配器（参考实现）。
+ *
+ * 与 KRAPNGViewHandler（基于 SDWebImage 的 SDAnimatedImageView）不同，
+ * 本实现不引入任何第三方库：手工解析 APNG 块结构（IHDR/acTL/fcTL/IDAT/fdAT），
+ * 逐帧重建标准 PNG 交给 UIImage 解码，按帧延时调度播放。
+ *
+ * 适用边界：仅支持「全帧」APNG（每帧尺寸=画布尺寸、offset=0、blend/dispose=0），
+ * 这类文件覆盖了大多数图标/加载动效场景（常见导出工具默认产出全帧）。
+ * 解析失败或不含动画帧时降级为静态图显示，不崩溃。
+ *
+ * 注意：本类不做 +load 自动注册（demo 中的 KRAPNGViewHandler 已在 +load 注册，
+ * 两个 +load 同时存在时生效顺序不确定）。业务如需使用本实现，请在启动时显式调用
+ * +registerToKuikly 覆盖注册。
+ */
+@interface KRAPNGViewHandlerLite : UIView <APNGImageViewProtocol>
+
+/// 注册到 Kuikly（覆盖此前注册的 creator），业务启动时调用
++ (void)registerToKuikly;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iosApp/iosApp/KuiklyRenderExpand/Handlers/KRAPNGViewHandlerLite.h
+++ b/iosApp/iosApp/KuiklyRenderExpand/Handlers/KRAPNGViewHandlerLite.h
@@ -19,23 +19,28 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * 零第三方依赖的 APNG 宿主适配器（参考实现）。
+ * Zero-dependency APNG host adapter (reference implementation).
  *
- * 与 KRAPNGViewHandler（基于 SDWebImage 的 SDAnimatedImageView）不同，
- * 本实现不引入任何第三方库：手工解析 APNG 块结构（IHDR/acTL/fcTL/IDAT/fdAT），
- * 逐帧重建标准 PNG 交给 UIImage 解码，按帧延时调度播放。
+ * Unlike KRAPNGViewHandler (built on SDWebImage's SDAnimatedImageView), this
+ * implementation pulls in no third-party dependency: it parses the APNG chunk
+ * structure (IHDR/acTL/fcTL/IDAT/fdAT) by hand, rebuilds each frame as a
+ * standard PNG for UIImage to decode, and schedules playback by per-frame delays.
  *
- * 适用边界：仅支持「全帧」APNG（每帧尺寸=画布尺寸、offset=0、blend/dispose=0），
- * 这类文件覆盖了大多数图标/加载动效场景（常见导出工具默认产出全帧）。
- * 解析失败或不含动画帧时降级为静态图显示，不崩溃。
+ * Scope: only "full-frame" APNG files are supported (every frame matches the
+ * canvas size, offset = 0, blend/dispose = 0). Most export tools produce
+ * full-frame output by default, which covers typical icon/loading animations.
+ * On parse failure or missing animation frames, falls back to displaying a
+ * static image instead of crashing.
  *
- * 注意：本类不做 +load 自动注册（demo 中的 KRAPNGViewHandler 已在 +load 注册，
- * 两个 +load 同时存在时生效顺序不确定）。业务如需使用本实现，请在启动时显式调用
- * +registerToKuikly 覆盖注册。
+ * Note: this class intentionally does NOT self-register in +load. The demo's
+ * KRAPNGViewHandler already registers in +load, and with two +load registrations
+ * the winner is undefined. To use this implementation, call +registerToKuikly
+ * explicitly at app startup to override the registered creator.
  */
 @interface KRAPNGViewHandlerLite : UIView <APNGImageViewProtocol>
 
-/// 注册到 Kuikly（覆盖此前注册的 creator），业务启动时调用
+/// Registers this implementation with Kuikly (overrides any previously
+/// registered creator). Call once at app startup.
 + (void)registerToKuikly;
 
 @end

--- a/iosApp/iosApp/KuiklyRenderExpand/Handlers/KRAPNGViewHandlerLite.m
+++ b/iosApp/iosApp/KuiklyRenderExpand/Handlers/KRAPNGViewHandlerLite.m
@@ -15,9 +15,9 @@
 
 #import "KRAPNGViewHandlerLite.h"
 
-#pragma mark - APNG 手工解析
+#pragma mark - Hand-rolled APNG parser
 
-/// 单个动画帧：重建好的标准 PNG 数据 + 展示时长（秒）
+/// One animation frame: rebuilt standard PNG data + display duration (seconds)
 @interface KRAPNGLiteFrame : NSObject
 @property (nonatomic, strong) NSData *pngData;
 @property (nonatomic, assign) NSTimeInterval duration;
@@ -26,7 +26,7 @@
 @implementation KRAPNGLiteFrame
 @end
 
-/// PNG CRC32（自实现，避免引入 libz 链接依赖）
+/// PNG CRC32 (self-contained, avoids linking libz just for this)
 static uint32_t KRAPNGLiteCrc32(const void *bytes, NSUInteger length) {
     static uint32_t table[256];
     static dispatch_once_t onceToken;
@@ -47,7 +47,7 @@ static uint32_t KRAPNGLiteCrc32(const void *bytes, NSUInteger length) {
     return c ^ 0xFFFFFFFFu;
 }
 
-/// 写出一块 PNG chunk（length + type + data + crc32）
+/// Writes one PNG chunk (length + type + data + crc32)
 static NSData *KRAPNGLiteChunk(NSString *type, NSData *data) {
     NSMutableData *out = [NSMutableData data];
     uint32_t len = CFSwapInt32HostToBig((uint32_t)data.length);
@@ -63,8 +63,8 @@ static NSData *KRAPNGLiteChunk(NSString *type, NSData *data) {
     return out;
 }
 
-/// 解析 APNG 文件。仅支持全帧（offset=0, blend/dispose=0），见头文件说明。
-/// 解析失败返回 nil（调用方降级为静态图，不崩溃）。
+/// Parses an APNG file. Full-frame only (offset = 0, blend/dispose = 0); see header doc.
+/// Returns nil on parse failure (caller falls back to a static image; no crash).
 static NSArray<KRAPNGLiteFrame *> *KRAPNGLiteParse(NSData *data, NSInteger *outNumPlays) {
     static const uint8_t kSig[] = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
     if (data.length < 8 || memcmp(data.bytes, kSig, 8) != 0) {
@@ -73,14 +73,15 @@ static NSArray<KRAPNGLiteFrame *> *KRAPNGLiteParse(NSData *data, NSInteger *outN
     const uint8_t *p = (const uint8_t *)data.bytes + 8;
     const uint8_t *end = (const uint8_t *)data.bytes + data.length;
 
-    // 注意：ihdr/pendingDelay 在 flushFrame 闭包内读取，必须 __block，
-    // 否则闭包按值捕获到的是创建瞬间的初始值（帧永远组装不出来）
+    // NOTE: ihdr/pendingDelay are read inside the flushFrame block and must be
+    // __block — otherwise the block captures the initial values by value and
+    // never sees the assignments made later in the loop (frames never assemble).
     __block NSData *ihdr = nil;
     NSMutableArray<KRAPNGLiteFrame *> *frames = [NSMutableArray array];
     __block NSTimeInterval pendingDelay = 0.1;
     __block BOOL hasPendingFctl = NO;
     NSMutableData *pendingIdat = [NSMutableData data];
-    NSInteger numPlays = 0; // acTL num_plays，0 = 无限
+    NSInteger numPlays = 0; // acTL num_plays: 0 = loop forever
 
     __auto_type flushFrame = ^{
         if (!hasPendingFctl || pendingIdat.length == 0 || ihdr == nil) { return; }
@@ -101,7 +102,7 @@ static NSArray<KRAPNGLiteFrame *> *KRAPNGLiteParse(NSData *data, NSInteger *outN
         uint32_t len = CFSwapInt32BigToHost(*(const uint32_t *)p);
         const uint8_t *type = p + 4;
         const uint8_t *body = p + 8;
-        if (body + len + 4 > end) { break; } // 截断文件，止损
+        if (body + len + 4 > end) { break; } // truncated file, bail out
 
         if (memcmp(type, "IHDR", 4) == 0) {
             ihdr = [NSData dataWithBytes:body length:len];
@@ -111,7 +112,7 @@ static NSArray<KRAPNGLiteFrame *> *KRAPNGLiteParse(NSData *data, NSInteger *outN
             flushFrame();
             uint16_t delayNum = CFSwapInt16BigToHost(*(const uint16_t *)(body + 20));
             uint16_t delayDen = CFSwapInt16BigToHost(*(const uint16_t *)(body + 22));
-            if (delayDen == 0) { delayDen = 100; } // 规范：den=0 按 100 计
+            if (delayDen == 0) { delayDen = 100; } // Spec: den = 0 means 100
             pendingDelay = MAX(0.01, (NSTimeInterval)delayNum / delayDen);
             hasPendingFctl = YES;
         } else if (memcmp(type, "IDAT", 4) == 0) {
@@ -121,7 +122,7 @@ static NSArray<KRAPNGLiteFrame *> *KRAPNGLiteParse(NSData *data, NSInteger *outN
         } else if (memcmp(type, "IEND", 4) == 0) {
             break;
         }
-        p = body + len + 4; // 跳过 data + crc
+        p = body + len + 4; // skip data + crc
     }
     flushFrame();
     if (outNumPlays) { *outNumPlays = numPlays; }
@@ -133,11 +134,11 @@ static NSArray<KRAPNGLiteFrame *> *KRAPNGLiteParse(NSData *data, NSInteger *outN
 @interface KRAPNGViewHandlerLite ()
 @property (nonatomic, strong) UIImageView *imageView;
 @property (nonatomic, copy) NSArray<KRAPNGLiteFrame *> *frames;
-@property (nonatomic, assign) NSInteger fileNumPlays; // 文件自带的播放次数
+@property (nonatomic, assign) NSInteger fileNumPlays; // play count from the file itself
 @property (nonatomic, assign) NSUInteger frameIndex;
 @property (nonatomic, assign) NSUInteger playedLoops;
 @property (nonatomic, assign) BOOL animating;
-@property (nonatomic, assign) BOOL didSetPlayCount;   // 区分「未设置」与「显式 0」
+@property (nonatomic, assign) BOOL didSetPlayCount;   // distinguishes "unset" from "explicitly 0"
 @end
 
 @implementation KRAPNGViewHandlerLite
@@ -189,9 +190,9 @@ static NSArray<KRAPNGLiteFrame *> *KRAPNGLiteParse(NSData *data, NSInteger *outN
         self.frames = frames;
         self.fileNumPlays = numPlays;
         firstImage = [UIImage imageWithData:frames.firstObject.pngData];
-        self.imageView.image = firstImage; // 未播放时定格首帧
+        self.imageView.image = firstImage; // hold the first frame until playback starts
     } else if (data) {
-        // 解析失败/普通 PNG：降级为静态图兜底，不崩溃
+        // Parse failure or plain PNG: fall back to a static image, no crash
         firstImage = [UIImage imageWithData:data];
         self.imageView.image = firstImage;
     }
@@ -215,8 +216,8 @@ static NSArray<KRAPNGLiteFrame *> *KRAPNGLiteParse(NSData *data, NSInteger *outN
 #pragma mark - private
 
 - (NSInteger)p_effectivePlayCount {
-    if (self.didSetPlayCount) { return self.playCount; } // 宿主显式设置（含 0=无限）
-    return self.fileNumPlays;                            // 否则用文件里的 num_plays
+    if (self.didSetPlayCount) { return self.playCount; } // host explicitly set it (0 = infinite)
+    return self.fileNumPlays;                            // otherwise use the file's num_plays
 }
 
 - (void)p_showFrameAtIndex:(NSUInteger)index {
@@ -233,27 +234,28 @@ static NSArray<KRAPNGLiteFrame *> *KRAPNGLiteParse(NSData *data, NSInteger *outN
 }
 
 - (void)p_advanceFromIndex:(NSUInteger)index {
-    if (!self.animating || index != self.frameIndex) { return; } // 已停止或已被新播放覆盖
+    if (!self.animating || index != self.frameIndex) { return; } // stopped or superseded by a new play
     NSUInteger next = index + 1;
     if (next < self.frames.count) {
         [self p_showFrameAtIndex:next];
         return;
     }
-    // 一轮播完
+    // One loop finished
     self.playedLoops += 1;
     if ([self.delegate respondsToSelector:@selector(apngImageView:playEndLoop:)]) {
         [self.delegate apngImageView:self playEndLoop:self.playedLoops];
     }
     NSInteger maxLoops = [self p_effectivePlayCount];
     if (maxLoops <= 0 || self.playedLoops < (NSUInteger)maxLoops) {
-        [self p_showFrameAtIndex:0]; // 继续下一轮
+        [self p_showFrameAtIndex:0]; // start the next loop
     } else {
-        self.animating = NO; // 定格末帧（imageView 已停在最后一帧）
+        self.animating = NO; // hold the last frame (imageView already shows it)
     }
 }
 
 - (void)p_stopTimer {
-    // 播放基于 dispatch_after + frameIndex 守卫，无需显式取消：把 index 推大即可让旧回调失效
+    // Playback is driven by dispatch_after guarded by frameIndex; no explicit
+    // cancellation needed — bumping the index invalidates any pending callback.
     self.frameIndex = NSUIntegerMax / 2;
 }
 

--- a/iosApp/iosApp/KuiklyRenderExpand/Handlers/KRAPNGViewHandlerLite.m
+++ b/iosApp/iosApp/KuiklyRenderExpand/Handlers/KRAPNGViewHandlerLite.m
@@ -1,0 +1,264 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "KRAPNGViewHandlerLite.h"
+
+#pragma mark - APNG 手工解析
+
+/// 单个动画帧：重建好的标准 PNG 数据 + 展示时长（秒）
+@interface KRAPNGLiteFrame : NSObject
+@property (nonatomic, strong) NSData *pngData;
+@property (nonatomic, assign) NSTimeInterval duration;
+@end
+
+@implementation KRAPNGLiteFrame
+@end
+
+/// PNG CRC32（自实现，避免引入 libz 链接依赖）
+static uint32_t KRAPNGLiteCrc32(const void *bytes, NSUInteger length) {
+    static uint32_t table[256];
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        for (uint32_t i = 0; i < 256; i++) {
+            uint32_t c = i;
+            for (int k = 0; k < 8; k++) {
+                c = (c & 1) ? (0xEDB88320u ^ (c >> 1)) : (c >> 1);
+            }
+            table[i] = c;
+        }
+    });
+    const uint8_t *p = (const uint8_t *)bytes;
+    uint32_t c = 0xFFFFFFFFu;
+    for (NSUInteger i = 0; i < length; i++) {
+        c = table[(c ^ p[i]) & 0xFF] ^ (c >> 8);
+    }
+    return c ^ 0xFFFFFFFFu;
+}
+
+/// 写出一块 PNG chunk（length + type + data + crc32）
+static NSData *KRAPNGLiteChunk(NSString *type, NSData *data) {
+    NSMutableData *out = [NSMutableData data];
+    uint32_t len = CFSwapInt32HostToBig((uint32_t)data.length);
+    [out appendBytes:&len length:4];
+    NSData *typeData = [type dataUsingEncoding:NSASCIIStringEncoding];
+    [out appendData:typeData];
+    [out appendData:data];
+    NSMutableData *crcIn = [NSMutableData data];
+    [crcIn appendData:typeData];
+    [crcIn appendData:data];
+    uint32_t crcBE = CFSwapInt32HostToBig(KRAPNGLiteCrc32(crcIn.bytes, crcIn.length));
+    [out appendBytes:&crcBE length:4];
+    return out;
+}
+
+/// 解析 APNG 文件。仅支持全帧（offset=0, blend/dispose=0），见头文件说明。
+/// 解析失败返回 nil（调用方降级为静态图，不崩溃）。
+static NSArray<KRAPNGLiteFrame *> *KRAPNGLiteParse(NSData *data, NSInteger *outNumPlays) {
+    static const uint8_t kSig[] = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+    if (data.length < 8 || memcmp(data.bytes, kSig, 8) != 0) {
+        return nil;
+    }
+    const uint8_t *p = (const uint8_t *)data.bytes + 8;
+    const uint8_t *end = (const uint8_t *)data.bytes + data.length;
+
+    // 注意：ihdr/pendingDelay 在 flushFrame 闭包内读取，必须 __block，
+    // 否则闭包按值捕获到的是创建瞬间的初始值（帧永远组装不出来）
+    __block NSData *ihdr = nil;
+    NSMutableArray<KRAPNGLiteFrame *> *frames = [NSMutableArray array];
+    __block NSTimeInterval pendingDelay = 0.1;
+    __block BOOL hasPendingFctl = NO;
+    NSMutableData *pendingIdat = [NSMutableData data];
+    NSInteger numPlays = 0; // acTL num_plays，0 = 无限
+
+    __auto_type flushFrame = ^{
+        if (!hasPendingFctl || pendingIdat.length == 0 || ihdr == nil) { return; }
+        NSMutableData *png = [NSMutableData data];
+        [png appendBytes:kSig length:8];
+        [png appendData:KRAPNGLiteChunk(@"IHDR", ihdr)];
+        [png appendData:KRAPNGLiteChunk(@"IDAT", pendingIdat)];
+        [png appendData:KRAPNGLiteChunk(@"IEND", [NSData data])];
+        KRAPNGLiteFrame *f = [[KRAPNGLiteFrame alloc] init];
+        f.pngData = png;
+        f.duration = pendingDelay;
+        [frames addObject:f];
+        [pendingIdat setLength:0];
+        hasPendingFctl = NO;
+    };
+
+    while (p + 12 <= end) {
+        uint32_t len = CFSwapInt32BigToHost(*(const uint32_t *)p);
+        const uint8_t *type = p + 4;
+        const uint8_t *body = p + 8;
+        if (body + len + 4 > end) { break; } // 截断文件，止损
+
+        if (memcmp(type, "IHDR", 4) == 0) {
+            ihdr = [NSData dataWithBytes:body length:len];
+        } else if (memcmp(type, "acTL", 4) == 0 && len >= 8) {
+            numPlays = CFSwapInt32BigToHost(*(const uint32_t *)(body + 4));
+        } else if (memcmp(type, "fcTL", 4) == 0 && len >= 26) {
+            flushFrame();
+            uint16_t delayNum = CFSwapInt16BigToHost(*(const uint16_t *)(body + 20));
+            uint16_t delayDen = CFSwapInt16BigToHost(*(const uint16_t *)(body + 22));
+            if (delayDen == 0) { delayDen = 100; } // 规范：den=0 按 100 计
+            pendingDelay = MAX(0.01, (NSTimeInterval)delayNum / delayDen);
+            hasPendingFctl = YES;
+        } else if (memcmp(type, "IDAT", 4) == 0) {
+            if (hasPendingFctl) { [pendingIdat appendBytes:body length:len]; }
+        } else if (memcmp(type, "fdAT", 4) == 0 && len >= 4) {
+            if (hasPendingFctl) { [pendingIdat appendBytes:(body + 4) length:(len - 4)]; }
+        } else if (memcmp(type, "IEND", 4) == 0) {
+            break;
+        }
+        p = body + len + 4; // 跳过 data + crc
+    }
+    flushFrame();
+    if (outNumPlays) { *outNumPlays = numPlays; }
+    return frames.count > 0 ? frames : nil;
+}
+
+#pragma mark - KRAPNGViewHandlerLite
+
+@interface KRAPNGViewHandlerLite ()
+@property (nonatomic, strong) UIImageView *imageView;
+@property (nonatomic, copy) NSArray<KRAPNGLiteFrame *> *frames;
+@property (nonatomic, assign) NSInteger fileNumPlays; // 文件自带的播放次数
+@property (nonatomic, assign) NSUInteger frameIndex;
+@property (nonatomic, assign) NSUInteger playedLoops;
+@property (nonatomic, assign) BOOL animating;
+@property (nonatomic, assign) BOOL didSetPlayCount;   // 区分「未设置」与「显式 0」
+@end
+
+@implementation KRAPNGViewHandlerLite
+
+@synthesize delegate = _delegate;
+@synthesize playCount = _playCount;
+
++ (void)registerToKuikly {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        [KRAPNGView registerAPNGViewCreator:^id<APNGImageViewProtocol> _Nonnull(CGRect frame) {
+            return [[KRAPNGViewHandlerLite alloc] initWithFrame:frame];
+        }];
+    });
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    if (self = [super initWithFrame:frame]) {
+        _imageView = [[UIImageView alloc] initWithFrame:self.bounds];
+        _imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        _imageView.contentMode = UIViewContentModeScaleAspectFit;
+        [self addSubview:_imageView];
+    }
+    return self;
+}
+
+- (void)setPlayCount:(NSInteger)playCount {
+    _playCount = playCount;
+    _didSetPlayCount = YES;
+}
+
+#pragma mark - APNGImageViewProtocol
+
+- (void)setFilePath:(NSString *)filePath {
+    [self setFilePath:filePath withCompletion:nil];
+}
+
+- (void)setFilePath:(NSString *)filePath withCompletion:(void (^)(UIImage * _Nullable))completion {
+    [self p_stopTimer];
+    self.animating = NO;
+    self.frames = nil;
+    self.imageView.image = nil;
+
+    NSData *data = filePath.length > 0 ? [NSData dataWithContentsOfFile:filePath] : nil;
+    NSInteger numPlays = 0;
+    NSArray<KRAPNGLiteFrame *> *frames = data ? KRAPNGLiteParse(data, &numPlays) : nil;
+    UIImage *firstImage = nil;
+    if (frames.count > 0) {
+        self.frames = frames;
+        self.fileNumPlays = numPlays;
+        firstImage = [UIImage imageWithData:frames.firstObject.pngData];
+        self.imageView.image = firstImage; // 未播放时定格首帧
+    } else if (data) {
+        // 解析失败/普通 PNG：降级为静态图兜底，不崩溃
+        firstImage = [UIImage imageWithData:data];
+        self.imageView.image = firstImage;
+    }
+    if (completion) { completion(firstImage); }
+}
+
+- (void)startAPNGAnimating {
+    if (self.frames.count == 0) { return; }
+    [self p_stopTimer];
+    self.animating = YES;
+    self.frameIndex = 0;
+    self.playedLoops = 0;
+    [self p_showFrameAtIndex:0];
+}
+
+- (void)stopAPNGAnimating {
+    [self p_stopTimer];
+    self.animating = NO;
+}
+
+#pragma mark - private
+
+- (NSInteger)p_effectivePlayCount {
+    if (self.didSetPlayCount) { return self.playCount; } // 宿主显式设置（含 0=无限）
+    return self.fileNumPlays;                            // 否则用文件里的 num_plays
+}
+
+- (void)p_showFrameAtIndex:(NSUInteger)index {
+    if (index >= self.frames.count) { return; }
+    self.frameIndex = index;
+    KRAPNGLiteFrame *frame = self.frames[index];
+    self.imageView.image = [UIImage imageWithData:frame.pngData];
+    NSTimeInterval delay = frame.duration;
+    __weak typeof(self) weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        [weakSelf p_advanceFromIndex:index];
+    });
+}
+
+- (void)p_advanceFromIndex:(NSUInteger)index {
+    if (!self.animating || index != self.frameIndex) { return; } // 已停止或已被新播放覆盖
+    NSUInteger next = index + 1;
+    if (next < self.frames.count) {
+        [self p_showFrameAtIndex:next];
+        return;
+    }
+    // 一轮播完
+    self.playedLoops += 1;
+    if ([self.delegate respondsToSelector:@selector(apngImageView:playEndLoop:)]) {
+        [self.delegate apngImageView:self playEndLoop:self.playedLoops];
+    }
+    NSInteger maxLoops = [self p_effectivePlayCount];
+    if (maxLoops <= 0 || self.playedLoops < (NSUInteger)maxLoops) {
+        [self p_showFrameAtIndex:0]; // 继续下一轮
+    } else {
+        self.animating = NO; // 定格末帧（imageView 已停在最后一帧）
+    }
+}
+
+- (void)p_stopTimer {
+    // 播放基于 dispatch_after + frameIndex 守卫，无需显式取消：把 index 推大即可让旧回调失效
+    self.frameIndex = NSUIntegerMax / 2;
+}
+
+- (void)dealloc {
+    self.animating = NO;
+}
+
+@end

--- a/iosApp/iosApp/KuiklyRenderExpand/Handlers/KRAPNGViewHandlerLite.m
+++ b/iosApp/iosApp/KuiklyRenderExpand/Handlers/KRAPNGViewHandlerLite.m
@@ -209,8 +209,14 @@ static NSArray<KRAPNGLiteFrame *> *KRAPNGLiteParse(NSData *data, NSInteger *outN
 }
 
 - (void)stopAPNGAnimating {
+    // Mirror the demo's KRAPNGViewHandler: report the end-of-playback callback once
+    // on an explicit stop (only when actually animating, so dealloc stays silent).
+    BOOL wasAnimating = self.animating;
     [self p_stopTimer];
     self.animating = NO;
+    if (wasAnimating) {
+        [self p_notifyPlayEnd];
+    }
 }
 
 #pragma mark - private
@@ -218,6 +224,14 @@ static NSArray<KRAPNGLiteFrame *> *KRAPNGLiteParse(NSData *data, NSInteger *outN
 - (NSInteger)p_effectivePlayCount {
     if (self.didSetPlayCount) { return self.playCount; } // host explicitly set it (0 = infinite)
     return self.fileNumPlays;                            // otherwise use the file's num_plays
+}
+
+/// Fires the play-end callback. Per framework semantics the APNG `animationEnd`
+/// event must fire once per finished playback — not once per loop.
+- (void)p_notifyPlayEnd {
+    if ([self.delegate respondsToSelector:@selector(apngImageView:playEndLoop:)]) {
+        [self.delegate apngImageView:self playEndLoop:self.playedLoops];
+    }
 }
 
 - (void)p_showFrameAtIndex:(NSUInteger)index {
@@ -242,14 +256,12 @@ static NSArray<KRAPNGLiteFrame *> *KRAPNGLiteParse(NSData *data, NSInteger *outN
     }
     // One loop finished
     self.playedLoops += 1;
-    if ([self.delegate respondsToSelector:@selector(apngImageView:playEndLoop:)]) {
-        [self.delegate apngImageView:self playEndLoop:self.playedLoops];
-    }
     NSInteger maxLoops = [self p_effectivePlayCount];
     if (maxLoops <= 0 || self.playedLoops < (NSUInteger)maxLoops) {
-        [self p_showFrameAtIndex:0]; // start the next loop
+        [self p_showFrameAtIndex:0]; // start the next loop (no end callback mid-playback)
     } else {
         self.animating = NO; // hold the last frame (imageView already shows it)
+        [self p_notifyPlayEnd]; // report once when playback truly finishes
     }
 }
 


### PR DESCRIPTION
## 背景

`APNG` 组件在 Android/iOS 是宿主扩展，需要业务自行实现适配器。目前 demo 工程的两个参考实现均依赖第三方解码库：

- Android：`KRAPNGViewAdapter` 依赖 [APNG4Android](https://github.com/penfeizhou/APNG4Android)（`com.github.penfeizhou.android.animation:apng`）
- iOS：`KRAPNGViewHandler` 依赖 SDWebImage（`SDAnimatedImageView`）

对于不希望引入这类第三方库的业务（包体积/合规审计/依赖收敛场景），缺少一个可直接使用的零依赖选择。

## 改动

新增两个零第三方依赖的 APNG 适配器参考实现（单文件、可直接拷贝使用）：

- **Android**：`KRAPNGViewAdapterLite.kt`——手工解析 APNG 块结构（`IHDR`/`acTL`/`fcTL`/`IDAT`/`fdAT`），逐帧重建标准 PNG 交 `BitmapFactory` 解码，`Handler` 按帧延时切帧；
- **iOS**：`KRAPNGViewHandlerLite.h/.m`——同一解析思路，帧数据交 `UIImage` 解码，`dispatch_after` + frameIndex 守卫调度；CRC32 自实现，不引入 libz；
- **文档**：`docs/API/components/apng.md` 新增「零第三方依赖参考实现」一节，说明注册方式与适用边界。

解析失败或不含动画帧时降级为静态图显示，不崩溃。

## 适用边界（已在代码注释与文档中标注）

仅支持「全帧」APNG（每帧尺寸 = 画布尺寸、offset = 0、blend/dispose = 0）。常见导出工具默认产出全帧，覆盖图标/加载动效等大多数场景；需要局部帧/帧合成的复杂 APNG 仍建议使用第三方解码库适配器。

## 测试

在业务项目（Kuikly 2.23.2）真机验证：Android/iOS 双端 APNG 正常解码播放、播完定格末帧、repeatCount 语义生效；解析失败路径降级正常。

## 说明

- 不动现有 demo 适配器与构建配置，纯新增文件；iOS 侧特意**不做 `+load` 自动注册**（demo 中 `KRAPNGViewHandler` 已在 `+load` 注册，两个 `+load` 并存时生效顺序不确定），由业务显式调用 `+registerToKuikly`。
