### PR TITLE
fix(ohos): guard leftover cJSON GetString null adopt

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/file/KRFileModule.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/file/KRFileModule.cpp
@@ -73,6 +73,10 @@ std::string KRFileModule::GetProfilerDir() {
 // ---------------------------------------------------------------------------
 void KRFileModule::WriteFile(const KRAnyValue &params, const KRRenderCallback &callback) {
     auto jsonObj = util::JSONObject::Parse(params->toString());
+    if (!jsonObj) {
+        if (callback) callback(MakeResult("error", "invalid json"));
+        return;
+    }
     const std::string filename = jsonObj->GetString("filename");
     const std::string content  = jsonObj->GetString("content");
 
@@ -106,6 +110,10 @@ void KRFileModule::WriteFile(const KRAnyValue &params, const KRRenderCallback &c
 // ---------------------------------------------------------------------------
 void KRFileModule::AppendFile(const KRAnyValue &params, const KRRenderCallback &callback) {
     auto jsonObj = util::JSONObject::Parse(params->toString());
+    if (!jsonObj) {
+        if (callback) callback(MakeResult("error", "invalid json"));
+        return;
+    }
     const std::string filename = jsonObj->GetString("filename");
     const std::string content  = jsonObj->GetString("content");
 

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/preferences/KRSharedPreferencesModule.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/preferences/KRSharedPreferencesModule.cpp
@@ -61,6 +61,9 @@ std::string KRSharedPreferencesModule::SetItem(const KRAnyValue &params) {
     InitIfNeeded();
 
     auto jsonObj = util::JSONObject::Parse(params->toString());
+    if (!jsonObj) {
+        return "";
+    }
     std::string key = jsonObj->GetString("key");
     std::string value = jsonObj->GetString("value");
     // KLOG_INFO(TAG) << "==== set item key = " << key << " value = " << value;

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRJSONObject.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRJSONObject.cpp
@@ -41,11 +41,10 @@ std::string JSONObject::GetString(const std::string &key, const std::string &def
         return default_value;
     }
     cJSON *item = cJSON_GetObjectItem(reinterpret_cast<cJSON *>(cjson_), key.c_str());
-    if (item) {
-        std::string str = cJSON_GetStringValue(item);
-        return str;
+    if (item == nullptr || !cJSON_IsString(item)) {
+        return default_value;
     }
-    return default_value;
+    return AdoptCJsonStringValue(cJSON_GetStringValue(item), default_value);
 }
 
 std::vector<std::string> JSONObject::GetStringArray(const std::string &key) {
@@ -53,15 +52,22 @@ std::vector<std::string> JSONObject::GetStringArray(const std::string &key) {
         return std::vector<std::string>();
     }
     cJSON *item = cJSON_GetObjectItem(reinterpret_cast<cJSON *>(cjson_), key.c_str());
-    if (item) {
-        std::vector<std::string> result;
-        for (int i = 0; i < cJSON_GetArraySize(item); ++i) {
-            std::string str = cJSON_GetStringValue(cJSON_GetArrayItem(item, i));
-            result.emplace_back(str);
-        }
-        return result;
+    if (item == nullptr) {
+        return std::vector<std::string>();
     }
-    return std::vector<std::string>();
+    std::vector<std::string> result;
+    const int size = cJSON_GetArraySize(item);
+    for (int i = 0; i < size; ++i) {
+        cJSON *elem = cJSON_GetArrayItem(item, i);
+        if (!cJSON_IsString(elem)) {
+            continue;
+        }
+        std::string adopted;
+        if (TryAdoptCJsonStringValue(cJSON_GetStringValue(elem), &adopted)) {
+            result.emplace_back(std::move(adopted));
+        }
+    }
+    return result;
 }
 
 double JSONObject::GetNumber(const std::string &key, const double default_value) {

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRJSONObject.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRJSONObject.h
@@ -15,12 +15,45 @@
 
 #ifndef CORE_RENDER_OHOS_KRJSONOBJECT_H
 #define CORE_RENDER_OHOS_KRJSONOBJECT_H
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace kuikly {
 namespace util {
+
+// Leftover adopt/get-string helper. cJSON_GetStringValue (or a stub with the
+// same contract) returns nullptr for non-string items. Constructing
+// std::string from that NULL is UB — always adopt through this helper.
+inline std::string AdoptCJsonStringValue(const char *value, const std::string &default_value = "") {
+    if (value == nullptr) {
+        return default_value;
+    }
+    return std::string(value);
+}
+
+// Wrap cJSON_GetStringValue or a tiny host stub that returns nullptr for
+// non-strings. item may be a real cJSON* or a stub handle.
+inline std::string AdoptCJsonGetString(const char *(*get_string_value)(const void *item), const void *item,
+                                       const std::string &default_value = "") {
+    if (get_string_value == nullptr) {
+        return default_value;
+    }
+    return AdoptCJsonStringValue(get_string_value(item), default_value);
+}
+
+// Array path: skip the element instead of substituting a default.
+inline bool TryAdoptCJsonStringValue(const char *value, std::string *out) {
+    if (value == nullptr || out == nullptr) {
+        return false;
+    }
+    out->assign(value);
+    return true;
+}
+
 class JSONObject : public std::enable_shared_from_this<JSONObject> {
  public:
+    // Returns nullptr on bad JSON. Callers must check before dereference.
     static std::shared_ptr<JSONObject> Parse(const std::string &str);
 
     explicit JSONObject(void *cjson, std::shared_ptr<JSONObject> owner = nullptr);

--- a/core-render-ohos/src/test/cpp/kr_json_object_getstring_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_json_object_getstring_test.cpp
@@ -1,0 +1,132 @@
+// Host unit test for leftover KRJSONObject GetString / GetStringArray UB.
+//
+// cJSON_GetStringValue returns NULL for non-string items. Leftover
+// GetString/GetStringArray constructed std::string from that NULL (UB/crash).
+// The adopt/get-string helper is host-testable without Harmony (wraps cJSON
+// or a stub that returns nullptr for non-strings).
+//
+// Build + run (from this directory):
+//   ./run_kr_json_object_getstring_test.sh
+//   ./run_kr_json_object_getstring_test.sh asan
+
+#include "KRJSONObject.h"
+#include "thirdparty/cJSON/cJSON.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using kuikly::util::AdoptCJsonGetString;
+using kuikly::util::AdoptCJsonStringValue;
+using kuikly::util::JSONObject;
+using kuikly::util::TryAdoptCJsonStringValue;
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_eq(const char *name, const std::string &got, const std::string &want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got \"%s\" want \"%s\"\n", name, got.c_str(), want.c_str());
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_eq_size(const char *name, std::size_t got, std::size_t want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got %zu want %zu\n", name, got, want);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+// Tiny stub matching cJSON_GetStringValue: nullptr for non-string items.
+static const char *stub_get_string_value_on_number(const void *item) {
+    (void)item;
+    return nullptr;
+}
+
+static const char *stub_get_string_value_on_string(const void *item) {
+    return static_cast<const char *>(item);
+}
+
+int main() {
+    // 1) leftover: cJSON_GetStringValue on a number item is null → helper
+    //    returns default, does not crash (also via a tiny stub).
+    {
+        cJSON *num = cJSON_CreateNumber(1);
+        const char *raw = cJSON_GetStringValue(num);
+        expect_true("cJSON_GetStringValue(number) is null", raw == nullptr);
+        expect_eq("AdoptCJsonStringValue(null from number)", AdoptCJsonStringValue(raw, "DEF"), "DEF");
+        expect_eq("AdoptCJsonStringValue(null default empty)", AdoptCJsonStringValue(raw), "");
+        cJSON_Delete(num);
+
+        int stub_item = 1;
+        expect_eq("AdoptCJsonGetString(number stub)",
+                  AdoptCJsonGetString(stub_get_string_value_on_number, &stub_item, "DEF"), "DEF");
+        expect_eq("AdoptCJsonGetString(string stub)",
+                  AdoptCJsonGetString(stub_get_string_value_on_string, "hello", "DEF"), "hello");
+        expect_true("TryAdoptCJsonStringValue(null) skips", !TryAdoptCJsonStringValue(nullptr, nullptr));
+        std::string adopted;
+        expect_true("TryAdoptCJsonStringValue(null) skip-element",
+                    !TryAdoptCJsonStringValue(nullptr, &adopted));
+    }
+
+    // 2) leftover: GetString on {"key":1} returns default "".
+    {
+        auto obj = JSONObject::Parse(R"({"key":1})");
+        expect_true("Parse({\"key\":1}) non-null", obj != nullptr);
+        expect_eq("GetString({\"key\":1})", obj->GetString("key"), "");
+        expect_eq("GetString({\"key\":1}, custom default)", obj->GetString("key", "DEF"), "DEF");
+        expect_eq("GetString missing key", obj->GetString("missing", "MISS"), "MISS");
+    }
+
+    // String item still works (IsString + adopt).
+    {
+        auto obj = JSONObject::Parse(R"({"key":"hello"})");
+        expect_eq("GetString({\"key\":\"hello\"})", obj->GetString("key"), "hello");
+    }
+
+    // 3) leftover: GetStringArray skips / does not crash on mixed/non-string.
+    {
+        auto obj = JSONObject::Parse(R"({"arr":["ok",1,null,true,{"x":1},"two",""]})");
+        expect_true("Parse mixed array non-null", obj != nullptr);
+        const std::vector<std::string> arr = obj->GetStringArray("arr");
+        expect_eq_size("GetStringArray mixed size", arr.size(), 3);
+        expect_eq("GetStringArray[0]", arr.size() > 0 ? arr[0] : "", "ok");
+        expect_eq("GetStringArray[1]", arr.size() > 1 ? arr[1] : "", "two");
+        expect_eq("GetStringArray[2] empty string kept", arr.size() > 2 ? arr[2] : "MISSING", "");
+        const std::vector<std::string> missing = obj->GetStringArray("nope");
+        expect_eq_size("GetStringArray missing key", missing.size(), 0);
+    }
+
+    // 4) Parse("{") is nullptr; callers must not deref.
+    {
+        auto bad = JSONObject::Parse("{");
+        expect_true("Parse(\"{\") is nullptr", bad == nullptr);
+        // Call-site contract: only use GetString after a non-null Parse.
+        if (bad) {
+            std::fprintf(stderr, "FAIL callers must not deref Parse nullptr\n");
+            ++g_failed;
+        } else {
+            std::printf("PASS callers must not deref Parse nullptr\n");
+        }
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_json_object_getstring_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_json_object_getstring_test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Compile + run leftover KRJSONObject GetString host unit tests (no Harmony device).
+#
+# Usage:
+#   ./run_kr_json_object_getstring_test.sh          # g++ default
+#   ./run_kr_json_object_getstring_test.sh asan     # Address+UB sanitizers
+#
+# KRJSONObject.cpp has no OHOS APIs. Host g++/clang++ + bundled cJSON is enough.
+# The adopt/get-string helper can also wrap a tiny stub that returns nullptr
+# for non-strings (see kr_json_object_getstring_test.cpp).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CPP_DIR="$SCRIPT_DIR/../../main/cpp"
+UTIL_DIR="$CPP_DIR/libohos_render/utils"
+CJSON_DIR="$CPP_DIR/thirdparty/cJSON"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -I"$UTIL_DIR"
+    -I"$CPP_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_json_object_getstring_test.cpp"
+    "$UTIL_DIR/KRJSONObject.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_json_object_getstring_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -x c "$CJSON_DIR/cJSON.c" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_json_object_getstring_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -x c "$CJSON_DIR/cJSON.c" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"

--- a/core-render-ohos/src/test/cpp/run_kr_json_object_getstring_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_json_object_getstring_test.sh
@@ -19,6 +19,7 @@ OUT_DIR="$SCRIPT_DIR/build"
 mkdir -p "$OUT_DIR"
 
 CXX="${CXX:-g++}"
+CC="${CC:-gcc}"
 MODE="${1:-default}"
 
 COMMON_FLAGS=(
@@ -26,6 +27,12 @@ COMMON_FLAGS=(
     -Wall
     -Wextra
     -I"$UTIL_DIR"
+    -I"$CPP_DIR"
+)
+
+C_FLAGS=(
+    -Wall
+    -Wextra
     -I"$CPP_DIR"
 )
 
@@ -37,14 +44,21 @@ SRCS=(
 case "$MODE" in
     default)
         BIN="$OUT_DIR/kr_json_object_getstring_test"
+        CJSON_OBJ="$OUT_DIR/cJSON.o"
+        echo ">>> [$CC] compile $CJSON_OBJ"
+        "$CC" "${C_FLAGS[@]}" -O2 -c "$CJSON_DIR/cJSON.c" -o "$CJSON_OBJ"
         echo ">>> [$CXX] compile $BIN"
-        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -x c "$CJSON_DIR/cJSON.c" -o "$BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" "$CJSON_OBJ" -o "$BIN"
         ;;
     asan)
         BIN="$OUT_DIR/kr_json_object_getstring_test_asan"
+        CJSON_OBJ="$OUT_DIR/cJSON_asan.o"
+        echo ">>> [$CC] ASan/UBSan compile $CJSON_OBJ"
+        "$CC" "${C_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined -c "$CJSON_DIR/cJSON.c" -o "$CJSON_OBJ"
         echo ">>> [$CXX] ASan/UBSan compile $BIN"
         "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
-            -fsanitize=address,undefined "${SRCS[@]}" -x c "$CJSON_DIR/cJSON.c" -o "$BIN"
+            -fsanitize=address,undefined "${SRCS[@]}" "$CJSON_OBJ" -o "$BIN"
         ;;
     *)
         echo "unknown mode: $MODE (default|asan)"


### PR DESCRIPTION
## leftover

OHOS `JSONObject::GetString` / `GetStringArray` adopted `cJSON_GetStringValue` into `std::string` whenever the key existed. `cJSON_GetStringValue` returns NULL for non-string items (`{"key":1}`, mixed arrays). `std::string(NULL)` is UB/crash. Sibling `KRRenderValue::fromJsonValue` already guards with `cJSON_IsString`.

- `GetString`: if `!cJSON_IsString(item)` or `cJSON_GetStringValue == nullptr`, return default
- `GetStringArray`: skip non-string / null elements (empty strings are kept)
- `JSONObject::Parse("{")` is nullptr; `KRSharedPreferencesModule::SetItem` and `KRFileModule::WriteFile` / `AppendFile` no longer deref a failed parse

Host test (no Harmony device): `core-render-ohos/src/test/cpp/run_kr_json_object_getstring_test.sh`

Does not touch KRDate, KRBase64Util, KREncodeURLComponent, or KRThread.

Signed-off-by: Tony Coder <407243179@qq.com>
