### PR TITLE
feat(demo): retDouble/retInt 走原子通路并兼容三端 Number 类型

### DIFF
--- a/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/MyModuleDemoPage.kt
+++ b/demo/src/commonMain/kotlin/com/tencent/kuikly/demo/pages/demo/MyModuleDemoPage.kt
@@ -84,20 +84,22 @@ internal class MyModule : Module() {
 
     /**
      * retDouble: 无参数，同步返回 Native 侧的 Double 值（3.14）。
-     * 注意：同步 JSON 通路(syncToNativeMethod JSONObject 版本)的回传值恒为 String，
-     * 因此此处返回 String("3.14")，由 Demo 页直接展示。
+     * 走 syncToNativeMethod 的 Any? 版本（原子通路）。三端 Native 回传数字的具体类型不一致
+     * （鸿蒙 ArkTS 的 number 恒等于 Double；Android 传 Int；iOS 传 NSNumber(double)），
+     * 因此先 cast 为 Number 再 toDouble() 兼容三端。
      */
-    fun retDouble(): String {
-        return syncToNativeMethod("retDouble", null, null)
+    fun retDouble(): Double {
+        return (syncToNativeMethod("retDouble", arrayOf<Any>(), null) as Number).toDouble()
     }
 
     /**
      * retInt: 无参数，同步返回 Native 侧的 Int 值（314）。
-     * 注意：同步 JSON 通路(syncToNativeMethod JSONObject 版本)的回传值恒为 String，
-     * 因此此处返回 String("314")，由 Demo 页直接展示。
+     * 走 syncToNativeMethod 的 Any? 版本（原子通路）。三端 Native 回传的整数类型不一致
+     * （鸿蒙 ArkTS 的 number 恒等于 Double，即使写 314 到 Kotlin 侧也是 Double；Android 传 Int；
+     * iOS 传 NSNumber(int)），因此先 cast 为 Number 再 toInt() 强转为整数类型。
      */
-    fun retInt(): String {
-        return syncToNativeMethod("retInt", null, null)
+    fun retInt(): Int {
+        return (syncToNativeMethod("retInt", arrayOf<Any>(), null) as Number).toInt()
     }
 
     companion object {
@@ -477,7 +479,8 @@ fontWeightBold()
                     event {
                         click {
                             val module = ctx.acquireModule<MyModule>(MyModule.MODULE_NAME)
-                            ctx.retDoubleResult = module.retDouble().toString()
+                            val d: Double = module.retDouble()
+                            ctx.retDoubleResult = "Double=$d"
                         }
                     }
                 }
@@ -532,7 +535,8 @@ fontWeightBold()
                     event {
                         click {
                             val module = ctx.acquireModule<MyModule>(MyModule.MODULE_NAME)
-                            ctx.retIntResult = module.retInt().toString()
+                            val i: Int = module.retInt()
+                            ctx.retIntResult = "Int=$i"
                         }
                     }
                 }

--- a/docs/DevGuide/expand-native-api.md
+++ b/docs/DevGuide/expand-native-api.md
@@ -66,13 +66,23 @@ Module 返回值和 callback 参数支持的类型：
 
 | 类目         |   序列化方式   | 涉及类型                                                 |
 |:-----------|:---------:|:-----------------------------------------------------|
-| **基础类型**   |   直接透传    | `String` `Int` `Float` `Double` `Boolean` `NSNumber` |
+| **基础类型**   |   直接透传    | `String` `Int` `Float` `Double` `Boolean` `NSNumber`（见下方鸿蒙特殊说明） |
 | **二进制数据**  |   直接透传    | `ByteArray` `NSData` `ArrayBuffer`                   |
 | **JSON数据** |  JSON字符串  | `JSONObject` `JSONArray`                             |
 | **集合类型**   |  JSON字符串  | `Map/Record` `List` `NSDictionary` `NSArray` `Array` |
 | **特殊规则**   |    直接透传   | Array 中包含`ByteArray`/`NSData`时                       |
 
 :::tip 注意
+- **鸿蒙数值类型的特殊情况**：ArkTS 语言层面只有一个 `number` 类型（底层为 IEEE 754 double），没有独立的 `int` 原始类型。因此 Native 侧无论是写 `return 314` 还是 `return 3.14`，经 napi 桥接透传到 Kotlin 侧时，**运行时类型统一为 `kotlin.Double`**。这意味着如果直接把返回值强转成 `Int`（例如 `syncToNativeMethod(...) as Int`），在鸿蒙上会抛出 `ClassCastException`。对比其他平台：Android 侧 Java 的 `int` 会到达 Kotlin 侧的 `kotlin.Int`；iOS 侧 `NSNumber` 会根据实际内部类型桥接为 `kotlin.Int`/`kotlin.Double`。为了写出跨三端都能正确工作的业务代码，**推荐先 cast 为 `kotlin.Number` 父接口，再调用 `.toInt()` / `.toDouble()` 进行显式收窄**：
+
+```kotlin
+// ✅ 推荐（三端兼容）
+val intValue = (syncToNativeMethod("retInt", arrayOf<Any>(), null) as Number).toInt()
+val doubleValue = (syncToNativeMethod("retDouble", arrayOf<Any>(), null) as Number).toDouble()
+
+// ❌ 不推荐（在鸿蒙上会因 ArkTS number 均为 Double 而抛 ClassCastException）
+val intValue = syncToNativeMethod("retInt", arrayOf<Any>(), null) as Int
+```
 - syncToNativeMethod和asyncToNativeMethod，传入参数params是JSONObject且序列化为jSON字符串传至Native侧，
 序列化过程不支持对ByteArray二进制数据进行处理。因此请选择params为Any的syncToNativeMethod/asyncToNativeMethod方法传输二进制参数
 - callback中解析回传至Koltin侧二进制数据，可参考示例：


### PR DESCRIPTION
MyModuleDemoPage 的 retDouble/retInt 从原先的 JSON 通路(syncToNativeMethod 返回 String)切换到原子通路(syncToNativeMethod 返回 Any?)，返回类型改为原生的 Double / Int。

三端 Native 侧同步返回数字时的具体类型不一致：Android 为 Int，iOS 为 NSNumber(double/int)，鸿蒙 ArkTS 的 number 统一映射为 Kotlin.Double。因此 Kotlin 侧统一 (Any? as Number).toDouble() / .toInt()，避免鸿蒙侧直接 as Int 触发 ClassCastException。

已在 Android / iOS / 鸿蒙 三端真机 + 模拟器点击验证，retDouble 输出 3.14，retInt 输出 314，App 均无崩溃。