### PR TITLE
fix(compose): realign lazy content after Android background expansion

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.tencent.kuikly.compose.foundation.gestures.Orientation
+import com.tencent.kuikly.compose.scroller.AndroidBackgroundAlignmentState
 import com.tencent.kuikly.compose.ui.node.StickyHeaderCacheManager
 import com.tencent.kuikly.compose.ui.unit.IntOffset
 import com.tencent.kuikly.core.layout.Frame
@@ -155,6 +156,8 @@ class KuiklyScrollInfo {
      * size is already exact via [ScrollState.maxValue] + viewport.
      */
     var skipExpandStartSize: Boolean = false
+
+    internal val androidBackgroundAlignmentState = AndroidBackgroundAlignmentState()
 
     /**
      * Sticky Header Position Cache Manager

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/AndroidBackgroundAlignmentExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/AndroidBackgroundAlignmentExtensions.kt
@@ -1,0 +1,89 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.compose.scroller
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import com.tencent.kuikly.compose.foundation.drawer.DrawerInternalPagerState
+import com.tencent.kuikly.compose.foundation.gestures.ScrollableState
+import com.tencent.kuikly.compose.foundation.pager.PagerState
+import com.tencent.kuikly.lifecycle.DefaultLifecycleObserver
+import com.tencent.kuikly.lifecycle.LifecycleOwner
+import com.tencent.kuikly.lifecycle.compose.LocalLifecycleOwner
+
+internal class AndroidBackgroundAlignmentState {
+    private var isPageVisible = true
+    private var needsOffsetRealignment = false
+
+    fun deferIfPageInvisible(): Boolean {
+        if (isPageVisible) {
+            return false
+        }
+        needsOffsetRealignment = true
+        return true
+    }
+
+    fun onPageInvisible() {
+        isPageVisible = false
+    }
+
+    fun consumeRealignmentOnPageVisible(): Boolean {
+        isPageVisible = true
+        if (!needsOffsetRealignment) {
+            return false
+        }
+        needsOffsetRealignment = false
+        return true
+    }
+}
+
+private fun ScrollableState.isPagerState(): Boolean {
+    return this is PagerState || this is DrawerInternalPagerState
+}
+
+internal fun ScrollableState.shouldDeferAndroidOffsetAlignment(): Boolean {
+    val scrollInfo = kuiklyInfo
+    return scrollInfo.pageData?.isAndroid == true &&
+        !isPagerState() &&
+        scrollInfo.androidBackgroundAlignmentState.deferIfPageInvisible()
+}
+
+@Composable
+internal fun ScrollableState.AndroidBackgroundAlignmentEffect() {
+    if (kuiklyInfo.pageData?.isAndroid != true || isPagerState()) {
+        return
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, this) {
+        val observer = object : DefaultLifecycleObserver {
+            override fun onPause(owner: LifecycleOwner) {
+                kuiklyInfo.androidBackgroundAlignmentState.onPageInvisible()
+            }
+
+            override fun onResume(owner: LifecycleOwner) {
+                if (kuiklyInfo.androidBackgroundAlignmentState.consumeRealignmentOnPageVisible()) {
+                    kuiklyInfo.updateContentSizeToRender()
+                    tryExpandStartSizeNoScroll(forceExpand = true)
+                }
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+}

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ScrollableStateExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ScrollableStateExtensions.kt
@@ -168,6 +168,11 @@ internal fun ScrollableState.shouldRejectNativeScrollOffset(newOffset: Int): Boo
 internal fun ScrollableState.applyScrollViewOffsetDelta(delta: Int) {
     if (kuiklyInfo.scrollView == null || delta == 0) return
 
+    if (shouldDeferAndroidOffsetAlignment()) {
+        kuiklyInfo.offsetDirty = true
+        return
+    }
+
     val newOffset = kuiklyInfo.scrollView!!.applyOffsetDelta(delta, kuiklyInfo)
     kuiklyInfo.composeOffset = if (kuiklyInfo.orientation == Orientation.Vertical) {
         newOffset.y.toFloat()

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/ui/layout/SubcomposeLayout.kt
@@ -78,6 +78,7 @@ import com.tencent.kuikly.compose.layout.checkOffScreenNode
 import com.tencent.kuikly.compose.layout.hideOffsetScreenView
 import com.tencent.kuikly.compose.layout.restoreScrollerViewOnReuse
 import com.tencent.kuikly.compose.layout.transferScrollToTopCallback
+import com.tencent.kuikly.compose.scroller.AndroidBackgroundAlignmentEffect
 import com.tencent.kuikly.compose.scroller.handleScrollToTopCallback
 import com.tencent.kuikly.compose.scroller.isAtTop
 import com.tencent.kuikly.compose.scroller.lastItemVisible
@@ -239,6 +240,8 @@ fun SubcomposeLayout(
     val isPagerView = scrollableState is PagerState || scrollableState is DrawerInternalPagerState
     val isDrawerPager = scrollableState is DrawerInternalPagerState
     val coroutineScope = rememberCoroutineScope()
+
+    scrollableState.AndroidBackgroundAlignmentEffect()
 
     LaunchedEffect(scrollViewSize) {
         scrollableState.calculateAndUpdateContentSize()


### PR DESCRIPTION
## Summary
- defer native offset alignment for Android non-Pager scroll containers while the page is backgrounded
- realign content once on resume only when a background offset update was deferred
- keep Pager and Drawer Pager behavior unchanged

## Test plan
- [x] `./gradlew :compose:compileDebugKotlinAndroid --stacktrace`
- [x] `./gradlew :compose:compileKotlinIosArm64 --stacktrace`
- [x] Verify Android background media switching no longer leaves lazy content blank after resume


Made with [Cursor](https://cursor.com)