### PR TITLE
fix(ohos): resolve Dl_info type mismatch on Windows cinterop

### DIFF
--- a/core/src/ohosArm64Main/kotlin/com/tencent/kuikly/core/exception/ThrowableExt.ohos.kt
+++ b/core/src/ohosArm64Main/kotlin/com/tencent/kuikly/core/exception/ThrowableExt.ohos.kt
@@ -22,6 +22,7 @@ import kotlinx.cinterop.LongVar
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.sizeOf
 import kotlinx.cinterop.toCPointer
 import kotlinx.cinterop.toKString
@@ -165,7 +166,9 @@ private fun parseSymbolInfo(addrList: List<Long>): List<SymbolInfo> {
             symbolInfo.offsetFromSoBase = addr - result.dli_fbase.toLong() - 1
             symbolInfo.soName = result.dli_fname?.toKString() ?: ""
 
-            kr_fill_dl_info_sym(xdlInfo.ptr, result.ptr, symbolInfo.offsetFromSoBase)
+            // Windows cinterop may type the second parameter as ohos.Dl_info while
+            // alloc/dladdr use platform.posix.Dl_info. Infer the expected struct.
+            kr_fill_dl_info_sym(xdlInfo.ptr, result.ptr.reinterpret(), symbolInfo.offsetFromSoBase)
             symbolInfo.name = result.dli_sname?.toKString() ?: ""
             symbolInfo.offsetFromSymbol = result.dli_saddr.toLong()
             symbolInfoList.add(symbolInfo)


### PR DESCRIPTION
Fixes #1413.

Windows OHOS demo compile fails at `ThrowableExt.ohos.kt` when passing a `platform.posix.Dl_info` pointer into `kr_fill_dl_info_sym`.

On Mac/Linux, cinterop reuses `platform.posix.Dl_info`. On Windows with DevEco SDK headers, the same C `Dl_info*` can be imported as a distinct `ohos.Dl_info`, producing:

    Argument type mismatch: actual type is 'kotlinx.cinterop.CPointer', but 'kotlinx.cinterop.CValuesRef<ohos.Dl_info>?' was expected.

`dladdr` still requires `platform.posix.Dl_info`, so the alloc cannot simply switch types. `result.ptr.reinterpret()` lets the compiler infer whichever struct the current cinterop binding expects.

## Test plan

- [x] Typechecked `:core:compileKotlinOhosArm64` with Kotlin 2.0.21-KBA-010 and OpenHarmony native sysroot (API 20) on Linux
- [ ] Please confirm `2.0_ohos_demo_build.bat` on Windows with DevEco `OHOS_SDK_HOME` (the reported site)
