### PR TITLE
fix(ohos): initialize Dispatchers.Main via initMainHandler

### DIFF
--- a/core-ksp/src/main/kotlin/impl/OhOsTargetEntryBuilder.kt
+++ b/core-ksp/src/main/kotlin/impl/OhOsTargetEntryBuilder.kt
@@ -37,6 +37,7 @@ class OhOsTargetEntryBuilder(private val catchException: Boolean) : KuiklyCoreAb
             addImport("com.tencent.kuikly.core.manager", "KotlinMethod")
             addImport("kotlinx.cinterop", "staticCFunction")
             addImport("ohos", "com_tencent_kuikly_SetCallKotlin")
+            addImport("kotlinx.coroutines", "initMainHandler")
 
             addFunction(createCallNativeFunc())
             addFunction(createInitKuiklyMethod(pagesAnnotations))
@@ -56,9 +57,15 @@ class OhOsTargetEntryBuilder(private val catchException: Boolean) : KuiklyCoreAb
     ): FunSpec {
         return FunSpec.builder("initKuikly")
             .addAnnotations(createCFuncAnnotations())
+            .addParameter("env", ClassName("platform.ohos", "napi_env"))
             .returns(Int::class)
             .addStatement(
                 "if (!BridgeManager.isDidInit()) {\n" +
+                        // kotlinx.coroutines Dispatchers.Main on OHOS is backed by a
+                        // thread-safe napi function. initMainHandler(env) must run once
+                        // on the ArkTS thread or withContext(Dispatchers.Main) throws
+                        // UninitializedPropertyAccessException: lateinit property tsfn.
+                        "initMainHandler(env)\n" +
                         "BridgeManager.init(${catchException})\n"
             )
             .addRegisterPageRouteStatement(pagesAnnotations)

--- a/core-ksp/src/main/kotlin/impl/OhOsTargetMultiEntryBuilder.kt
+++ b/core-ksp/src/main/kotlin/impl/OhOsTargetMultiEntryBuilder.kt
@@ -40,6 +40,7 @@ class OhOsTargetMultiEntryBuilder(private val catchException: Boolean, private v
                 addImport("com.tencent.kuikly.core.manager", "KotlinMethod")
                 addImport("kotlinx.cinterop", "staticCFunction")
                 addImport("ohos", "com_tencent_kuikly_SetCallKotlin")
+                addImport("kotlinx.coroutines", "initMainHandler")
 
                 addFunction(createCallNativeFunc())
                 addFunction(createInitKuiklyMethod(pagesAnnotations))
@@ -60,9 +61,15 @@ class OhOsTargetMultiEntryBuilder(private val catchException: Boolean, private v
     ): FunSpec {
         return FunSpec.builder("initKuikly")
             .addAnnotations(createCFuncAnnotations())
+            .addParameter("env", ClassName("platform.ohos", "napi_env"))
             .returns(Int::class)
             .addStatement(
                 "if (!BridgeManager.isDidInit()) {\n" +
+                        // kotlinx.coroutines Dispatchers.Main on OHOS is backed by a
+                        // thread-safe napi function. initMainHandler(env) must run once
+                        // on the ArkTS thread or withContext(Dispatchers.Main) throws
+                        // UninitializedPropertyAccessException: lateinit property tsfn.
+                        "initMainHandler(env)\n" +
                         "BridgeManager.init(${catchException})\n"
             )
             .addRegisterPageRouteStatement(pagesAnnotations)

--- a/docs/DevGuide/expand-native-api.md
+++ b/docs/DevGuide/expand-native-api.md
@@ -658,7 +658,8 @@ static napi_value InitKuikly(napi_env env, napi_callback_info info) {
     }
     
     auto api = libshared_symbols();
-    int handler = api->kotlin.root.initKuikly();
+    // Pass napi_env so kotlinx.coroutines Dispatchers.Main can be initialized (initMainHandler).
+    int handler = api->kotlin.root.initKuikly(env);
     napi_value result;
     napi_create_int32(env, handler, &result);
     return result;

--- a/docs/DevGuide/thread-and-coroutines.md
+++ b/docs/DevGuide/thread-and-coroutines.md
@@ -84,6 +84,8 @@ maven("https://mirrors.tencent.com/nexus/repository/maven-tencent/")
 
 :::tip 提示
 不同平台支持的调度器有所不同，例如，除了各平台共有的Dispatchers.Default和Dispatchers.Unconfined，Android平台还提供了Dispatchers.Main、Dispatchers.IO等。 具体可以参考kotlinx.coroutines的API文档。
+
+鸿蒙平台的 `Dispatchers.Main` 依赖 kotlinx.coroutines OHOS 适配中的 `initMainHandler(env)`。Kuikly 会在 NAPI `InitKuikly` 把 `napi_env` 传入生成的 `initKuikly(env)` 时完成这次初始化。宿主需要调用 `api->kotlin.root.initKuikly(env)`（不要再调用无参的 `initKuikly()`），且业务模块需依赖 `org.jetbrains.kotlinx:kotlinx-coroutines-core` 的 KBA/OHOS 版本（compose 模块已传递依赖）。未初始化时 `withContext(Dispatchers.Main)` 会抛出 `UninitializedPropertyAccessException: lateinit property tsfn has not been initialized`，并可能触发 `ecma_vm cannot run in multi-thread`。
 :::
 
 #### kuiklyx.coroutines库

--- a/docs/DevGuide/view-external-prop.md
+++ b/docs/DevGuide/view-external-prop.md
@@ -158,7 +158,7 @@ static napi_value InitKuikly(napi_env env, napi_callback_info info) {
 
     KRRenderViewSetExternalPropHandler(*ViewPropHandler, *ViewResetPropHandler);
 
-    // 位于api->kotlin.root.initKuikly()之前;
+    // 位于api->kotlin.root.initKuikly(env)之前;
  
     ...
 }

--- a/docs/QuickStart/harmony.md
+++ b/docs/QuickStart/harmony.md
@@ -536,7 +536,8 @@ target_link_libraries(entry PUBLIC libace_napi.z.so kuikly_shared kuikly_render)
 static napi_value InitKuikly(napi_env env, napi_callback_info info) {
   // symbols入口名和kuikly工程的配置有关，具体查看产物的头文件
   auto api = libshared_symbols();
-  int handler = api->kotlin.root.initKuikly();
+  // Pass napi_env so kotlinx.coroutines Dispatchers.Main can be initialized (initMainHandler).
+  int handler = api->kotlin.root.initKuikly(env);
   napi_value result;
   napi_create_int32(env, handler, &result);
   return result;

--- a/ohosApp/entry/src/main/cpp/napi_init.cpp
+++ b/ohosApp/entry/src/main/cpp/napi_init.cpp
@@ -596,7 +596,9 @@ static napi_value InitKuikly(napi_env env, napi_callback_info info) {
     }
 
     auto api = libshared_symbols();
-    int handler = api->kotlin.root.initKuikly();
+    // Pass the ArkTS napi_env so generated initKuikly can initialize
+    // kotlinx.coroutines Dispatchers.Main (initMainHandler / tsfn).
+    int handler = api->kotlin.root.initKuikly(env);
     napi_value result;
     napi_create_int32(env, handler, &result);
     return result;


### PR DESCRIPTION
Fixes issue 1276.
Generated initKuikly dropped napi_env, so initMainHandler was never called and Dispatchers.Main stayed uninitialized on OHOS.
initKuikly now takes env and calls initMainHandler once. Host InitKuikly must pass env. Not verified on a HarmonyOS device.
