### PR TITLE
feat(demo): MyModule Demo 命名优化，补齐 iOS/Android module 实现

### DIFF
--- a/androidApp/src/main/java/com/tencent/kuikly/android/demo/ContextCodeHandler.kt
+++ b/androidApp/src/main/java/com/tencent/kuikly/android/demo/ContextCodeHandler.kt
@@ -24,6 +24,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import com.tencent.kuikly.android.demo.module.KRBridgeModule
+import com.tencent.kuikly.android.demo.module.KRMyModule
 import com.tencent.kuikly.android.demo.module.KRShareModule
 import com.tencent.kuikly.android.demo.module.tdf.KRTDFTestModule
 import com.tencent.kuikly.core.render.android.IKuiklyRenderExport
@@ -149,6 +150,9 @@ open class ContextCodeHandler(
         with(kuiklyRenderExport) {
             moduleExport(KRBridgeModule.MODULE_NAME) {
                 KRBridgeModule()
+            }
+            moduleExport(KRMyModule.MODULE_NAME) {
+                KRMyModule()
             }
             moduleExport(KRShareModule.MODULE_NAME) {
                 KRShareModule()

--- a/androidApp/src/main/java/com/tencent/kuikly/android/demo/KuiklyRenderView.kt
+++ b/androidApp/src/main/java/com/tencent/kuikly/android/demo/KuiklyRenderView.kt
@@ -17,6 +17,7 @@ package com.tencent.kuikly.android.demo
 
 import android.content.Context
 import com.tencent.kuikly.android.demo.module.KRBridgeModule
+import com.tencent.kuikly.android.demo.module.KRMyModule
 import com.tencent.kuikly.android.demo.module.KRShareModule
 import com.tencent.kuikly.core.render.android.IKuiklyRenderExport
 import com.tencent.kuikly.core.render.android.expand.KuiklyRenderViewBaseDelegatorDelegate
@@ -29,6 +30,9 @@ class KuiklyRenderView(context: Context, delegate: KuiklyRenderViewBaseDelegator
         with(kuiklyRenderExport) {
             moduleExport(KRBridgeModule.MODULE_NAME) {
                 KRBridgeModule()
+            }
+            moduleExport(KRMyModule.MODULE_NAME) {
+                KRMyModule()
             }
             moduleExport(KRShareModule.MODULE_NAME) {
                 KRShareModule()

--- a/androidApp/src/main/java/com/tencent/kuikly/android/demo/module/KRMyModule.kt
+++ b/androidApp/src/main/java/com/tencent/kuikly/android/demo/module/KRMyModule.kt
@@ -1,0 +1,88 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.android.demo.module
+
+import com.tencent.kuikly.core.render.android.export.KuiklyRenderBaseModule
+import com.tencent.kuikly.core.render.android.export.KuiklyRenderCallback
+import org.json.JSONObject
+
+/**
+ * 对应鸿蒙侧 KRMyModule / iOS 侧 KRMyModule，用于演示 Kuikly Module 的同步与异步调用。
+ * 方法名需与 Kotlin 侧 MyModule 调用及鸿蒙/iOS 侧实现保持一致。
+ */
+class KRMyModule : KuiklyRenderBaseModule() {
+
+    override fun call(method: String, params: Any?, callback: KuiklyRenderCallback?): Any? {
+        return when (method) {
+            // 同步调用(JSON传输)：接收JSON字符串，返回data字段值
+            "syncJsonCall" -> {
+                val json = JSONObject(params as? String ?: "{}")
+                json.optString("data")
+            }
+            // 同步调用(ByteArray传输)：接收含ByteArray的数组，交换字节后返回
+            "syncByteArrayCall" -> {
+                val array = params as? Array<*>
+                val bytes = (array?.firstOrNull() as? ByteArray) ?: byteArrayOf()
+                if (bytes.size >= 4) {
+                    val tmp1 = bytes[0]
+                    val tmp2 = bytes[1]
+                    bytes[0] = bytes[3]
+                    bytes[1] = bytes[2]
+                    bytes[2] = tmp2
+                    bytes[3] = tmp1
+                }
+                bytes
+            }
+            // 异步回调(JSON传输)：接收JSON字符串，通过callback回传 **JSON字符串**（与鸿蒙一致）。
+            // 框架 Module.toNative 的 CallbackFn 路径在 res is String 时会用框架 JSONObject 解析，
+            // 才能被 Kotlin CallbackFn(JSONObject?) 正确接收；传 Map 或 org.json.JSONObject 都会因
+            // 类型判断失败导致 dataJSONObject=null。
+            "asyncJsonCallback" -> {
+                val json = JSONObject(params as? String ?: "{}")
+                val content = json.optString("data")
+                callback?.invoke("{\"content\":\"$content\"}")
+                null
+            }
+            // 异步回调(数组传输)：接收字符串数组，通过callback回传第一个元素
+            "asyncArrayCallback" -> {
+                val array = params as? Array<*>
+                callback?.invoke(array?.firstOrNull()?.toString())
+                null
+            }
+            // 异步回调(混合数组)：无业务参数，通过callback回传 [ByteArray, String, String]
+            "asyncMixedArrayCallback" -> {
+                callback?.invoke(arrayOf(byteArrayOf(33, 34, 35), "s1", "hello"))
+                null
+            }
+            // 同步调用(返回Double 3.14)
+            "retDouble" -> {
+                3.14
+            }
+            // 同步调用(返回Int 314)
+            "retInt" -> {
+                314
+            }
+            else -> callback?.invoke(mapOf(
+                "code" to -1,
+                "message" to "方法不存在"
+            ))
+        }
+    }
+
+    companion object {
+        const val MODULE_NAME = "KRMyModule"
+    }
+}

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/MyModuleDemoPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/MyModuleDemoPage.kt
@@ -1,0 +1,557 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.demo.pages.demo
+
+import com.tencent.kuikly.core.annotations.Page
+import com.tencent.kuikly.core.base.Color
+import com.tencent.kuikly.core.base.ViewBuilder
+import com.tencent.kuikly.core.module.AnyCallbackFn
+import com.tencent.kuikly.core.module.CallbackFn
+import com.tencent.kuikly.core.module.Module
+import com.tencent.kuikly.core.nvi.serialization.json.JSONObject
+import com.tencent.kuikly.core.reactive.handler.observable
+import com.tencent.kuikly.core.views.Scroller
+import com.tencent.kuikly.core.views.Text
+import com.tencent.kuikly.core.views.View
+import com.tencent.kuikly.core.views.compose.Button
+import com.tencent.kuikly.demo.pages.base.BasePager
+import com.tencent.kuikly.demo.pages.demo.base.NavBar
+
+/**
+ * Kotlin 侧 MyModule，对应鸿蒙侧的 KRMyModule
+ */
+internal class MyModule : Module() {
+
+    override fun moduleName(): String = MODULE_NAME
+
+    /**
+     * syncJsonCall: 传递 JSON 字符串，同步获取返回值（返回 JSON 中的 data 字段）
+     */
+    fun syncJsonCall(data: String): String {
+        val json = JSONObject()
+        json.put("data", data)
+        return syncToNativeMethod("syncJsonCall", json, null)
+    }
+
+    /**
+     * syncByteArrayCall: 传递 ByteArray，同步获取交换字节后的 ByteArray
+     */
+    fun syncByteArrayCall(bytes: ByteArray): Any? {
+        return syncToNativeMethod("syncByteArrayCall", arrayOf<Any>(bytes), null)
+    }
+
+    /**
+     * asyncJsonCallback: 传递 JSON 字符串，通过 callback 异步获取结果
+     */
+    fun asyncJsonCallback(data: String, callbackFn: CallbackFn) {
+        val json = JSONObject()
+        json.put("data", data)
+        toNative(
+            false,
+            "asyncJsonCallback",
+            json.toString(),
+            callbackFn,
+            false
+        )
+    }
+
+    /**
+     * asyncArrayCallback: 传递基本类型数组，通过 callback 异步获取结果
+     */
+    fun asyncArrayCallback(content: String, callbackFn: AnyCallbackFn) {
+        asyncToNativeMethod("asyncArrayCallback", arrayOf<Any>(content), callbackFn)
+    }
+
+    /**
+     * asyncMixedArrayCallback: 无参数，通过 callback 异步获取数组结果 [ByteArray, String, String]
+     */
+    fun asyncMixedArrayCallback(callbackFn: AnyCallbackFn) {
+        asyncToNativeMethod("asyncMixedArrayCallback", arrayOf<Any>(""), callbackFn)
+    }
+
+    /**
+     * retDouble: 无参数，同步返回 Native 侧的 Double 值（3.14）。
+     * 注意：同步 JSON 通路(syncToNativeMethod JSONObject 版本)的回传值恒为 String，
+     * 因此此处返回 String("3.14")，由 Demo 页直接展示。
+     */
+    fun retDouble(): String {
+        return syncToNativeMethod("retDouble", null, null)
+    }
+
+    /**
+     * retInt: 无参数，同步返回 Native 侧的 Int 值（314）。
+     * 注意：同步 JSON 通路(syncToNativeMethod JSONObject 版本)的回传值恒为 String，
+     * 因此此处返回 String("314")，由 Demo 页直接展示。
+     */
+    fun retInt(): String {
+        return syncToNativeMethod("retInt", null, null)
+    }
+
+    companion object {
+        const val MODULE_NAME = "KRMyModule"
+    }
+}
+
+/**
+ * MyModule Demo 页面，演示 KRMyModule 各方法的调用
+ */
+@Page("MyModuleDemoPage")
+internal class MyModuleDemoPage : BasePager() {
+
+    private var syncJsonCallResult by observable("未调用")
+    private var syncByteArrayCallResult by observable("未调用")
+    private var asyncJsonCallbackResult by observable("未调用")
+    private var asyncArrayCallbackResult by observable("未调用")
+    private var asyncMixedArrayCallbackResult by observable("未调用")
+    private var retDoubleResult by observable("未调用")
+    private var retIntResult by observable("未调用")
+
+    override fun createExternalModules(): Map<String, Module>? {
+        val modules = super.createExternalModules()?.toMutableMap() ?: hashMapOf()
+        modules[MyModule.MODULE_NAME] = MyModule()
+        return modules
+    }
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            attr {
+                backgroundColor(Color.WHITE)
+            }
+            NavBar {
+                attr {
+                    title = "MyModule Demo"
+                }
+            }
+            Scroller {
+                attr {
+                    flex(1f)
+                    margin(15f)
+                }
+
+                // syncJsonCall 演示
+                Text {
+                    attr {
+                        fontSize(16f)
+fontWeightBold()
+                        marginTop(10f)
+                        text("syncJsonCall - 同步调用(JSON传输)")
+                    }
+                }
+                Text {
+                    attr {
+                        fontSize(14f)
+                        color(Color(0xFF666666L))
+                        marginTop(5f)
+                        text("传入JSON字符串，同步返回data字段值")
+                    }
+                }
+                Button {
+                    attr {
+                        marginTop(8f)
+                        height(40f)
+                        borderRadius(8f)
+                        backgroundColor(Color(0xFF3c6cbdL))
+                        testTag("call_syncJsonCall")
+                        titleAttr {
+                            text("调用 syncJsonCall")
+                            fontSize(14f)
+                            color(Color.WHITE)
+                        }
+                    }
+                    event {
+                        click {
+                            val module = ctx.acquireModule<MyModule>(MyModule.MODULE_NAME)
+                            ctx.syncJsonCallResult = module.syncJsonCall("Hello from Kotlin!")
+                        }
+                    }
+                }
+                Text {
+                    attr {
+                        fontSize(14f)
+                        marginTop(5f)
+                        testTag("result_syncJsonCall")
+                        text("结果: ${ctx.syncJsonCallResult}")
+                    }
+                }
+
+                // 分隔线
+                View {
+                    attr {
+                        height(1f)
+                        marginTop(15f)
+                        backgroundColor(Color(0xFFEEEEEEL))
+                    }
+                }
+
+                // syncByteArrayCall 演示
+                Text {
+                    attr {
+                        fontSize(16f)
+fontWeightBold()
+                        marginTop(15f)
+                        text("syncByteArrayCall - 同步调用(ByteArray传输)")
+                    }
+                }
+                Text {
+                    attr {
+                        fontSize(14f)
+                        color(Color(0xFF666666L))
+                        marginTop(5f)
+                        text("传入ByteArray[1,2,3,4]，Native侧交换字节后返回")
+                    }
+                }
+                Button {
+                    attr {
+                        marginTop(8f)
+                        height(40f)
+                        borderRadius(8f)
+                        backgroundColor(Color(0xFF3c6cbdL))
+                        testTag("call_syncByteArrayCall")
+                        titleAttr {
+                            text("调用 syncByteArrayCall")
+                            fontSize(14f)
+                            color(Color.WHITE)
+                        }
+                    }
+                    event {
+                        click {
+                            val module = ctx.acquireModule<MyModule>(MyModule.MODULE_NAME)
+                            val inputBytes = byteArrayOf(1, 2, 3, 4)
+                            val result = module.syncByteArrayCall(inputBytes)
+                            if (result is ByteArray) {
+                                ctx.syncByteArrayCallResult = "ByteArray[${result.joinToString(",")}]"
+                            } else {
+                                ctx.syncByteArrayCallResult = "返回类型: ${result?.let { it::class.simpleName }}, 值: $result"
+                            }
+                        }
+                    }
+                }
+                Text {
+                    attr {
+                        fontSize(14f)
+                        marginTop(5f)
+                        testTag("result_syncByteArrayCall")
+                        text("结果: ${ctx.syncByteArrayCallResult}")
+                    }
+                }
+
+                // 分隔线
+                View {
+                    attr {
+                        height(1f)
+                        marginTop(15f)
+                        backgroundColor(Color(0xFFEEEEEEL))
+                    }
+                }
+
+                // asyncJsonCallback 演示
+                Text {
+                    attr {
+                        fontSize(16f)
+fontWeightBold()
+                        marginTop(15f)
+                        text("asyncJsonCallback - 异步回调(JSON传输)")
+                    }
+                }
+                Text {
+                    attr {
+                        fontSize(14f)
+                        color(Color(0xFF666666L))
+                        marginTop(5f)
+                        text("传入JSON字符串，通过callback回调结果")
+                    }
+                }
+                Button {
+                    attr {
+                        marginTop(8f)
+                        height(40f)
+                        borderRadius(8f)
+                        backgroundColor(Color(0xFF3c6cbdL))
+                        testTag("call_asyncJsonCallback")
+                        titleAttr {
+                            text("调用 asyncJsonCallback")
+                            fontSize(14f)
+                            color(Color.WHITE)
+                        }
+                    }
+                    event {
+                        click {
+                            val module = ctx.acquireModule<MyModule>(MyModule.MODULE_NAME)
+                            module.asyncJsonCallback("Kuikly回调测试") { jsonObj ->
+                                ctx.asyncJsonCallbackResult = jsonObj?.toString() ?: "null"
+                            }
+                        }
+                    }
+                }
+                Text {
+                    attr {
+                        fontSize(14f)
+                        marginTop(5f)
+                        testTag("result_asyncJsonCallback")
+                        text("结果: ${ctx.asyncJsonCallbackResult}")
+                    }
+                }
+
+                // 分隔线
+                View {
+                    attr {
+                        height(1f)
+                        marginTop(15f)
+                        backgroundColor(Color(0xFFEEEEEEL))
+                    }
+                }
+
+                // asyncArrayCallback 演示
+                Text {
+                    attr {
+                        fontSize(16f)
+fontWeightBold()
+                        marginTop(15f)
+                        text("asyncArrayCallback - 异步回调(数组传输)")
+                    }
+                }
+                Text {
+                    attr {
+                        fontSize(14f)
+                        color(Color(0xFF666666L))
+                        marginTop(5f)
+                        text("传入字符串数组，通过callback回调第一个元素")
+                    }
+                }
+                Button {
+                    attr {
+                        marginTop(8f)
+                        height(40f)
+                        borderRadius(8f)
+                        backgroundColor(Color(0xFF3c6cbdL))
+                        testTag("call_asyncArrayCallback")
+                        titleAttr {
+                            text("调用 asyncArrayCallback")
+                            fontSize(14f)
+                            color(Color.WHITE)
+                        }
+                    }
+                    event {
+                        click {
+                            val module = ctx.acquireModule<MyModule>(MyModule.MODULE_NAME)
+                            module.asyncArrayCallback("asyncArrayCallback的参数") { result ->
+                                ctx.asyncArrayCallbackResult = result?.toString() ?: "null"
+                            }
+                        }
+                    }
+                }
+                Text {
+                    attr {
+                        fontSize(14f)
+                        marginTop(5f)
+                        testTag("result_asyncArrayCallback")
+                        text("结果: ${ctx.asyncArrayCallbackResult}")
+                    }
+                }
+
+                // 分隔线
+                View {
+                    attr {
+                        height(1f)
+                        marginTop(15f)
+                        backgroundColor(Color(0xFFEEEEEEL))
+                    }
+                }
+
+                // asyncMixedArrayCallback 演示
+                Text {
+                    attr {
+                        fontSize(16f)
+fontWeightBold()
+                        marginTop(15f)
+                        text("asyncMixedArrayCallback - 异步回调(混合数组)")
+                    }
+                }
+                Text {
+                    attr {
+                        fontSize(14f)
+                        color(Color(0xFF666666L))
+                        marginTop(5f)
+                        text("无参数，回调包含ByteArray和String的数组")
+                    }
+                }
+                Button {
+                    attr {
+                        marginTop(8f)
+                        height(40f)
+                        borderRadius(8f)
+                        backgroundColor(Color(0xFF3c6cbdL))
+                        testTag("call_asyncMixedArrayCallback")
+                        titleAttr {
+                            text("调用 asyncMixedArrayCallback")
+                            fontSize(14f)
+                            color(Color.WHITE)
+                        }
+                    }
+                    event {
+                        click {
+                            val module = ctx.acquireModule<MyModule>(MyModule.MODULE_NAME)
+                            module.asyncMixedArrayCallback { result ->
+                                if (result is Array<*>) {
+                                    val sb = StringBuilder("Array[")
+                                    result.forEachIndexed { index, item ->
+                                        if (index > 0) {
+                                            sb.append(", ")
+                                        }
+                                        when (item) {
+                                            is ByteArray -> sb.append("ByteArray[${item.joinToString(",")}]")
+                                            else -> sb.append(item.toString())
+                                        }
+                                    }
+                                    sb.append("]")
+                                    ctx.asyncMixedArrayCallbackResult = sb.toString()
+                                } else {
+                                    ctx.asyncMixedArrayCallbackResult = "返回类型: ${result?.let { it::class.simpleName }}, 值: $result"
+                                }
+                            }
+                        }
+                    }
+                }
+                Text {
+                    attr {
+                        fontSize(14f)
+                        marginTop(5f)
+                        testTag("result_asyncMixedArrayCallback")
+                        text("结果: ${ctx.asyncMixedArrayCallbackResult}")
+                    }
+                }
+
+                // 分隔线
+                View {
+                    attr {
+                        height(1f)
+                        marginTop(15f)
+                        backgroundColor(Color(0xFFEEEEEEL))
+                    }
+                }
+
+                // retDouble 演示
+                Text {
+                    attr {
+                        fontSize(16f)
+fontWeightBold()
+                        marginTop(15f)
+                        text("retDouble - 同步调用(返回Double)")
+                    }
+                }
+                Text {
+                    attr {
+                        fontSize(14f)
+                        color(Color(0xFF666666L))
+                        marginTop(5f)
+                        text("无参数，Native侧同步返回 Double 值 3.14")
+                    }
+                }
+                Button {
+                    attr {
+                        marginTop(8f)
+                        height(40f)
+                        borderRadius(8f)
+                        backgroundColor(Color(0xFF3c6cbdL))
+                        testTag("call_retDouble")
+                        titleAttr {
+                            text("调用 retDouble")
+                            fontSize(14f)
+                            color(Color.WHITE)
+                        }
+                    }
+                    event {
+                        click {
+                            val module = ctx.acquireModule<MyModule>(MyModule.MODULE_NAME)
+                            ctx.retDoubleResult = module.retDouble().toString()
+                        }
+                    }
+                }
+                Text {
+                    attr {
+                        fontSize(14f)
+                        marginTop(5f)
+                        testTag("result_retDouble")
+                        text("结果: ${ctx.retDoubleResult}")
+                    }
+                }
+
+                // 分隔线
+                View {
+                    attr {
+                        height(1f)
+                        marginTop(15f)
+                        backgroundColor(Color(0xFFEEEEEEL))
+                    }
+                }
+
+                // retInt 演示
+                Text {
+                    attr {
+                        fontSize(16f)
+fontWeightBold()
+                        marginTop(15f)
+                        text("retInt - 同步调用(返回Int)")
+                    }
+                }
+                Text {
+                    attr {
+                        fontSize(14f)
+                        color(Color(0xFF666666L))
+                        marginTop(5f)
+                        text("无参数，Native侧同步返回 Int 值 314")
+                    }
+                }
+                Button {
+                    attr {
+                        marginTop(8f)
+                        height(40f)
+                        borderRadius(8f)
+                        backgroundColor(Color(0xFF3c6cbdL))
+                        testTag("call_retInt")
+                        titleAttr {
+                            text("调用 retInt")
+                            fontSize(14f)
+                            color(Color.WHITE)
+                        }
+                    }
+                    event {
+                        click {
+                            val module = ctx.acquireModule<MyModule>(MyModule.MODULE_NAME)
+                            ctx.retIntResult = module.retInt().toString()
+                        }
+                    }
+                }
+                Text {
+                    attr {
+                        fontSize(14f)
+                        marginTop(5f)
+                        testTag("result_retInt")
+                        text("结果: ${ctx.retIntResult}")
+                    }
+                }
+
+                // 底部间距
+                View {
+                    attr {
+                        height(30f)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/RootDemoPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/RootDemoPage.kt
@@ -258,6 +258,12 @@ internal class RootDemoPage: BasePager() {
             itemList.add(this)
         }
 
+        ButtonDataItem().apply {
+            title = "MyModule Demo"
+            jumUrl = generateJumpUrl("MyModuleDemoPage")
+            itemList.add(this)
+        }
+
     }
 
     private fun generateJumpUrl(pagerName: String, presentMarginTop: Int = 0) : String {

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		3A622B9B2AB052B0002410B8 /* TDFTestModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A622B982AB052B0002410B8 /* TDFTestModule.m */; };
 		3A622B9C2AB052B0002410B8 /* KRNewTestModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A622B992AB052B0002410B8 /* KRNewTestModule.m */; };
+		3A622BA02AB052B0002410B8 /* KRMyModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A622BA12AB052B0002410B8 /* KRMyModule.m */; };
 		3AF526722A9309C300A93682 /* RootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AF526712A9309C300A93682 /* RootViewController.m */; };
 		7126B4462E1E726900B6B1D9 /* KRTabbarView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7126B4452E1E709000B6B1D9 /* KRTabbarView.m */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
@@ -41,6 +42,8 @@
 		3A622B982AB052B0002410B8 /* TDFTestModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDFTestModule.m; sourceTree = "<group>"; };
 		3A622B992AB052B0002410B8 /* KRNewTestModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KRNewTestModule.m; sourceTree = "<group>"; };
 		3A622B9A2AB052B0002410B8 /* KRNewTestModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KRNewTestModule.h; sourceTree = "<group>"; };
+		3A622BA12AB052B0002410B8 /* KRMyModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KRMyModule.m; sourceTree = "<group>"; };
+		3A622BA22AB052B0002410B8 /* KRMyModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KRMyModule.h; sourceTree = "<group>"; };
 		3AF526702A9309C300A93682 /* RootViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RootViewController.h; sourceTree = "<group>"; };
 		3AF526712A9309C300A93682 /* RootViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RootViewController.m; sourceTree = "<group>"; };
 		7126B4442E1E708100B6B1D9 /* KRTabbarView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KRTabbarView.h; sourceTree = "<group>"; };
@@ -237,6 +240,8 @@
 			children = (
 				FF05C64129C851A500C5E02A /* KRBridgeModule.h */,
 				FF05C64029C851A500C5E02A /* KRBridgeModule.m */,
+				3A622BA22AB052B0002410B8 /* KRMyModule.h */,
+				3A622BA12AB052B0002410B8 /* KRMyModule.m */,
 				3A622B9A2AB052B0002410B8 /* KRNewTestModule.h */,
 				3A622B992AB052B0002410B8 /* KRNewTestModule.m */,
 				3A622B972AB052B0002410B8 /* TDFTestModule.h */,
@@ -391,6 +396,7 @@
 				FF5BF1702B6EC62D001C5632 /* KRFontHanlder.m in Sources */,
 				FF151BB82A23A7E800D2BBED /* KRVideoViewHandler.m in Sources */,
 				3A622B9C2AB052B0002410B8 /* KRNewTestModule.m in Sources */,
+				3A622BA02AB052B0002410B8 /* KRMyModule.m in Sources */,
 				3AF526722A9309C300A93682 /* RootViewController.m in Sources */,
 				FF05C64229C851A500C5E02A /* KRBridgeModule.m in Sources */,
 				FF05C63C29C84FFF00C5E02A /* KuiklyRenderViewController.m in Sources */,

--- a/iosApp/iosApp/KuiklyRenderExpand/Modules/KRMyModule.h
+++ b/iosApp/iosApp/KuiklyRenderExpand/Modules/KRMyModule.h
@@ -1,0 +1,27 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import "KRBaseModule.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// 对应鸿蒙侧 KRMyModule / Android 侧 KRMyModule，演示 Kuikly Module 的同步与异步调用。
+/// module 名 = 类名 "KRMyModule"（KRBaseModule 系统通过 NSClassFromString 自动映射）。
+@interface KRMyModule : KRBaseModule
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iosApp/iosApp/KuiklyRenderExpand/Modules/KRMyModule.m
+++ b/iosApp/iosApp/KuiklyRenderExpand/Modules/KRMyModule.m
@@ -1,0 +1,96 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "KRMyModule.h"
+
+@implementation KRMyModule
+
+// KRBaseModule 通过 `hrv_callWithMethod:params:callback:` 反射调用形如 `- (id)methodName:(NSDictionary *)args` 的方法。
+// args[KR_PARAM_KEY] 为 Kotlin 传入的 param，args[KR_CALLBACK_KEY] 为回调（存在时）。
+// 返回值 = 同步返回值；如需异步回调，用 args[KR_CALLBACK_KEY] 触发。
+
+// 同步调用(JSON传输)：接收 JSON 字符串，同步返回 data 字段值
+- (id)syncJsonCall:(NSDictionary *)args {
+    NSString *jsonStr = args[KR_PARAM_KEY] ?: @"";
+    NSData *jsonData = [jsonStr dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:nil];
+    return json[@"data"] ?: @"";
+}
+
+// 同步调用(ByteArray传输)：接收含 NSData 的数组，交换字节后返回
+- (id)syncByteArrayCall:(NSDictionary *)args {
+    NSArray *params = args[KR_PARAM_KEY];
+    if (![params isKindOfClass:[NSArray class]] || params.count == 0) {
+        return nil;
+    }
+    NSData *bytes = params.firstObject;
+    if (![bytes isKindOfClass:[NSData class]] || bytes.length < 4) {
+        return bytes;
+    }
+    NSMutableData *result = [bytes mutableCopy];
+    uint8_t *p = (uint8_t *)result.mutableBytes;
+    uint8_t tmp1 = p[0];
+    uint8_t tmp2 = p[1];
+    p[0] = p[3];
+    p[1] = p[2];
+    p[2] = tmp2;
+    p[3] = tmp1;
+    return result;
+}
+
+// 异步回调(JSON传输)：通过 callback 回传 JSON 字符串（Kotlin CallbackFn 会用框架 JSONObject 解析）
+- (id)asyncJsonCallback:(NSDictionary *)args {
+    NSString *jsonStr = args[KR_PARAM_KEY] ?: @"";
+    KuiklyRenderCallback callback = args[KR_CALLBACK_KEY];
+    NSData *jsonData = [jsonStr dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:nil];
+    NSString *content = json[@"data"] ?: @"";
+    if (callback) {
+        callback([NSString stringWithFormat:@"{\"content\":\"%@\"}", content]);
+    }
+    return nil;
+}
+
+// 异步回调(数组传输)：通过 callback 回传首元素
+- (id)asyncArrayCallback:(NSDictionary *)args {
+    NSArray *params = args[KR_PARAM_KEY];
+    KuiklyRenderCallback callback = args[KR_CALLBACK_KEY];
+    if (callback) {
+        callback([params isKindOfClass:[NSArray class]] ? params.firstObject : @"");
+    }
+    return nil;
+}
+
+// 异步回调(混合数组)：通过 callback 回传 [NSData, NSString, NSString]
+- (id)asyncMixedArrayCallback:(NSDictionary *)args {
+    KuiklyRenderCallback callback = args[KR_CALLBACK_KEY];
+    if (callback) {
+        NSData *x = [NSData dataWithBytes:(uint8_t[]){33, 34, 35} length:3];
+        callback(@[x, @"s1", @"hello"]);
+    }
+    return nil;
+}
+
+// 同步调用(返回 Double 3.14)
+- (id)retDouble:(NSDictionary *)args {
+    return @(3.14);
+}
+
+// 同步调用(返回 Int 314)
+- (id)retInt:(NSDictionary *)args {
+    return @(314);
+}
+
+@end

--- a/ohosApp/entry/src/main/ets/kuikly/modules/KRMyModule.ets
+++ b/ohosApp/entry/src/main/ets/kuikly/modules/KRMyModule.ets
@@ -27,12 +27,12 @@ export class KRMyModule extends KuiklyRenderBaseModule {
   call(method: string, params: KRAny, callback: KuiklyRenderCallback | null): KRAny {
     // 分发响应
     switch (method) {
-      case 'myFun1':
-        // 接收JSON字符串，返回JSON对象
+      case 'syncJsonCall':
+        // 接收JSON字符串，返回data字段值
         const json: Record<string, string> = JSON.parse(params as string);
         return json['data'];
-      case 'myFun2':
-        // 接收基本类型数组，返回基本类型
+      case 'syncByteArrayCall':
+        // 接收基本类型数组，交换字节后返回
         const array = params as Object[];
         const bytes = array[0] as Int8Array;
         const tmp1 = bytes[0];
@@ -42,23 +42,28 @@ export class KRMyModule extends KuiklyRenderBaseModule {
         bytes[2] = tmp2;
         bytes[3] = tmp1;
         return bytes;
-      case 'myFun3':
+      case 'asyncJsonCallback':
         // 接收JSON字符串，回调JSON对象
         const json2: Record<string, string> = JSON.parse(params as string);
         const content = json2['data'];
-        callback?.(`{"content": "${content}"}`);
-        return null;
-      case 'myFun4':
-        // 接收基本类型数组，回调基本类型
+        callback?.(`{\"content\": \"${content}\"}`);
+        return 123;
+      case 'asyncArrayCallback':
+        // 接收基本类型数组，回调第一个元素
         const array2 = params as Object[];
         callback?.(array2[0] as string);
         return null;
-      case 'aTestMethod':
-        console.log('aTestMethod called');
+      case 'asyncMixedArrayCallback':
+        console.log('asyncMixedArrayCallback called');
         const x = new Int8Array([33, 34, 35]);
         const ret: KRArray = [x, 's1', 'hello'];
         callback?.(ret);
         return null;
+
+      case 'retDouble':
+        return 3.14;
+      case 'retInt':
+        return 314;
 
       default:
         return null;


### PR DESCRIPTION
三端 module 方法命名统一为语义化名字：
- myFun1  -> syncJsonCall           (同步 JSON 传输)
- myFun2  -> syncByteArrayCall      (同步 ByteArray 传输)
- myFun3  -> asyncJsonCallback      (异步 JSON 回调)
- myFun4  -> asyncArrayCallback     (异步数组回调)
- aTestMethod -> asyncMixedArrayCallback (异步混合数组回调)
- retDouble / retInt 保持不变

参照鸿蒙 KRMyModule.ets 补齐 iOS / Android 实现：
- iOS 新增 KRMyModule.h/.m，继承 KRBaseModule，用 '- (id)methodName:(NSDictionary *)args' 模式实现，通过 args[KR_PARAM_KEY] / args[KR_CALLBACK_KEY] 收发数据；同步方法回传 '{"content":"..."}' JSON 字符串，Kotlin CallbackFn 路径可用 框架 JSONObject 正确解析。同步加到 iosApp.xcodeproj target。
- Android 新增 KRMyModule.kt，继承 KuiklyRenderBaseModule，用 call(method, params, callback) 分发；异步 JSON 回调回传 JSON 字符串（对齐 Kotlin CallbackFn 桥接：Android toKotlinObject 是 identity，只有 String 分支能被框架 JSONObject 解析）。 在 KuiklyRenderView.kt 与 ContextCodeHandler.kt 注册 module。
- 鸿蒙 KRMyModule.ets 方法名对齐新命名，并修正原 myFun1 的 throw + 读取 dataX 的 bug（正确 return json['data']）。

真机/模拟器验证：三端 7/7 测试按钮全部通过。