### PR TITLE
fix(compose): stabilize Pager state across native snaps

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/pager/PagerState.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.structuralEqualityPolicy
 import com.tencent.kuikly.compose.foundation.gestures.snapping.SnapPosition
@@ -74,6 +75,7 @@ import kotlin.math.sign
 import kotlin.ranges.IntRange
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.math.max
 import kotlin.math.min
@@ -419,7 +421,19 @@ abstract class PagerState internal constructor(
     }
 
     /** Native setContentOffset(animated=true) snap is in progress. */
-    internal var isSnapAnimating = false
+    internal var isSnapAnimating by mutableStateOf(false)
+
+    /**
+     * Versions native snap/alignment work so an alignment callback from an interrupted snap
+     * cannot settle or clear the state of the newer scroll session.
+     */
+    private var snapSessionId = 0
+
+    private var nativeDragSessionActive = false
+
+    private var pagerScrollInProgressState by mutableStateOf(false)
+
+    private var programmaticScrollMutations = 0
 
     /** Native content offset that the snap animation is settling to. */
     internal var snapTargetContentOffset = 0
@@ -463,6 +477,8 @@ abstract class PagerState internal constructor(
         targetKey: Any? = null,
         desyncPages: Int = 0
     ) {
+        snapSessionId++
+        pagerScrollInProgressState = true
         isSnapAnimating = true
         snapTargetContentOffset = targetContentOffset
         snapStartPageCount = pageCount
@@ -532,6 +548,7 @@ abstract class PagerState internal constructor(
 
     /** Clears drag/animated snap tracking. Call before instant programmatic scroll. */
     internal fun clearSnapAnimationState() {
+        snapSessionId++
         if (isSnapAnimating) {
             pagerSnapDebugLog {
                 "clearSnapState: stateId=$debugPagerStateId orientation=${layoutInfo.orientation} " +
@@ -542,6 +559,9 @@ abstract class PagerState internal constructor(
             }
         }
         isSnapAnimating = false
+        if (programmaticScrollMutations == 0 && !nativeDragSessionActive) {
+            pagerScrollInProgressState = false
+        }
         snapTargetContentOffset = 0
         snapStartPageCount = 0
         snapTargetItemKey = null
@@ -567,6 +587,7 @@ abstract class PagerState internal constructor(
         delayMs: Long,
         layoutSize: Int = currentLayoutMainAxisSize()
     ) {
+        val scheduledSnapSessionId = snapSessionId
         val scheduledOrientation = layoutInfo.orientation
         val scheduledPageSizeWithSpacing = pageSizeWithSpacing
         val scheduledContentOffset = kuiklyInfo.contentOffset
@@ -593,7 +614,8 @@ abstract class PagerState internal constructor(
                     scheduledContentOffset,
                     scheduledComposeOffset,
                     scheduledLayoutGeneration,
-                    scheduledPageCount
+                    scheduledPageCount,
+                    scheduledSnapSessionId
                 )
             }
         }
@@ -653,8 +675,12 @@ abstract class PagerState internal constructor(
         scheduledContentOffset: Int,
         scheduledComposeOffset: Int,
         scheduledLayoutGeneration: Int,
-        scheduledPageCount: Int
+        scheduledPageCount: Int,
+        scheduledSnapSessionId: Int
     ) {
+        if (scheduledSnapSessionId != snapSessionId) {
+            return
+        }
         if (TouchActivityTracker.isTouchActive(kuiklyInfo.pageData)) {
             pagerSnapDebugLog {
                 "deferAlignDuringActiveTouch: stateId=$debugPagerStateId " +
@@ -1026,7 +1052,11 @@ abstract class PagerState internal constructor(
                 "pageCount=$pageCount snapTargetPage=$snapTargetRelocatedPage " +
                 "snapTargetKey=$snapTargetItemKey snapStartDesyncPages=$snapStartDesyncPages"
         }
+        snapSessionId++
         isSnapAnimating = false
+        if (programmaticScrollMutations == 0 && !nativeDragSessionActive) {
+            pagerScrollInProgressState = false
+        }
         snapTargetContentOffset = 0
         snapStartPageCount = 0
         snapTargetItemKey = null
@@ -1046,6 +1076,14 @@ abstract class PagerState internal constructor(
         if (!isSnapAnimating || hasSnapReachedTarget(contentOffset)) {
             snapStallAlignmentRetryRequested = false
             return false
+        }
+
+        val isOutsideScrollBounds =
+            contentOffset < minScrollOffset.toInt() || contentOffset > maxScrollOffset.toInt()
+        if (isOutsideScrollBounds) {
+            snapStallAlignmentRetryRequested = false
+            scheduleScrollViewOffsetAlignment(SNAP_MEASURE_JOB_INITIAL_DELAY_MS, layoutSize)
+            return true
         }
 
         if (contentOffset != scheduledContentOffset) {
@@ -1156,6 +1194,50 @@ abstract class PagerState internal constructor(
     private var programmaticScrollTargetPage by mutableIntStateOf(-1)
 
     private var settledPageState by mutableIntStateOf(currentPage)
+
+    private var scrollToPageRequestId by mutableIntStateOf(0)
+
+    /**
+     * Native scroll / snap bypasses [scroll], so capture settled page the same way AndroidX does
+     * at the start of a scroll session.
+     */
+    internal fun captureSettledPageIfIdle() {
+        if (!isScrollInProgress) {
+            settledPageState = currentPage
+        }
+    }
+
+    /**
+     * Starts or continues a native scroll session. A user drag supersedes an unfinished native
+     * snap, while keeping the logical session active until the new drag reaches its final target.
+     */
+    internal fun onNativeScroll() {
+        if (!kuiklyInfo.isDragging && !isSnapAnimating && !pagerScrollInProgressState) {
+            return
+        }
+        captureSettledPageIfIdle()
+        if (kuiklyInfo.isDragging && !nativeDragSessionActive) {
+            nativeDragSessionActive = true
+            if (isSnapAnimating) {
+                clearSnapAnimationState()
+            }
+        }
+        pagerScrollInProgressState = true
+    }
+
+    internal fun onNativeScrollEnd() {
+        if (kuiklyInfo.scrollView?.isDragging == true || programmaticScrollMutations != 0) {
+            return
+        }
+        nativeDragSessionActive = false
+        if (!isSnapAnimating) {
+            pagerScrollInProgressState = false
+        }
+    }
+
+    internal fun onNativeDragEnd() {
+        nativeDragSessionActive = false
+    }
 
     /**
      * The page that is currently "settled". This is an animation/gesture unaware page in the sense
@@ -1271,15 +1353,26 @@ abstract class PagerState internal constructor(
     suspend fun scrollToPage(
         page: Int,
         @FloatRange(from = -0.5, to = 0.5) pageOffsetFraction: Float = 0f
-    ) = scroll {
-        clearSnapAnimationState()
-        debugLog { "Scroll from page=$currentPage to page=$page" }
-        awaitScrollDependencies()
+    ) {
         require(pageOffsetFraction in -0.5..0.5) {
             "pageOffsetFraction $pageOffsetFraction is not within the range -0.5 to 0.5"
         }
-        val targetPage = page.coerceInPageRange()
-        snapToItem(targetPage, pageOffsetFraction, forceRemeasure = true)
+        val requestId = ++scrollToPageRequestId
+        awaitScrollDependencies()
+        if (isScrollInProgress) {
+            snapshotFlow {
+                !isScrollInProgress || requestId != scrollToPageRequestId
+            }.first { it }
+        }
+        if (requestId != scrollToPageRequestId) {
+            return
+        }
+        scroll {
+            clearSnapAnimationState()
+            debugLog { "Scroll from page=$currentPage to page=$page" }
+            val targetPage = page.coerceInPageRange()
+            snapToItem(targetPage, pageOffsetFraction, forceRemeasure = true)
+        }
     }
 
 //    /**
@@ -1347,14 +1440,18 @@ abstract class PagerState internal constructor(
         @AndroidXIntRange(from = 0) page: Int,
         @FloatRange(from = -0.5, to = 0.5) pageOffsetFraction: Float = 0.0f
     ) {
+        scrollToPageRequestId++
         clearSnapAnimationState()
         // Cancel any scroll in progress.
-        if (isScrollInProgress) {
+        if (programmaticScrollMutations != 0) {
             pagerLayoutInfoState.value.coroutineScope.launch {
                 stopScroll()
             }
         }
         snapToItem(page.coerceInPageRange(), pageOffsetFraction, forceRemeasure = false)
+        if (programmaticScrollMutations == 0 && !nativeDragSessionActive) {
+            pagerScrollInProgressState = false
+        }
     }
 
     /**
@@ -1379,10 +1476,13 @@ abstract class PagerState internal constructor(
         if (page == currentPage && currentPageOffsetFraction == pageOffsetFraction ||
             pageCount == 0
         ) return
-        awaitScrollDependencies()
         require(pageOffsetFraction in -0.5..0.5) {
             "pageOffsetFraction $pageOffsetFraction is not within the range -0.5 to 0.5"
         }
+        scrollToPageRequestId++
+        awaitScrollDependencies()
+        // Native setContentOffset snap does not go through [scroll]; capture settled page here.
+        captureSettledPageIfIdle()
         val targetPage = page.coerceInPageRange()
         val targetPageOffsetToSnappedPosition =
             (pageOffsetFraction * pageSizeWithSpacing)
@@ -1405,7 +1505,15 @@ abstract class PagerState internal constructor(
             targetValue = finalTargetOffset
         )
 
-        markSnapAnimationStarted(finalTargetOffset.toInt())
+        val targetKey = runCatching {
+            layoutInfo.visiblePagesInfo.firstOrNull { it.index == targetPage }?.key
+        }.getOrNull()
+        markSnapAnimationStarted(
+            targetContentOffset = finalTargetOffset.toInt(),
+            targetPage = targetPage,
+            targetKey = targetKey,
+            desyncPages = 0
+        )
 
         kuiklyInfo.run {
             val targetOffsetDp = if (isVertical()) {
@@ -1434,11 +1542,21 @@ abstract class PagerState internal constructor(
     ) {
         awaitScrollDependencies()
         // will scroll and it's not scrolling already update settled page
-        if (!isScrollInProgress) {
-            settledPageState = currentPage
+        captureSettledPageIfIdle()
+        if (isSnapAnimating) {
+            clearSnapAnimationState()
         }
-        scrollableState.scroll(scrollPriority, block)
-        programmaticScrollTargetPage = -1 // reset animated scroll target page indicator
+        programmaticScrollMutations++
+        pagerScrollInProgressState = true
+        try {
+            scrollableState.scroll(scrollPriority, block)
+        } finally {
+            programmaticScrollMutations--
+            programmaticScrollTargetPage = -1 // reset animated scroll target page indicator
+            if (programmaticScrollMutations == 0 && !isSnapAnimating && !nativeDragSessionActive) {
+                pagerScrollInProgressState = false
+            }
+        }
     }
 
     override fun dispatchRawDelta(delta: Float): Float {
@@ -1446,7 +1564,7 @@ abstract class PagerState internal constructor(
     }
 
     override val isScrollInProgress: Boolean
-        get() = scrollableState.isScrollInProgress
+        get() = pagerScrollInProgressState
 
     final override var canScrollForward: Boolean by mutableStateOf(false)
         private set

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ScrollableStateExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ScrollableStateExtensions.kt
@@ -71,6 +71,7 @@ internal fun ScrollableState.kuiklyOnScrollEnd(params: ScrollParams) {
             // leaves updateFromMeasureResult unprotected. isSnapAnimating is
             // cleared in the applyMeasureResult_job after FIXING decision.
             scrollableState.kuiklyOnScrollEnd(params)
+            onNativeScrollEnd()
         }
         is DrawerInternalPagerState -> scrollableState.kuiklyOnScrollEnd(params)
         is LazyGridState -> scrollableState.kuiklyOnScrollEnd(params)

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
@@ -319,10 +319,13 @@ fun SubcomposeLayout(
                 val offset = if (isVertical) scaleParams.offsetY.toInt() else scaleParams.offsetX.toInt()
                 kuiklyInfo.contentOffset = offset
                 kuiklyInfo.isDragging = kuiklyInfo.scrollView?.isDragging ?: false
+                (scrollableState as? PagerState)?.onNativeDragEnd()
             }
             scroll {
                 val scaleParams = it.scaleWithDensity(kuiklyInfo.getDensity())
                 val offset = if (isVertical) scaleParams.offsetY.toInt() else scaleParams.offsetX.toInt()
+                kuiklyInfo.isDragging = kuiklyInfo.scrollView?.isDragging ?: false
+                (scrollableState as? PagerState)?.onNativeScroll()
 
                 // Reject unexpected native offset jumps (e.g. HarmonyOS HandleCrashTop).
                 // Correct the native side back and skip this event entirely to prevent
@@ -343,7 +346,6 @@ fun SubcomposeLayout(
                 kuiklyInfo.contentOffset = offset
                 (scrollableState as? PagerState)?.onNativeContentOffsetChanged(offset)
                 (scrollableState as? DrawerInternalPagerState)?.onNativeContentOffsetChanged(offset)
-                kuiklyInfo.isDragging = kuiklyInfo.scrollView?.isDragging ?: false
 
                 if (kuiklyInfo.ignoreScrollOffset != null) {
                     val ignoreOffset = kuiklyInfo.ignoreScrollOffset!!


### PR DESCRIPTION
## Summary
- keep `settledPage` stable for the full native drag/snap session
- keep `isScrollInProgress` true until native snap alignment finishes
- ignore stale alignment callbacks and defer queued `scrollToPage` requests until the active snap settles
- wait for boundary bounce offsets to return within scroll bounds before treating a snap as stalled

Fixes #1560

## Test plan
- [x] Compile Android Compose target
- [x] Compile iOS Simulator Compose target
- [x] Verify manual paging and `animateScrollToPage` on Android and iOS
- [x] Verify queued `scrollToPage` during an active snap
- [x] Verify boundary bounce behavior on iOS simulator and device

Made with [Cursor](https://cursor.com)