### PR TITLE
fix(ohos): normalize leftover negative KRDate milliseconds

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRDate.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRDate.cpp
@@ -20,19 +20,38 @@
 namespace kuikly {
 namespace util {
 
+namespace {
+
+// C++ / and % are toward-zero. JS/Android Date keep millis in [0, 999], so a
+// leftover-negative remainder must borrow one second (floor-div).
+void SplitEpochMillis(std::int64_t timestamp, std::int64_t *seconds, int *millisOut) {
+    auto q = timestamp / 1000;
+    auto r = timestamp % 1000;
+    if (r < 0) {
+        q--;
+        r += 1000;
+    }
+    *seconds = q;
+    *millisOut = static_cast<int>(r);
+}
+
+}  // namespace
+
 Date::Date() {
     std::chrono::milliseconds msTime =
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
     std::int64_t timestamp = msTime.count();
-    time_t timeSec = static_cast<time_t>(timestamp / 1000);
+    std::int64_t seconds = 0;
+    SplitEpochMillis(timestamp, &seconds, &millis);
+    time_t timeSec = static_cast<time_t>(seconds);
     localtime_r(&timeSec, &time);
-    millis = static_cast<int>(timestamp % 1000);
 }
 
 Date::Date(std::int64_t timestamp) {
-    time_t timeSec = static_cast<time_t>(timestamp / 1000);
+    std::int64_t seconds = 0;
+    SplitEpochMillis(timestamp, &seconds, &millis);
+    time_t timeSec = static_cast<time_t>(seconds);
     localtime_r(&timeSec, &time);
-    millis = static_cast<int>(timestamp % 1000);
 }
 
 Date::Date(const Date &other) {
@@ -102,8 +121,13 @@ void Date::SetSeconds(int sec) {
     time.tm_sec = sec;
 }
 void Date::SetMilliseconds(int num) {
-    time.tm_sec += num / 1000;  // 溢出处理。如果设置的毫秒数超过1000，则要进位到秒
-    millis = num % 1000;
+    // 溢出处理。如果设置的毫秒数超过1000或为负，则按 floor-div 进位/借位到秒，
+    // 使 millis 始终落在 [0, 999]（对齐 JS/Android Date）。
+    std::int64_t q = 0;
+    int r = 0;
+    SplitEpochMillis(num, &q, &r);
+    time.tm_sec += static_cast<int>(q);
+    millis = r;
 }
 
 std::int64_t Date::GetTime() {

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRDate.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRDate.h
@@ -60,6 +60,8 @@ class Date {
 
  private:
     tm time;
+    // Always in [0, 999]. C++ / and % are toward-zero, so leftover-negative
+    // timestamps and SetMilliseconds values are normalized with floor-div.
     int millis;
 };
 

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRDate.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRDate.h
@@ -14,6 +14,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <ctime>
 #include <string>
 

--- a/core-render-ohos/src/test/cpp/krdate_millis_host_test.cpp
+++ b/core-render-ohos/src/test/cpp/krdate_millis_host_test.cpp
@@ -1,0 +1,75 @@
+// Host unit test for KRDate leftover-negative / leftover-positive milliseconds.
+//
+// KRDate.cpp has no OHOS APIs, so this can be built with host g++/clang++.
+// C++ / and % are toward-zero; JS/Android Date keep millis in [0, 999].
+//
+// Build + run (from this directory):
+//   ./run_krdate_millis_host_test.sh
+//   ./run_krdate_millis_host_test.sh asan
+
+#include "KRDate.h"
+
+#include <cstdio>
+
+using kuikly::util::Date;
+
+static int g_failed = 0;
+
+static void expect_eq(const char *name, int got, int want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got %d want %d\n", name, got, want);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+int main() {
+    // leftover-negative timestamp: Date(-1500) is 1.5s before epoch.
+    // Toward-zero leftover: millis = -500. Floor-div: -2s + 500ms.
+    expect_eq("Date(-1500).GetMilliseconds()", Date(-1500).GetMilliseconds(), 500);
+
+    // leftover-negative exact second boundary stays 0 (no leftover remainder).
+    expect_eq("Date(-1000).GetMilliseconds()", Date(-1000).GetMilliseconds(), 0);
+
+    // leftover-negative just past a second: toward-zero leftover millis = -1.
+    expect_eq("Date(-1001).GetMilliseconds()", Date(-1001).GetMilliseconds(), 999);
+
+    // leftover-positive path unchanged.
+    expect_eq("Date(1500).GetMilliseconds()", Date(1500).GetMilliseconds(), 500);
+    expect_eq("Date(0).GetMilliseconds()", Date(0).GetMilliseconds(), 0);
+    expect_eq("Date(999).GetMilliseconds()", Date(999).GetMilliseconds(), 999);
+    expect_eq("Date(1000).GetMilliseconds()", Date(1000).GetMilliseconds(), 0);
+
+    // SetMilliseconds leftover-negative: borrow one second, millis = 999.
+    {
+        Date d;
+        int secBefore = d.GetSeconds();
+        d.SetMilliseconds(-1);
+        expect_eq("SetMilliseconds(-1).GetMilliseconds()", d.GetMilliseconds(), 999);
+        expect_eq("SetMilliseconds(-1) seconds borrowed", d.GetSeconds(), secBefore - 1);
+    }
+
+    // SetMilliseconds leftover-positive carry and in-range value.
+    {
+        Date d;
+        int secBefore = d.GetSeconds();
+        d.SetMilliseconds(1500);
+        expect_eq("SetMilliseconds(1500).GetMilliseconds()", d.GetMilliseconds(), 500);
+        expect_eq("SetMilliseconds(1500) seconds carried", d.GetSeconds(), secBefore + 1);
+    }
+    {
+        Date d;
+        int secBefore = d.GetSeconds();
+        d.SetMilliseconds(500);
+        expect_eq("SetMilliseconds(500).GetMilliseconds()", d.GetMilliseconds(), 500);
+        expect_eq("SetMilliseconds(500) seconds unchanged", d.GetSeconds(), secBefore);
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_krdate_millis_host_test.sh
+++ b/core-render-ohos/src/test/cpp/run_krdate_millis_host_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Compile + run KRDate leftover-millisecond host unit tests (no Harmony device).
+#
+# Usage:
+#   ./run_krdate_millis_host_test.sh          # g++ default
+#   ./run_krdate_millis_host_test.sh asan     # Address+UB sanitizers
+#
+# KRDate.cpp has no OHOS APIs. Host g++/clang++ is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CALENDAR_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/modules/calendar"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -I"$CALENDAR_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/krdate_millis_host_test.cpp"
+    "$CALENDAR_DIR/KRDate.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/krdate_millis_host_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/krdate_millis_host_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
OHOS `KRDate` split epoch milliseconds with C++ `/` and `%`, which are toward-zero. Negative timestamps and `SetMilliseconds` values left `millis` negative (`Date(-1500)` → `-500`; `SetMilliseconds(-1)` → `-1` with no second borrow). JS/Android Date keep milliseconds in `[0, 999]`. `ZeroPadded(-1, 3)` then formatted `"0-1"`.

Floor-div the remainder so `millis` is always in `[0, 999]`:

```
auto q = num / 1000; auto r = num % 1000;
if (r < 0) { q--; r += 1000; }
```

Applied in `Date(int64_t)`, the now constructor, and `SetMilliseconds`. Host g++ test (no Harmony device):

- `Date(-1500).GetMilliseconds() == 500`
- `SetMilliseconds(-1)` → millis `999` and one second borrowed
- Positive path unchanged (`1500` → `500`)

Does not touch KREncodeURLComponent, KRThread, or other already-filed leftovers.

Signed-off-by: Tony Coder <407243179@qq.com>
