### PR TITLE
feat: Add HTTP/SSE streaming request support in Network module

### DIFF
--- a/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/module/KRNetworkModule.kt
+++ b/core-render-android/src/main/java/com/tencent/kuikly/core/render/android/expand/module/KRNetworkModule.kt
@@ -34,16 +34,28 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLConnection
 import java.net.URLEncoder
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Created by kam on 2023/4/19.
  */
 class KRNetworkModule : KuiklyRenderBaseModule() {
 
+    private val activeStreamConnections = ConcurrentHashMap<String, HttpURLConnection>()
+
     override fun call(method: String, params: String?, callback: KuiklyRenderCallback?): Any? {
         return when (method) {
             METHOD_HTTP_REQUEST -> KuiklyRenderAdapterManager.krThreadAdapter?.executeOnSubThread {
                 httpRequest(params, null, callback)
+            }
+            METHOD_HTTP_STREAM_REQUEST -> KuiklyRenderAdapterManager.krThreadAdapter?.executeOnSubThread {
+                httpStreamRequest(params, callback)
+            }
+            METHOD_CLOSE_STREAM_REQUEST -> {
+                KuiklyRenderAdapterManager.krThreadAdapter?.executeOnSubThread {
+                    closeStreamRequest(params)
+                }
+                null
             }
             else -> super.call(method, params, callback)
         }
@@ -105,6 +117,165 @@ class KRNetworkModule : KuiklyRenderBaseModule() {
                     connection?.disconnect()
                 } catch (e: IOException) {
                     KuiklyRenderLog.e(MODULE_NAME, "Network module close error: $e")
+                }
+            }
+        }
+    }
+
+    private fun httpStreamRequest(params: String?, callback: KuiklyRenderCallback?) {
+        val paramsJSON = params.toJSONObjectSafely()
+        val url = paramsJSON.optString("url")
+        val method = paramsJSON.optString("method")
+        val param = paramsJSON.optJSONObject("param")
+        val header = paramsJSON.optJSONObject("headers")
+        val cookie = paramsJSON.optString("cookie")
+        val timeoutS = paramsJSON.optInt("timeout", DEFAULT_TIMEOUT_S)
+        val requestId = paramsJSON.optString("requestId")
+
+        if (requestId.isEmpty()) {
+            KuiklyRenderLog.e(MODULE_NAME, "Stream request error: requestId is empty")
+            callback?.invoke(
+                mapOf(
+                    KEY_STREAM_EVENT to STREAM_EVENT_ERROR,
+                    KEY_STREAM_DATA to "requestId is empty",
+                    KEY_STATUS_CODE to STATE_CODE_UNKNOWN
+                )
+            )
+            return
+        }
+
+        // 防御性判断：requestId 必须唯一，避免覆盖已有连接导致句柄丢失、状态错乱
+        if (activeStreamConnections.containsKey(requestId)) {
+            KuiklyRenderLog.e(MODULE_NAME, "Stream request error: duplicate requestId=$requestId")
+            callback?.invoke(
+                mapOf(
+                    KEY_STREAM_EVENT to STREAM_EVENT_ERROR,
+                    KEY_STREAM_DATA to "duplicate requestId",
+                    KEY_STATUS_CODE to STATE_CODE_UNKNOWN
+                )
+            )
+            return
+        }
+
+        var reader: InputStreamReader? = null
+        var errorStream: InputStream? = null
+        var connection: HttpURLConnection? = null
+        try {
+            connection = openConnection(url, method, param) as HttpURLConnection
+            activeStreamConnections[requestId] = connection
+            val timeoutMs = if (timeoutS > 0) timeoutS * 1000 else DEFAULT_TIMEOUT_S * 1000
+            connection.connectTimeout = timeoutMs
+            connection.readTimeout = timeoutMs
+            connection.useCaches = false
+            connection.doInput = true
+            addHeaderToConnection(connection, header, cookie)
+            addBodyParamsIfNeed(connection, method, header, param, null)
+            setRequestMethod(connection, method)
+
+            val responseCode = connection.responseCode
+            if (responseCode >= 200 && responseCode <= 299) {
+                val rawStream = connection.inputStream
+                val headers: String = try {
+                    if (connection.headerFields != null) connection.headerFields.toJSONObject().toString() else ""
+                } catch (e: Throwable) {
+                    KuiklyRenderLog.e(MODULE_NAME, "stream headerFields to json exception: $e")
+                    ""
+                }
+                reader = InputStreamReader(rawStream, Charsets.UTF_8)
+                var isFirstCallback = true
+                val buffer = CharArray(8192)
+                var charsRead: Int
+                while (reader.read(buffer).also { charsRead = it } != -1) {
+                    if (!activeStreamConnections.containsKey(requestId)) {
+                        break
+                    }
+                    val chunk = String(buffer, 0, charsRead)
+                    val eventData = mapOf(
+                        KEY_STREAM_EVENT to STREAM_EVENT_DATA,
+                        KEY_STREAM_DATA to chunk
+                    ).let {
+                        if (isFirstCallback) {
+                            isFirstCallback = false
+                            it + mapOf(
+                                KEY_HEADERS to headers,
+                                KEY_STATUS_CODE to responseCode
+                            )
+                        } else {
+                            it
+                        }
+                    }
+                    callback?.invoke(eventData)
+                }
+                if (activeStreamConnections.containsKey(requestId)) {
+                    callback?.invoke(
+                        mapOf(
+                            KEY_STREAM_EVENT to STREAM_EVENT_COMPLETE,
+                            KEY_STREAM_DATA to ""
+                        )
+                    )
+                }
+            } else {
+                errorStream = connection.errorStream
+                val errorMsg = readInputStreamAsString(errorStream)
+                callback?.invoke(
+                    mapOf(
+                        KEY_STREAM_EVENT to STREAM_EVENT_ERROR,
+                        KEY_STREAM_DATA to errorMsg,
+                        KEY_STATUS_CODE to responseCode
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            KuiklyRenderLog.e(MODULE_NAME, "Stream request error: $e")
+            // 如果是主动关闭导致的异常（requestId 已被 closeStreamRequest 移除），不回调 error
+            if (activeStreamConnections.containsKey(requestId)) {
+                callback?.invoke(
+                    mapOf(
+                        KEY_STREAM_EVENT to STREAM_EVENT_ERROR,
+                        KEY_STREAM_DATA to (e.message ?: "io exception"),
+                        KEY_STATUS_CODE to STATE_CODE_UNKNOWN
+                    )
+                )
+            }
+        } finally {
+            activeStreamConnections.remove(requestId)
+            try {
+                reader?.close()
+                errorStream?.close()
+                connection?.disconnect()
+            } catch (e: IOException) {
+                KuiklyRenderLog.e(MODULE_NAME, "Stream request close error: $e")
+            }
+        }
+    }
+
+    private fun closeStreamRequest(params: String?) {
+        val paramsJSON = params.toJSONObjectSafely()
+        val requestId = paramsJSON.optString("requestId")
+        val connection = activeStreamConnections.remove(requestId)
+        try {
+            connection?.disconnect()
+        } catch (e: Exception) {
+            KuiklyRenderLog.e(MODULE_NAME, "Close stream request error: $e")
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        //  remove 在主线程立即执行，disconnect() 交给子线程执行，
+        // 使用 iterator.remove() 逐个原子移除，避免 values snapshot 和 clear 之间的竞态窗口
+        val connections = ArrayList<HttpURLConnection>()
+        val iterator = activeStreamConnections.entries.iterator()
+        while (iterator.hasNext()) {
+            connections.add(iterator.next().value)
+            iterator.remove()
+        }
+        if (connections.isNotEmpty()) {
+            KuiklyRenderAdapterManager.krThreadAdapter?.executeOnSubThread {
+                for (conn in connections) {
+                    try {
+                        conn.disconnect()
+                    } catch (_: Exception) {}
                 }
             }
         }
@@ -376,14 +547,22 @@ class KRNetworkModule : KuiklyRenderBaseModule() {
         const val MODULE_NAME = "KRNetworkModule"
         private const val METHOD_HTTP_REQUEST = "httpRequest"
         private const val METHOD_HTTP_REQUEST_BINARY = "httpRequestBinary"
+        private const val METHOD_HTTP_STREAM_REQUEST = "httpStreamRequest"
+        private const val METHOD_CLOSE_STREAM_REQUEST = "closeStreamRequest"
         private const val HTTP_METHOD_GET = "GET"
         private const val HTTP_METHOD_POST = "POST"
         private const val KEY_SUCCESS = "success"
         private const val KEY_ERROR_MSG = "errorMsg"
         private const val KEY_HEADERS = "headers"
         private const val KEY_STATUS_CODE = "statusCode"
+        private const val KEY_STREAM_EVENT = "event"
+        private const val KEY_STREAM_DATA = "data"
+        private const val STREAM_EVENT_DATA = "data"
+        private const val STREAM_EVENT_COMPLETE = "complete"
+        private const val STREAM_EVENT_ERROR = "error"
 
         private const val STATE_CODE_UNKNOWN = -1000
+        private const val DEFAULT_TIMEOUT_S = 30
 
     }
 }

--- a/core-render-ios/Extension/Modules/KRNetworkModule.h
+++ b/core-render-ios/Extension/Modules/KRNetworkModule.h
@@ -16,10 +16,17 @@
 #import "KRBaseModule.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+@class KRStreamSessionDelegate;
+
 /*
  * @brief Http网络请求模块
  */
 @interface KRNetworkModule : KRBaseModule
+
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSURLSessionDataTask *> *activeStreamTasks;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, KRStreamSessionDelegate *> *activeStreamDelegates;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSURLSession *> *activeStreamSessions;
 
 @end
 

--- a/core-render-ios/Extension/Modules/KRNetworkModule.m
+++ b/core-render-ios/Extension/Modules/KRNetworkModule.m
@@ -16,6 +16,97 @@
 #import "KRNetworkModule.h"
 #import "KRHttpRequestTool.h"
 
+#pragma mark - KRStreamSessionDelegate
+
+@interface KRStreamSessionDelegate : NSObject <NSURLSessionDataDelegate>
+
+@property (nonatomic, copy) KuiklyRenderCallback callback;
+@property (nonatomic, copy) NSString *requestId;
+@property (nonatomic, assign) BOOL isFirstCallback;
+@property (nonatomic, strong) NSHTTPURLResponse *httpResponse;
+/// 请求结束（成功/失败/被取消）后由 delegate 主动回调，用于统一清理
+/// module 侧持有的 session/task/delegate 三个字典条目，并 invalidate session。
+@property (nonatomic, copy) void (^onFinish)(NSString *requestId);
+
+@end
+
+@implementation KRStreamSessionDelegate
+
+- (instancetype)initWithCallback:(KuiklyRenderCallback)callback requestId:(NSString *)requestId {
+    self = [super init];
+    if (self) {
+        _callback = callback;
+        _requestId = requestId;
+        _isFirstCallback = YES;
+    }
+    return self;
+}
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler {
+    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+        self.httpResponse = (NSHTTPURLResponse *)response;
+        NSInteger statusCode = self.httpResponse.statusCode;
+        if (statusCode < 200 || statusCode > 299) {
+            completionHandler(NSURLSessionResponseCancel);
+            if (self.callback) {
+                NSString *headers = [self.httpResponse.allHeaderFields hr_dictionaryToString] ?: @"";
+                self.callback(@{
+                    @"event": @"error",
+                    @"data": [NSString stringWithFormat:@"HTTP error %ld", (long)statusCode],
+                    @"headers": headers,
+                    @"statusCode": @(statusCode)
+                });
+            }
+            return;
+        }
+    }
+    completionHandler(NSURLSessionResponseAllow);
+}
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data {
+    if (!self.callback) return;
+    NSString *text = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] ?: @"";
+    NSMutableDictionary *eventData = [@{
+        @"event": @"data",
+        @"data": text
+    } mutableCopy];
+    if (self.isFirstCallback && self.httpResponse) {
+        self.isFirstCallback = NO;
+        NSString *headers = [self.httpResponse.allHeaderFields hr_dictionaryToString] ?: @"";
+        eventData[@"headers"] = headers;
+        eventData[@"statusCode"] = @(self.httpResponse.statusCode);
+    }
+    self.callback([eventData copy]);
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error {
+    if (self.callback) {
+        if (error) {
+            if (error.code != NSURLErrorCancelled) {
+                self.callback(@{
+                    @"event": @"error",
+                    @"data": error.localizedDescription ?: @"unknown error",
+                    @"statusCode": @(-1000)
+                });
+            }
+        } else {
+            self.callback(@{
+                @"event": @"complete",
+                @"data": @""
+            });
+        }
+    }
+    // 无论成功/失败/取消，都需要通知 module 清理资源，避免 session/delegate 内存滞留
+    if (self.onFinish) {
+        self.onFinish(self.requestId);
+        self.onFinish = nil;
+    }
+}
+
+@end
+
+#pragma mark - KRNetworkModule
+
 @implementation KRNetworkModule
 
 /**
@@ -126,6 +217,40 @@
     return nil;
 }
 
+- (NSMutableDictionary<NSString *, NSURLSessionDataTask *> *)activeStreamTasks {
+    if (!_activeStreamTasks) {
+        _activeStreamTasks = [NSMutableDictionary dictionary];
+    }
+    return _activeStreamTasks;
+}
+
+- (NSMutableDictionary<NSString *, KRStreamSessionDelegate *> *)activeStreamDelegates {
+    if (!_activeStreamDelegates) {
+        _activeStreamDelegates = [NSMutableDictionary dictionary];
+    }
+    return _activeStreamDelegates;
+}
+
+- (NSMutableDictionary<NSString *, NSURLSession *> *)activeStreamSessions {
+    if (!_activeStreamSessions) {
+        _activeStreamSessions = [NSMutableDictionary dictionary];
+    }
+    return _activeStreamSessions;
+}
+
+/// 统一清理指定 requestId 关联的 session/task/delegate。
+/// 主动关闭（closeStreamRequest:）与请求结束回调（didCompleteWithError:）均走此方法，
+/// 避免 NSURLSession 因未 invalidate 而长期持有 delegate 造成内存滞留。
+- (void)kr_finalizeStreamRequestWithId:(NSString *)requestId {
+    if (requestId.length == 0) return;
+    NSURLSession *session = self.activeStreamSessions[requestId];
+    // invalidateAndCancel 会取消未完成的 task 并释放 session 对 delegate 的强引用
+    [session invalidateAndCancel];
+    [self.activeStreamSessions removeObjectForKey:requestId];
+    [self.activeStreamTasks removeObjectForKey:requestId];
+    [self.activeStreamDelegates removeObjectForKey:requestId];
+}
+
 /*
  * 通用Http请求接口， call by kotlin
  */
@@ -227,6 +352,123 @@
             callback(@[[resInfo hr_dictionaryToString], data ?: [NSData data]]);
         }
     }];
+}
+
+/*
+ * SSE 流式Http请求接口
+ */
+- (void)httpStreamRequest:(NSDictionary *)args {
+    NSDictionary *param = [args[KR_PARAM_KEY] hr_stringToDictionary];
+    KuiklyRenderCallback callback = args[KR_CALLBACK_KEY];
+    NSString *url = param[@"url"];
+    NSString *method = param[@"method"];
+    NSDictionary *requestParam = param[@"param"];
+    NSDictionary *headers = param[@"headers"];
+    NSString *cookie = param[@"cookie"];
+    NSInteger timeout = [param[@"timeout"] intValue];
+    NSString *requestId = param[@"requestId"];
+
+    if (!requestId || requestId.length == 0) {
+        if (callback) {
+            callback(@{
+                @"event": @"error",
+                @"data": @"requestId is empty",
+                @"statusCode": @(-1000)
+            });
+        }
+        return;
+    }
+
+    // 防御性判断：requestId 必须唯一，避免覆盖已有的流式请求导致句柄丢失
+    if (self.activeStreamTasks[requestId] != nil) {
+        if (callback) {
+            callback(@{
+                @"event": @"error",
+                @"data": @"duplicate requestId",
+                @"statusCode": @(-1000)
+            });
+        }
+        return;
+    }
+
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:url]];
+    request.HTTPMethod = method ?: @"GET";
+    request.timeoutInterval = timeout > 0 ? timeout : 30;
+
+    if (cookie.length > 0) {
+        [request setValue:cookie forHTTPHeaderField:@"Cookie"];
+    }
+    if (headers) {
+        for (NSString *key in headers) {
+            [request setValue:[headers[key] description] forHTTPHeaderField:key];
+        }
+    }
+
+    if ([method isEqualToString:@"POST"] && requestParam) {
+        NSString *contentType = headers[@"Content-Type"] ?: headers[@"content-type"] ?: @"";
+        if ([contentType containsString:@"application/json"]) {
+            NSData *body = [NSJSONSerialization dataWithJSONObject:requestParam options:0 error:nil];
+            request.HTTPBody = body;
+        } else {
+            NSMutableArray *parts = [NSMutableArray array];
+            for (NSString *key in requestParam) {
+                [parts addObject:[NSString stringWithFormat:@"%@=%@", key, requestParam[key]]];
+            }
+            request.HTTPBody = [[parts componentsJoinedByString:@"&"] dataUsingEncoding:NSUTF8StringEncoding];
+        }
+    }
+
+    KRStreamSessionDelegate *delegate = [[KRStreamSessionDelegate alloc] initWithCallback:callback requestId:requestId];
+    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+    // delegateQueue 使用主队列：
+    // 1. 所有 delegate 回调（didReceiveData / didCompleteWithError 等）都在主线程执行，
+    //    onFinish 里对 activeStreamXXX 三个字典的读写天然串行，无需额外加锁。
+    // 2. Kuikly Module 的 httpStreamRequest: / closeStreamRequest: 本身也在主线程调用，
+    //    统一线程后不存在多线程并发读写 NSMutableDictionary 的隐患。
+    // 3. SSE 每帧数据量小、解码轻量（仅 initWithData:encoding:），对主线程负担可忽略；
+    //    业务侧收到 data 事件后通常要更新 UI，本就需要主线程，避免了一次额外的线程切换。
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:config delegate:delegate delegateQueue:[NSOperationQueue mainQueue]];
+    NSURLSessionDataTask *task = [session dataTaskWithRequest:request];
+
+    __weak typeof(self) weakSelf = self;
+    delegate.onFinish = ^(NSString *finishedRequestId) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        // 请求正常结束/失败后，统一清理 session/task/delegate，避免内存滞留
+        [strongSelf kr_finalizeStreamRequestWithId:finishedRequestId];
+    };
+
+    self.activeStreamTasks[requestId] = task;
+    self.activeStreamDelegates[requestId] = delegate;
+    self.activeStreamSessions[requestId] = session;
+
+    [task resume];
+}
+
+/*
+ * 关闭 SSE 流式请求
+ */
+- (void)closeStreamRequest:(NSDictionary *)args {
+    NSDictionary *param = [args[KR_PARAM_KEY] hr_stringToDictionary];
+    NSString *requestId = param[@"requestId"];
+    // 使用统一清理入口：invalidate session + 移除三个字典条目
+    // NSURLSession 未 invalidate 时会 strong 持有 delegate，仅 cancel task 不足以释放
+    [self kr_finalizeStreamRequestWithId:requestId];
+}
+
+- (void)dealloc {
+    // 拷贝一份 key 快照，避免在遍历过程中修改字典
+    NSArray<NSString *> *requestIds = [self.activeStreamSessions.allKeys copy];
+    for (NSString *requestId in requestIds) {
+        [self kr_finalizeStreamRequestWithId:requestId];
+    }
+    // 兜底清理：即使某些请求仅存在于 tasks/delegates 字典中（异常路径），也确保全部释放
+    for (NSURLSessionDataTask *task in self.activeStreamTasks.allValues) {
+        [task cancel];
+    }
+    [self.activeStreamTasks removeAllObjects];
+    [self.activeStreamDelegates removeAllObjects];
+    [self.activeStreamSessions removeAllObjects];
 }
 
 @end

--- a/core-render-ohos/src/main/ets/modules/KRNetworkModule.ets
+++ b/core-render-ohos/src/main/ets/modules/KRNetworkModule.ets
@@ -21,6 +21,7 @@ import { BusinessError } from '@kit.BasicServicesKit';
 import Url from '@ohos.url';
 import buffer from '@ohos.buffer';
 import { KRRenderLog } from '../adapter/KRRenderLog';
+import { util } from '@kit.ArkTS';
 
 interface ParamsObject {
   url: string;
@@ -31,6 +32,17 @@ interface ParamsObject {
   timeout: number;
 }
 
+interface StreamParamsObject extends ParamsObject {
+  requestId: string;
+}
+
+interface StreamEventData {
+  event: string;
+  data: string;
+  headers?: string;
+  statusCode?: number;
+}
+
 export class KRNetworkModule extends KuiklyRenderBaseModule {
   syncMode(): boolean {
     return false;
@@ -39,6 +51,11 @@ export class KRNetworkModule extends KuiklyRenderBaseModule {
   static readonly MODULE_NAME = 'KRNetworkModule';
   private static readonly METHOD_HTTP_REQUEST = 'httpRequest';
   private static readonly METHOD_HTTP_REQUEST_BINARY = "httpRequestBinary";
+  private static readonly METHOD_HTTP_STREAM_REQUEST = 'httpStreamRequest';
+  private static readonly METHOD_CLOSE_STREAM_REQUEST = 'closeStreamRequest';
+  private static readonly DEFAULT_TIMEOUT_S = 30;
+  private static readonly STATE_CODE_UNKNOWN = -1000;
+  private activeStreamRequests: Map<string, http.HttpRequest> = new Map();
 
   call(method: string, params: KRAny, callback: KuiklyRenderCallback | null): KRAny {
     switch (method) {
@@ -55,12 +72,226 @@ export class KRNetworkModule extends KuiklyRenderBaseModule {
       case KRNetworkModule.METHOD_HTTP_REQUEST_BINARY:
         const args = params as Array<KRAny>;
         return this.httpRequest(args[0], args[1] as Int8Array, callback);
+      case KRNetworkModule.METHOD_HTTP_STREAM_REQUEST:
+        this.httpStreamRequest(params as string, callback);
+        return null;
+      case KRNetworkModule.METHOD_CLOSE_STREAM_REQUEST:
+        this.closeStreamRequest(params as string);
+        return null;
       default:
         return null;
     }
   }
 
   onDestroy(): void {
+    this.activeStreamRequests.forEach((httpReq) => {
+      this.cleanupHttpRequest(httpReq);
+    });
+    this.activeStreamRequests.clear();
+  }
+
+  /**
+   * 统一清理 HttpRequest 资源：注销事件监听并销毁请求。
+   * off/destroy 均可能抛异常，这里全部 try-catch 兜底，异常仅记录日志不再抛出，
+   */
+  private cleanupHttpRequest(httpReq: http.HttpRequest): void {
+    try {
+      httpReq.off('dataReceive');
+    } catch (e) {
+      KRRenderLog.e("NetworkModule", `off dataReceive error: ${(e as BusinessError).message}`);
+    }
+    try {
+      httpReq.off('dataEnd');
+    } catch (e) {
+      KRRenderLog.e("NetworkModule", `off dataEnd error: ${(e as BusinessError).message}`);
+    }
+    try {
+      httpReq.off('headersReceive');
+    } catch (e) {
+      KRRenderLog.e("NetworkModule", `off headersReceive error: ${(e as BusinessError).message}`);
+    }
+    try {
+      httpReq.destroy();
+    } catch (e) {
+      KRRenderLog.e("NetworkModule", `destroy httpRequest error: ${(e as BusinessError).message}`);
+    }
+  }
+
+  /**
+   * 清理指定 requestId 对应的流式请求，包含事件反注册、销毁与 Map 移除。
+   */
+  private finalizeStreamRequest(requestId: string): void {
+    const httpReq = this.activeStreamRequests.get(requestId);
+    if (httpReq) {
+      this.cleanupHttpRequest(httpReq);
+    }
+    this.activeStreamRequests.delete(requestId);
+  }
+
+  private httpStreamRequest(paramsStr: string, callback: KuiklyRenderCallback | null): void {
+    let requestId = '';
+    let httpRequest: http.HttpRequest | null = null;
+    try {
+      const params: StreamParamsObject = JSON.parse(paramsStr);
+      requestId = params.requestId;
+
+      // requestId 空校验
+      if (!requestId) {
+        KRRenderLog.e("NetworkModule", "Stream request error: requestId is empty");
+        if (callback) {
+          const eventData: StreamEventData = {
+            event: 'error',
+            data: 'requestId is empty',
+            statusCode: KRNetworkModule.STATE_CODE_UNKNOWN
+          };
+          callback(eventData);
+        }
+        return;
+      }
+
+      // 防御性判断：requestId 必须唯一，避免覆盖已有的流式请求导致句柄丢失
+      if (this.activeStreamRequests.has(requestId)) {
+        KRRenderLog.e("NetworkModule", `Stream request error: duplicate requestId=${requestId}`);
+        if (callback) {
+          const eventData: StreamEventData = {
+            event: 'error',
+            data: 'duplicate requestId',
+            statusCode: KRNetworkModule.STATE_CODE_UNKNOWN
+          };
+          callback(eventData);
+        }
+        return;
+      }
+
+      const urlOptions = this.createURLAndOptions(params, null);
+      if (urlOptions == null) {
+        return;
+      }
+
+      const url = urlOptions[0];
+      const options = urlOptions[1];
+
+      httpRequest = http.createHttp();
+      this.activeStreamRequests.set(requestId, httpRequest);
+
+      const decoder = util.TextDecoder.create('utf-8', { ignoreBOM: true });
+      let isFirstCallback = true;
+      let responseHeaders = '';
+      let responseCode = 0;
+
+      httpRequest.on('dataReceive', (data: ArrayBuffer) => {
+        // 若 requestId 已从 activeStreamRequests 中移除，说明业务侧已通过 closeStreamRequest
+        // 主动关闭（或 onDestroy 已触发），此时静默丢弃后续 chunk 即可。
+        // 注意：这里不需要再做 off/destroy 清理——资源释放由 close 路径的 finalizeStreamRequest 统一完成，
+        // 之所以仍可能收到回调，是因为 native 侧已入队的事件在 off 之前就 post 到了 ArkTS 事件循环。
+        if (!callback || !this.activeStreamRequests.has(requestId)) return;
+        const text = decoder.decodeToString(new Uint8Array(data));
+        const eventData: StreamEventData = {
+          event: 'data',
+          data: text
+        };
+        if (isFirstCallback) {
+          isFirstCallback = false;
+          eventData.headers = responseHeaders;
+          eventData.statusCode = responseCode;
+        }
+        callback(eventData);
+      });
+
+      httpRequest.on('dataEnd', () => {
+        // 与 dataReceive 同理：若已被主动关闭，这里静默返回；资源清理已由 close 路径完成。
+        if (!this.activeStreamRequests.has(requestId)) return;
+        if (callback) {
+          const eventData: StreamEventData = {
+            event: 'complete',
+            data: ''
+          };
+          callback(eventData);
+        }
+        this.finalizeStreamRequest(requestId);
+      });
+
+      // 监听 headersReceive 以获取响应头
+      httpRequest.on('headersReceive', (header: Object) => {
+        try {
+          responseHeaders = JSON.stringify(header);
+        } catch (_) {
+          responseHeaders = '';
+        }
+      });
+
+      options.expectDataType = http.HttpDataType.STRING;
+
+      httpRequest.requestInStream(url.toString(), options).then((code: number) => {
+        responseCode = code;
+        if (code >= 200 && code <= 299) {
+          // 成功，数据通过 dataReceive/dataEnd 事件回调处理
+        } else {
+          // 非 2xx 响应（含 3xx / 4xx / 5xx）统一按错误处理并清理资源。
+          // 关于 3xx：HarmonyOS http 底层（libcurl）默认会自动跟随重定向，业务侧通常只会看到最终响应码；
+          // 但 requestInStream 未开放 FOLLOWLOCATION 选项，若底层未跟随（如跨协议 http→https 被拒、
+          // 或 Location 头缺失），3xx 会直接透传到这里——此时对 SSE 场景已无法继续流式读取，
+          // 作为 error 回调给业务侧是合适的。
+          if (callback && this.activeStreamRequests.has(requestId)) {
+            const eventData: StreamEventData = {
+              event: 'error',
+              data: `HTTP error ${code}`,
+              statusCode: code
+            };
+            callback(eventData);
+          }
+          this.finalizeStreamRequest(requestId);
+        }
+      }).catch((err: Error) => {
+        KRRenderLog.e("NetworkModule", `Stream request error: ${err.message}`);
+        // 如果是主动关闭导致的异常（requestId 已被 closeStreamRequest 移除），不回调 error
+        if (callback && this.activeStreamRequests.has(requestId)) {
+          const eventData: StreamEventData = {
+            event: 'error',
+            data: err.message,
+            statusCode: KRNetworkModule.STATE_CODE_UNKNOWN
+          };
+          callback(eventData);
+        }
+        this.finalizeStreamRequest(requestId);
+      });
+    } catch (e) {
+      const errmsg = `stream request error: ${(e as BusinessError).message}`;
+      KRRenderLog.e("NetworkModule", errmsg);
+      // 兜底清理，两个分支互斥、对应 try 块中不同阶段抛出异常的场景：
+      //   1. 已 set 进 activeStreamRequests（如 on() 注册事件监听时抛异常）
+      //      → 走 finalizeStreamRequest 统一路径：反注册事件 + destroy + delete。
+      //   2. httpRequest 已创建但尚未 set 进 map 的中间状态
+      //      （如 http.createHttp() 之后、activeStreamRequests.set() 之前抛异常，窗口极窄）
+      //      → 此时 map 里没有条目，只需 cleanupHttpRequest 释放句柄，避免泄漏。
+      // 分支互斥：命中分支 1 时 httpRequest 指向的对象已被 finalizeStreamRequest 清理，
+      // 因此 else if 不会（也不应该）再重复清理。
+      if (requestId && this.activeStreamRequests.has(requestId)) {
+        this.finalizeStreamRequest(requestId);
+      } else if (httpRequest) {
+        this.cleanupHttpRequest(httpRequest);
+      }
+      if (callback) {
+        const eventData: StreamEventData = {
+          event: 'error',
+          data: errmsg,
+          statusCode: KRNetworkModule.STATE_CODE_UNKNOWN
+        };
+        callback(eventData);
+      }
+    }
+  }
+
+  private closeStreamRequest(paramsStr: string): void {
+    try {
+      const params = JSON.parse(paramsStr) as Record<string, string>;
+      const requestId = params['requestId'];
+      if (requestId && this.activeStreamRequests.has(requestId)) {
+        this.finalizeStreamRequest(requestId);
+      }
+    } catch (e) {
+      KRRenderLog.e("NetworkModule", `close stream error: ${(e as BusinessError).message}`);
+    }
   }
 
   private httpRequest(params: KRAny, bytes: Int8Array | null, callback: KuiklyRenderCallback | null): KRAny {
@@ -199,7 +430,9 @@ export class KRNetworkModule extends KuiklyRenderBaseModule {
     }
 
     // set timeout
-    options.readTimeout = params.timeout * 1000;
+    const timeoutS = params.timeout > 0 ? params.timeout : KRNetworkModule.DEFAULT_TIMEOUT_S;
+    options.readTimeout = timeoutS * 1000;
+    options.connectTimeout = timeoutS * 1000;
 
     //options.usingProxy = true;
 

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/module/NetworkModule.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/module/NetworkModule.kt
@@ -25,6 +25,15 @@ typealias NMAllResponse = (data: JSONObject, success : Boolean , errorMsg: Strin
 typealias NMDataResponse = (data: ByteArray, success: Boolean, errorMsg: String, response: NetworkResponse) -> Unit
 
 /**
+ * SSE 流式请求事件回调。
+ *
+ * @param event 事件类型：
+ * @param data 事件数据：
+ * @param response 网络响应信息（headers、statusCode），仅在首次回调中有值，后续为 null
+ */
+typealias NMStreamEventCallback = (event: String, data: String, response: NetworkResponse?) -> Unit
+
+/**
  * 表示网络响应的数据类。
  *
  * @property headerFields 包含响应头字段的JSONObject。
@@ -216,10 +225,106 @@ class NetworkModule : Module() {
         )
     }
 
+    /**
+     * SSE 流式 HTTP 请求。
+     * @param url 请求 URL
+     * @param isPost 是否为 POST 请求
+     * @param param 请求参数（GET 时拼接到 URL，POST 时作为 body）
+     * @param headers 自定义请求头
+     * @param cookie Cookie 字符串
+     * @param timeout 超时时间（秒）
+     * @param eventCallback 流式事件回调
+     * @return StreamRequestHandle 流式请求句柄
+     */
+    fun httpStreamRequest(
+        url: String,
+        isPost: Boolean,
+        param: JSONObject? = null,
+        headers: JSONObject? = null,
+        cookie: String? = null,
+        timeout: Int = 30,
+        eventCallback: NMStreamEventCallback
+    ): StreamRequestHandle {
+        val requestId = "stream_${streamRequestIdCounter++}"
+        val params = JSONObject().apply {
+            put("url", url)
+            put("method", if (isPost) "POST" else "GET")
+            param?.also {
+                put("param", it)
+            }
+            headers?.also {
+                put("headers", it)
+            }
+            cookie?.also {
+                put("cookie", it)
+            }
+            put("timeout", timeout)
+            put("requestId", requestId)
+        }
+        val returnValue = toNative(
+            true,
+            METHOD_HTTP_STREAM_REQUEST,
+            params.toString(),
+            callback = { res ->
+                res?.also {
+                    val event = it.optString("event", "")
+                    val data = it.optString("data", "")
+                    var networkResponse: NetworkResponse? = null
+                    if (it.has("headers") || it.has("statusCode")) {
+                        val respHeaders = it.optString("headers", "{}").toJSONObjectSafely()
+                        var statusCode: Int? = null
+                        if (it.has("statusCode")) {
+                            statusCode = it.optInt("statusCode")
+                        }
+                        networkResponse = NetworkResponse(respHeaders ?: JSONObject(), statusCode)
+                    }
+                    eventCallback(event, data, networkResponse)
+                }
+            },
+            syncCall = false
+        )
+        return StreamRequestHandle(this, returnValue.callbackRef, requestId)
+    }
+
+    /**
+     * 关闭 SSE 连接。
+     */
+    class StreamRequestHandle internal constructor(
+        private val module: NetworkModule,
+        private val callbackRef: CallbackRef?,
+        private val requestId: String
+    ) {
+        private var closed = false
+
+        /**
+         * 关闭流式连接并释放资源。
+         */
+        fun close() {
+            if (closed) return
+            closed = true
+            val params = JSONObject().apply {
+                put("requestId", requestId)
+            }
+            module.toNative(
+                false,
+                METHOD_CLOSE_STREAM_REQUEST,
+                params.toString(),
+                null,
+                false
+            )
+            callbackRef?.also {
+                module.removeCallback(it)
+            }
+        }
+    }
+
     companion object {
         const val MODULE_NAME = ModuleConst.NETWORK
         private const val METHOD_HTTP_REQUEST = "httpRequest"
         private const val METHOD_HTTP_REQUEST_BINARY = "httpRequestBinary"
+        private const val METHOD_HTTP_STREAM_REQUEST = "httpStreamRequest"
+        private const val METHOD_CLOSE_STREAM_REQUEST = "closeStreamRequest"
+        private var streamRequestIdCounter = 0L
 
         private fun Any.toJSONObjectSafely(): JSONObject? {
             return when {

--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/SSETypewriterDemoPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/SSETypewriterDemoPage.kt
@@ -1,0 +1,388 @@
+package com.tencent.kuikly.demo.pages.demo
+
+import com.tencent.kuikly.core.annotations.Page
+import com.tencent.kuikly.core.base.Color
+import com.tencent.kuikly.core.base.ViewBuilder
+import com.tencent.kuikly.core.module.NetworkModule
+import com.tencent.kuikly.core.module.NetworkResponse
+import com.tencent.kuikly.core.nvi.serialization.json.JSONArray
+import com.tencent.kuikly.core.nvi.serialization.json.JSONObject
+import com.tencent.kuikly.core.reactive.handler.observable
+import com.tencent.kuikly.core.views.Input
+import com.tencent.kuikly.core.views.Scroller
+import com.tencent.kuikly.core.views.Text
+import com.tencent.kuikly.core.views.View
+import com.tencent.kuikly.core.views.compose.Button
+import com.tencent.kuikly.core.views.layout.Row
+import com.tencent.kuikly.demo.pages.base.BasePager
+import com.tencent.kuikly.demo.pages.demo.base.NavBar
+
+/**
+ * SSE 流式效果 Demo
+ * 展示大模型逐 token 输出的效果。
+ */
+@Page("SSETypewriterDemoPage")
+internal class SSETypewriterDemoPage : BasePager() {
+
+    /** 当前已显示的文本 */
+    private var displayText by observable("")
+    /** 状态文本 */
+    private var statusText by observable("就绪")
+    /** 是否正在流式请求中 */
+    private var isStreaming by observable(false)
+    /** 当前流式请求句柄 */
+    private var currentHandle: NetworkModule.StreamRequestHandle? = null
+    /** 已收到的数据块数量 */
+    private var chunkCount by observable(0)
+    /** 用户输入的提问内容 */
+    private var userPrompt by observable("请用简洁的语言介绍一下你自己，以及你能做什么？")
+
+    companion object {
+        // 使用前需填写以下参数
+        /** API 地址（兼容 OpenAI 格式） */
+        private const val API_URL = "xxx"
+        /** API Key */
+        private const val API_KEY = "xxx"
+        /** 使用的模型 */
+        private const val MODEL = "xxx"
+    }
+
+    override fun body(): ViewBuilder {
+        val ctx = this
+        return {
+            attr {
+                backgroundColor(Color(0xFFF8F9FAL))
+            }
+
+            NavBar {
+                attr {
+                title = "AI 流式对话"
+                }
+            }
+
+            // 状态栏
+            View {
+                attr {
+                    marginLeft(12f)
+                    marginRight(12f)
+                    marginTop(10f)
+                    padding(12f)
+                    borderRadius(10f)
+                    backgroundColor(
+                        if (ctx.isStreaming) Color(0xFFE3F2FDL)
+                        else if (ctx.statusText.contains("完成")) Color(0xFFE8F5E9L)
+                        else if (ctx.statusText.contains("错误")) Color(0xFFFFEBEEL)
+                        else Color(0xFFF5F5F5L)
+                    )
+                }
+                Text {
+                    attr {
+                        text("状态: ${ctx.statusText}")
+                        fontSize(13f)
+                        color(Color(0xFF666666L))
+                    }
+                }
+            }
+
+            // 输入区域
+            View {
+                attr {
+                    marginLeft(12f)
+                    marginRight(12f)
+                    marginTop(10f)
+                    padding(12f)
+                    borderRadius(10f)
+                    backgroundColor(Color.WHITE)
+                }
+                Text {
+                    attr {
+                        text("输入你的问题：")
+                        fontSize(13f)
+                        fontWeightBold()
+                        color(Color(0xFF333333L))
+                        marginBottom(8f)
+                    }
+                }
+                Input {
+                    attr {
+                        height(80f)
+                        alignSelfStretch()
+                        backgroundColor(Color(0xFFF5F5F5L))
+                        borderRadius(8f)
+                        margin(10f)
+                        fontSize(14f)
+                        color(Color(0xFF333333L))
+                        text(ctx.userPrompt)
+                        placeholder("请输入...")
+                    }
+                    event {
+                        textDidChange {
+                            ctx.userPrompt = it.text
+                        }
+                    }
+                }
+            }
+
+            // 按钮区域
+            Row {
+                attr {
+                    marginTop(10f)
+                    marginLeft(8f)
+                    marginRight(8f)
+                }
+                // 发送按钮
+                Button {
+                    attr {
+                        flex(1f)
+                        height(44f)
+                        borderRadius(22f)
+                        marginLeft(4f)
+                        marginRight(4f)
+                        backgroundColor(
+                            if (ctx.isStreaming) Color(0xFFBDBDBDL) else Color(0xFF2196F3L)
+                        )
+                        titleAttr {
+                            text("发送")
+                            color(Color.WHITE)
+                            fontSize(14f)
+                        }
+                    }
+                    event {
+                        click {
+                            if (!ctx.isStreaming && ctx.userPrompt.isNotBlank()) {
+                                ctx.startStream()
+                            }
+                        }
+                    }
+                }
+                // 停止按钮
+                Button {
+                    attr {
+                        flex(1f)
+                        height(44f)
+                        borderRadius(22f)
+                        marginLeft(4f)
+                        marginRight(4f)
+                        backgroundColor(
+                            if (!ctx.isStreaming) Color(0xFFBDBDBDL) else Color(0xFFF44336L)
+                        )
+                        titleAttr {
+                            text("停止")
+                            color(Color.WHITE)
+                            fontSize(14f)
+                        }
+                    }
+                    event {
+                        click {
+                            if (ctx.isStreaming) {
+                                ctx.stopStream()
+                            }
+                        }
+                    }
+                }
+                // 清空按钮
+                Button {
+                    attr {
+                        flex(1f)
+                        height(44f)
+                        borderRadius(22f)
+                        marginLeft(4f)
+                        marginRight(4f)
+                        backgroundColor(
+                            if (ctx.isStreaming) Color(0xFFBDBDBDL) else Color(0xFF757575L)
+                        )
+                        titleAttr {
+                            text("清空")
+                            color(Color.WHITE)
+                            fontSize(14f)
+                        }
+                    }
+                    event {
+                        click {
+                            if (!ctx.isStreaming) {
+                                ctx.clearAll()
+                            }
+                        }
+                    }
+                }
+            }
+
+            // AI 回复输出区域
+            View {
+                attr {
+                    marginLeft(12f)
+                    marginRight(12f)
+                    marginTop(12f)
+                    marginBottom(12f)
+                    flex(1f)
+                    borderRadius(12f)
+                    backgroundColor(Color.WHITE)
+                }
+                // 顶部标题栏
+                View {
+                    attr {
+                        padding(12f)
+                        backgroundColor(Color(0xFF424242L))
+                        borderRadius(12f, 12f, 0f, 0f)
+                    }
+                    Text {
+                        attr {
+                            text("AI回复")
+                            fontSize(14f)
+                            fontWeightBold()
+                            color(Color.WHITE)
+                        }
+                    }
+                }
+                // 文本内容区域
+                Scroller {
+                    attr {
+                        padding(16f)
+                        flex(1f)
+                        alignSelfStretch()
+                    }
+                    Text {
+                        attr {
+                            text(
+                                if (ctx.displayText.isEmpty() && !ctx.isStreaming)
+                                    "输入问题并点击「发送提问"
+                                else if (ctx.displayText.isEmpty() && ctx.isStreaming)
+                                    "等待回复中..."
+                                else
+                                    ctx.displayText
+                            )
+                            fontSize(15f)
+                            lineHeight(24f)
+                            color(
+                                if (ctx.displayText.isEmpty())
+                                    Color(0xFF999999L)
+                                else
+                                    Color(0xFF333333L)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * 发起大模型流式请求
+     */
+    private fun startStream() {
+        displayText = ""
+        chunkCount = 0
+        statusText = "正在连接..."
+        isStreaming = true
+
+        // 构建请求体（OpenAI 兼容格式）
+        val requestBody = JSONObject().apply {
+            put("model", MODEL)
+            put("stream", true)
+            put("messages", JSONArray().apply {
+                put(JSONObject().apply {
+                    put("role", "system")
+                    put("content", "你是人工智能助手。请用中文回答用户的问题。")
+                })
+                put(JSONObject().apply {
+                    put("role", "user")
+                    put("content", userPrompt)
+                })
+            })
+        }
+
+        currentHandle = acquireModule<NetworkModule>(NetworkModule.MODULE_NAME)
+            .httpStreamRequest(
+                url = API_URL,
+                isPost = true,
+                param = requestBody,
+                headers = JSONObject().apply {
+                    put("Authorization", "Bearer $API_KEY")
+                    put("Content-Type", "application/json")
+                    put("Accept", "text/event-stream")
+                },
+                timeout = 60
+            ) { event, data, response ->
+                handleSSEEvent(event, data, response)
+            }
+    }
+
+    /**
+     * 处理 SSE 流式事件
+     */
+    private fun handleSSEEvent(
+        event: String,
+        data: String,
+        response: NetworkResponse?
+    ) {
+        when (event) {
+            "data" -> {
+                chunkCount++
+                if (response != null) {
+                    statusText = "已连接 (HTTP ${response.statusCode})，接收中..."
+                }
+
+                // SSE 返回格式：每行 "data: {json}" 或 "data: [DONE]"
+                // NetworkModule 可能一次回调包含多行 SSE 数据
+                val lines = data.split("\n")
+                for (line in lines) {
+                    val trimmed = line.trim()
+                    // 处理标准 SSE 格式 "data: ..."
+                    val jsonStr = when {
+                        trimmed.startsWith("data: ") -> trimmed.removePrefix("data: ").trim()
+                        trimmed.startsWith("{") -> trimmed  // 直接是 JSON
+                        else -> continue
+                    }
+
+                    if (jsonStr == "[DONE]") {
+                        // 流结束标记
+                        continue
+                    }
+
+                    try {
+                        val json = JSONObject(jsonStr)
+                        val choices = json.optJSONArray("choices")
+                        if (choices != null && choices.length() > 0) {
+                            val delta = choices.optJSONObject(0)?.optJSONObject("delta")
+                            val content = delta?.optString("content", "") ?: ""
+                            if (content.isNotEmpty()) {
+                                displayText += content
+                            }
+                        }
+                    } catch (_: Exception) {
+                        // 解析失败的行跳过（可能是不完整的 JSON 片段）
+                    }
+                }
+            }
+            "complete" -> {
+                statusText = "回复完成，共收到 $chunkCount 块数据"
+                isStreaming = false
+                currentHandle = null
+            }
+            "error" -> {
+                statusText = "错误: $data"
+                isStreaming = false
+                currentHandle = null
+            }
+        }
+    }
+
+    /**
+     * 停止流式请求
+     */
+    private fun stopStream() {
+        currentHandle?.close()
+        currentHandle = null
+        statusText = "已停止，共收到 $chunkCount 块数据"
+        isStreaming = false
+    }
+
+    /**
+     * 清空所有内容
+     */
+    private fun clearAll() {
+        displayText = ""
+        chunkCount = 0
+        statusText = "就绪"
+    }
+}

--- a/docs/API/modules/network.md
+++ b/docs/API/modules/network.md
@@ -95,6 +95,34 @@ HTTP请求模块
 | timeout <Badge text="非必需" type="warn"/>         | 请求超时时间, 单位为秒  | Int                               |
 | responseCallback <Badge text="必需" type="warn"/> | 请求回调闭包  | [NMDataResponse](#nmdataresponse) |
 
+## httpStreamRequest方法
+
+发送 SSE（Server-Sent Events）流式 HTTP 请求。适用于大模型流式输出、实时数据推送等场景。
+
+服务端通过 SSE 协议持续推送数据，客户端通过事件回调逐步接收，无需等待完整响应。
+
+<br/>
+
+**参数**
+
+| 参数  | 描述     | 类型                                              |
+|:----|:-------|:------------------------------------------------|
+| url <Badge text="必需" type="warn"/> | 请求url  | String                                          |
+| isPost <Badge text="必需" type="warn"/> | 是否为POST请求  | Boolean                                         |
+| param <Badge text="非必需" type="warn"/> | 请求参数（GET 时拼接到 URL，POST 时作为 body）  | JSONObject                                      |
+| headers <Badge text="非必需" type="warn"/> | 请求头参数  | JSONObject                                      |
+| cookie <Badge text="非必需" type="warn"/> | 请求cookie  | String                                          |
+| timeout <Badge text="非必需" type="warn"/> | 请求超时时间, 单位为秒，默认30  | Int                                             |
+| eventCallback <Badge text="必需" type="warn"/> | 流式事件回调  | [NMStreamEventCallback](#nmstreameventcallback) |
+
+**返回值**
+
+| 类型                                          | 描述                     |
+|:--------------------------------------------|:-----------------------|
+| [StreamRequestHandle](#streamrequesthandle) | 流式请求句柄，用于主动关闭连接 |
+
+---
+
 ## 类型说明
 ### NMAllResponse
 ```kotlin
@@ -119,6 +147,25 @@ NMDataResponse = (data: ByteArray, success: Boolean, errorMsg: String, response:
 | success | 请求是否成功 | Boolean                             |
 | errorMsg | 错误信息   | String                              |
 | response | 响应包信息  | [NetworkResponse](#networkresponse) |
+
+### NMStreamEventCallback
+```kotlin
+NMStreamEventCallback = (event: String, data: String, response: NetworkResponse?) -> Unit
+```
+
+| 参数  | 描述     | 类型                                  |
+|:----|:-------|:------------------------------------|
+| event | 事件类型，取值见下表 | String                              |
+| data | 事件数据 | String                              |
+| response | 网络响应信息（headers、statusCode），**仅在首次 `data` 事件回调中有值**，后续为 null | [NetworkResponse](#networkresponse)? |
+
+**event 事件类型**
+
+| 事件值 | 描述 |
+|:------|:-----|
+| `data` | 收到服务端推送的数据块。`data` 字段包含本次推送的文本内容。首次回调时 `response` 包含 HTTP 响应头和状态码 |
+| `complete` | 流式传输正常结束。`data` 为空字符串 |
+| `error` | 请求发生错误。`data` 包含错误信息描述 |
 
 ### NetworkResponse
 


### PR DESCRIPTION
## Summary
- Resubmit HTTP/SSE streaming support for `NetworkModule` (`httpStreamRequest` / `StreamRequestHandle`), covering core + Android/iOS/OHOS render implementations, API docs, and a demo page.
- This continues closed PR #1195. The original fork was deleted and the previous head was force-pushed empty; the implementation was recovered from historical commit `2885ec2` and reapplied onto current `main`.

## Test plan
- [ ] Android: start/stop an SSE stream via `SSETypewriterDemoPage`, confirm `data`/`complete`/`error` events and `StreamRequestHandle.close()`
- [ ] iOS: same flow; confirm session/task cleanup on close and page destroy
- [ ] OHOS: same flow; confirm non-2xx responses surface as error and clean up
- [ ] Confirm existing `httpRequest` / binary request paths are unchanged


Made with [Cursor](https://cursor.com)