### PR TITLE
fix(ohos): implement leftover KRBase64Util::Decode instead of re-encoding

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRBase64Util.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRBase64Util.cpp
@@ -15,6 +15,8 @@
 
 #include "KRBase64Util.h"
 
+#include <vector>
+
 static const char HEX_DIGITS[] = "0123456789abcdef";
 // Maps integer in the range [0,16) to a hex digit.
 
@@ -50,19 +52,20 @@ std::string KRBase64Util::Encode(const std::string &data) {
 
 std::string KRBase64Util::Decode(std::string_view in) {
     std::string out;
-    int val = 0, valb = -6;
+    std::vector<int> T(256, -1);
+    for (int i = 0; i < 64; i++)
+        T[base64_chars[i]] = i;
+    int val = 0, valb = -8;
     for (unsigned char c : in) {
-        val = (val << 8) + c;
-        valb += 8;
-        while (valb >= 0) {
-            out.push_back(base64_chars[(val >> valb) & 0x3F]);
-            valb -= 6;
+        if (T[c] == -1)
+            break;
+        val = (val << 6) + T[c];
+        valb += 6;
+        if (valb >= 0) {
+            out.push_back(static_cast<char>((val >> valb) & 0xFF));
+            valb -= 8;
         }
     }
-    if (valb > -6)
-        out.push_back(base64_chars[((val << 8) >> (valb + 8)) & 0x3F]);
-    while (out.size() % 4)
-        out.push_back('=');
     return out;
 }
 

--- a/core-render-ohos/src/test/cpp/kr_base64_util_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_base64_util_test.cpp
@@ -1,0 +1,42 @@
+// Host unit test for KRBase64Util leftover Decode polarity.
+//
+// KRBase64Util.cpp has no OHOS APIs, so this can be built with host g++/clang++.
+// Decode was a leftover copy of Encode (re-encodes); it must invert Encode.
+//
+// Build + run (from this directory):
+//   ./run_kr_base64_util_test.sh
+//   ./run_kr_base64_util_test.sh asan
+
+#include "KRBase64Util.h"
+
+#include <cstdio>
+#include <string>
+
+static int g_failed = 0;
+
+static void expect_eq(const char *name, const std::string &got, const std::string &want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got \"%s\" want \"%s\"\n", name, got.c_str(), want.c_str());
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+int main() {
+    // Known vector: Encode("hi") is aGk= (must not change Encode).
+    expect_eq("Encode(hi)", KRBase64Util::Encode("hi"), "aGk=");
+
+    // Leftover Decode copied Encode and re-encoded aGk= to YUdrPQ==.
+    expect_eq("Decode(aGk=)", KRBase64Util::Decode("aGk="), "hi");
+
+    // Round-trip through the public string overloads.
+    expect_eq("Decode(Encode(hello))", KRBase64Util::Decode(KRBase64Util::Encode("hello")), "hello");
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/kr_base64_util_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_base64_util_test.cpp
@@ -25,13 +25,15 @@ static void expect_eq(const char *name, const std::string &got, const std::strin
 
 int main() {
     // Known vector: Encode("hi") is aGk= (must not change Encode).
-    expect_eq("Encode(hi)", KRBase64Util::Encode("hi"), "aGk=");
+    // std::string disambiguates the string_view / const string& overloads.
+    expect_eq("Encode(hi)", KRBase64Util::Encode(std::string("hi")), "aGk=");
 
     // Leftover Decode copied Encode and re-encoded aGk= to YUdrPQ==.
-    expect_eq("Decode(aGk=)", KRBase64Util::Decode("aGk="), "hi");
+    expect_eq("Decode(aGk=)", KRBase64Util::Decode(std::string("aGk=")), "hi");
 
     // Round-trip through the public string overloads.
-    expect_eq("Decode(Encode(hello))", KRBase64Util::Decode(KRBase64Util::Encode("hello")), "hello");
+    expect_eq("Decode(Encode(hello))",
+              KRBase64Util::Decode(KRBase64Util::Encode(std::string("hello"))), "hello");
 
     if (g_failed != 0) {
         std::fprintf(stderr, "%d test(s) failed\n", g_failed);

--- a/core-render-ohos/src/test/cpp/run_kr_base64_util_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_base64_util_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Compile + run KRBase64Util host unit tests (no Harmony device).
+#
+# Usage:
+#   ./run_kr_base64_util_test.sh          # g++ default
+#   ./run_kr_base64_util_test.sh asan     # Address+UB sanitizers
+#
+# KRBase64Util.cpp has no OHOS APIs. Host g++/clang++ is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UTIL_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/utils"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -I"$UTIL_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_base64_util_test.cpp"
+    "$UTIL_DIR/KRBase64Util.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_base64_util_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_base64_util_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
OHOS `KRBase64Util::Decode(std::string_view)` was a leftover byte-for-byte copy of `Encode`: same `valb = -6`, emit `base64_chars`, pad `=`. Public Decode therefore re-encoded. `Encode("hi")` is `aGk=`; leftover `Decode("aGk=")` produced `YUdrPQ==` instead of `hi`.

Replace the Decode body with the existing table decoder from `KRBase64Decode` (`T[256]`, `valb = -8`, emit bytes). Encode is unchanged.

Host g++ test (no Harmony device): `Encode("hi") == "aGk="`, `Decode("aGk=") == "hi"`, `Decode(Encode("hello")) == "hello"`.

Does not touch KREncodeURLComponent (#1648), KRDate (#1649), or KRThread (#1646).

Signed-off-by: Tony Coder <407243179@qq.com>
