### PR TITLE
fix(core): accept Boolean/string RenderView.callMethod callback payloads

### DIFF
--- a/core/build.2.1.21.gradle.kts
+++ b/core/build.2.1.21.gradle.kts
@@ -47,6 +47,9 @@ kotlin {
         publishLibraryVariants("release")
     }
 
+    // Host unit tests (no device). jvmMain already has the expect/actuals.
+    jvm()
+
     iosSimulatorArm64()
     iosX64()
     iosArm64()
@@ -70,6 +73,11 @@ kotlin {
 
     sourceSets {
         val commonMain by getting
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
         val appleMain by sourceSets.creating {
             dependsOn(commonMain)
         }

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/base/RenderView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/base/RenderView.kt
@@ -19,9 +19,11 @@ import com.tencent.kuikly.core.global.GlobalFunctions
 import com.tencent.kuikly.core.layout.Frame
 import com.tencent.kuikly.core.manager.BridgeManager
 import com.tencent.kuikly.core.manager.PagerManager
+import com.tencent.kuikly.core.module.AnyCallbackFn
 import com.tencent.kuikly.core.module.CallbackFn
 import com.tencent.kuikly.core.module.CallbackRef
-import com.tencent.kuikly.core.nvi.serialization.json.JSONObject
+import com.tencent.kuikly.core.nvi.serialization.json.JSONEngine
+import com.tencent.kuikly.core.nvi.serialization.json.JSONException
 
 class RenderView(private val pagerId: String, private val viewRef: Int, private val viewName: String) {
 
@@ -58,11 +60,12 @@ class RenderView(private val pagerId: String, private val viewRef: Int, private 
             callbackRef = GlobalFunctions.createFunction(pagerId) { data ->
                 val trace = PagerManager.getPagerEventTrace(pagerId)
                 trace?.onViewCallbackStart(viewName, viewRef, methodName, peekedCallbackRef)
-                var res : JSONObject? = null
-                if (data != null && data is String) {
-                    res = JSONObject(data)
-                }
-                cb(res)
+                val res = decodeViewCallbackPayload(data)
+                // Native/WebView methods such as canGoBack return Boolean or String
+                // tokens, not JSON objects. CallbackFn stays JSONObject? for
+                // source compatibility; invoke through Any so primitives pass.
+                @Suppress("UNCHECKED_CAST")
+                (cb as AnyCallbackFn)(res)
                 trace?.onViewCallbackEnd(viewName, viewRef, methodName, peekedCallbackRef)
                 false
             }
@@ -87,5 +90,32 @@ class RenderView(private val pagerId: String, private val viewRef: Int, private 
 
     companion object {
         const val ROOT_VIEW_TAG = -1
+    }
+}
+
+/**
+ * Decode a native/WebView callMethod callback payload.
+ *
+ * Native sides may pass an already-typed value (Boolean, String, Number,
+ * JSONObject) or a JSON text token such as `true`, `false`, `"ok"`, or
+ * `{...}`. Forcing [JSONObject] throws
+ * `Value false of type Boolean cannot be converted to JSONObject`.
+ */
+internal fun decodeViewCallbackPayload(data: Any?): Any? {
+    return when (data) {
+        null -> null
+        is String -> decodeViewCallbackJsonString(data)
+        else -> data
+    }
+}
+
+internal fun decodeViewCallbackJsonString(json: String): Any? {
+    if (json.isEmpty()) {
+        return json
+    }
+    return try {
+        JSONEngine.parse(json)
+    } catch (_: JSONException) {
+        json
     }
 }

--- a/core/src/commonTest/kotlin/com/tencent/kuikly/core/base/RenderViewCallMethodCallbackTest.kt
+++ b/core/src/commonTest/kotlin/com/tencent/kuikly/core/base/RenderViewCallMethodCallbackTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tencent.kuikly.core.base
+
+import com.tencent.kuikly.core.global.GlobalFunctions
+import com.tencent.kuikly.core.nvi.serialization.json.JSONObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Host unit tests for RenderView.callMethod callback decoding.
+ * Covers Boolean/string payloads used by WebView canGoBack / canGoForward.
+ */
+class RenderViewCallMethodCallbackTest {
+
+    @Test
+    fun decodeBooleanJsonTokens() {
+        assertEquals(false, decodeViewCallbackPayload("false"))
+        assertEquals(true, decodeViewCallbackPayload("true"))
+        assertEquals(false, decodeViewCallbackPayload(false))
+        assertEquals(true, decodeViewCallbackPayload(true))
+    }
+
+    @Test
+    fun decodeStringJsonTokens() {
+        assertEquals("ok", decodeViewCallbackPayload("\"ok\""))
+        assertEquals("canGoBack", decodeViewCallbackPayload("canGoBack"))
+        assertEquals("", decodeViewCallbackPayload(""))
+    }
+
+    @Test
+    fun decodeJsonObjectStillWorks() {
+        val parsed = decodeViewCallbackPayload("""{"cursorIndex":3}""")
+        val obj = assertIs<JSONObject>(parsed)
+        assertEquals(3, obj.optInt("cursorIndex"))
+    }
+
+    @Test
+    fun decodeNullAndNumberTokens() {
+        assertNull(decodeViewCallbackPayload(null))
+        assertNull(decodeViewCallbackPayload("null"))
+        assertEquals(42, decodeViewCallbackPayload("42"))
+        assertEquals(42, decodeViewCallbackPayload(42))
+    }
+
+    @Test
+    fun canGoBackBooleanPayloadDoesNotThrow() {
+        val received = invokeCallMethodCallback("false")
+        assertEquals(false, received)
+        assertEquals(false, received?.toString() == "true")
+    }
+
+    @Test
+    fun canGoForwardTrueTokenMatchesWebViewContract() {
+        val received = invokeCallMethodCallback("true")
+        assertEquals(true, received)
+        assertTrue(received?.toString() == "true")
+    }
+
+    @Test
+    fun rawBooleanCallbackPayload() {
+        val received = invokeCallMethodCallback(false)
+        assertFalse(received as Boolean)
+        assertEquals(true, invokeCallMethodCallback(true))
+    }
+
+    @Test
+    fun stringCallbackPayload() {
+        assertEquals("ready", invokeCallMethodCallback("\"ready\""))
+        assertEquals("plain", invokeCallMethodCallback("plain"))
+    }
+
+    @Test
+    fun jsonObjectCallbackPayload() {
+        val received = invokeCallMethodCallback("""{"cursorIndex":7}""")
+        val obj = assertIs<JSONObject>(received)
+        assertEquals(7, obj.optInt("cursorIndex"))
+    }
+
+    private fun invokeCallMethodCallback(nativePayload: Any?): Any? {
+        val pagerId = "callback-test-${GlobalFunctions.peekNextRef()}"
+        val view = RenderView(pagerId, viewRef = 1, viewName = "KRWebView")
+        val callbackRef = GlobalFunctions.peekNextRef().toString()
+        var received: Any? = UNSET
+        try {
+            view.callMethod("canGoBack", null) { result: Any? ->
+                received = result
+            }
+            GlobalFunctions.invokeFunction(pagerId, callbackRef, nativePayload)
+            check(received !== UNSET) { "callback was not invoked" }
+            return received
+        } finally {
+            GlobalFunctions.destroyGlobalFunction(pagerId)
+        }
+    }
+
+    private companion object {
+        val UNSET = Any()
+    }
+}


### PR DESCRIPTION
Fixes #1241.

RenderView.callMethod forced callback JSON to JSONObject, so Boolean/string WebView callbacks (canGoBack / canGoForward) threw. Accept Boolean/string payloads too.

Host unit test: core/src/commonTest/kotlin/com/tencent/kuikly/core/base/RenderViewCallMethodCallbackTest.kt. No device.

Signed-off-by: Tony Coder <407243179@qq.com>