### PR TITLE
fix(ohos): cast KREncodeURLComponent bytes as unsigned

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/codec/KRCodec.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/codec/KRCodec.cpp
@@ -38,10 +38,12 @@ const char base64_chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 std::string KREncodeURLComponent(const std::string &in) {
     std::string out;
-    for (auto &b : in) {
+    // Iterate as unsigned: on OHOS aarch64/x86_64 char is signed, so UTF-8 high
+    // bytes become negative indexes into HEX_DIGITS_URI[16].
+    for (unsigned char b : in) {
         if (('A' <= b && b <= 'Z') || ('a' <= b && b <= 'z') || ('0' <= b && b <= '9') || b == '-' || b == '_' ||
             b == '.' || b == '!' || b == '~' || b == '*' || b == '\'' || b == '(' || b == ')') {
-            out.push_back(b);
+            out.push_back(static_cast<char>(b));
         } else {
             out.push_back('%');
             out.push_back(HEX_DIGITS_URI[b / 16]);

--- a/core-render-ohos/src/test/cpp/kr_encode_url_component_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_encode_url_component_test.cpp
@@ -1,0 +1,49 @@
+// Host unit test for KREncodeURLComponent.
+//
+// KRCodec.cpp has no OHOS APIs, so this can be built with host g++/clang++.
+// Covers signed-char OOB on UTF-8 high bytes (OHOS aarch64/x86_64 char is signed).
+//
+// Build + run (from this directory):
+//   ./run_kr_codec_test.sh
+//   ./run_kr_codec_test.sh asan
+
+#include "KRCodec.h"
+
+#include <cstdio>
+#include <string>
+
+using kuikly::KREncodeURLComponent;
+
+static int g_failed = 0;
+
+static void expect_eq(const char *name, const std::string &got, const std::string &want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got \"%s\" want \"%s\"\n", name, got.c_str(), want.c_str());
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+int main() {
+    // ASCII unreserved characters stay unescaped.
+    expect_eq("hello", KREncodeURLComponent("hello"), "hello");
+    expect_eq("unreserved", KREncodeURLComponent("AZaz09-_.!~*'()"), "AZaz09-_.!~*'()");
+
+    // Reserved / non-unreserved ASCII is percent-encoded (uppercase hex).
+    expect_eq("space", KREncodeURLComponent(" "), "%20");
+    expect_eq("slash", KREncodeURLComponent("a/b"), "a%2Fb");
+
+    // UTF-8 Chinese: bytes E4 BD A0 E5 A5 BD must not OOB on signed char.
+    expect_eq("nihao", KREncodeURLComponent("你好"), "%E4%BD%A0%E5%A5%BD");
+
+    // Empty input is a no-op.
+    expect_eq("empty", KREncodeURLComponent(""), "");
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_codec_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_codec_test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Compile + run KREncodeURLComponent host unit tests (no Harmony device).
+#
+# Usage:
+#   ./run_kr_codec_test.sh          # g++ default
+#   ./run_kr_codec_test.sh asan     # Address+UB sanitizers
+#
+# KRCodec.cpp has no OHOS APIs. Host g++/clang++ is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CODEC_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/modules/codec"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+# Host g++ does not pull <vector> transitively the way the OHOS SDK does.
+# Inject it only for this TU so the production codec stays drive-by-free.
+HOST_COMPAT="$OUT_DIR/host_compat.h"
+cat > "$HOST_COMPAT" <<'EOF'
+#include <vector>
+EOF
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -fsigned-char
+    -include "$HOST_COMPAT"
+    -I"$CODEC_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_encode_url_component_test.cpp"
+    "$CODEC_DIR/KRCodec.cpp"
+    "$CODEC_DIR/md5.c"
+    "$CODEC_DIR/sha256.c"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_encode_url_component_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_encode_url_component_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
On OpenHarmony aarch64/x86_64, `char` is signed. `KREncodeURLComponent` used those bytes as indexes into `HEX_DIGITS_URI[16]`, so UTF-8 high bytes (e.g. `你好`) went OOB.

Iterate as `unsigned char`, matching the Base64 path in the same file. Unreserved set is unchanged.

Host test (no device, `-fsigned-char`):

```
core-render-ohos/src/test/cpp/run_kr_codec_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>