### PR TITLE
fix(ohos): guard leftover getNApiArgsStdString against nullptr

### DIFF
--- a/core-render-ohos/.gitignore
+++ b/core-render-ohos/.gitignore
@@ -9,3 +9,6 @@ BuildProfile.ets
 
 # Kotlin/Native LLDB helpers (auto-generated, do not commit)
 /.kuikly/
+
+# Host unit-test binaries
+/src/test/cpp/build/

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/NAPIStringAdopt.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/NAPIStringAdopt.h
@@ -1,0 +1,38 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_NAPISTRINGADOPT_H
+#define CORE_RENDER_OHOS_NAPISTRINGADOPT_H
+
+#include <string>
+
+namespace kuikly {
+namespace util {
+
+// Copy a leftover NAPI UTF-8 C string into std::string without constructing
+// from nullptr. getNApiArgsString returns 0 after napi_throw_error; leftover
+// getNApiArgsStdString did std::string(resStr), which is UB on null.
+// The helper only copies; the caller still owns and may free resStr.
+inline std::string adopt_napi_cstr(const char *resStr) {
+    if (resStr == nullptr) {
+        return "";
+    }
+    return std::string(resStr);
+}
+
+}  // namespace util
+}  // namespace kuikly
+
+#endif  // CORE_RENDER_OHOS_NAPISTRINGADOPT_H

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/NAPIUtil.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/NAPIUtil.cpp
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include "NAPIStringAdopt.h"
 #include "NAPIUtil.h"
 
 namespace kuikly {
@@ -63,7 +64,10 @@ char *getNApiArgsString(napi_env env, napi_value value) {
 
 std::string getNApiArgsStdString(napi_env env, napi_value value) {
     char *resStr = getNApiArgsString(env, value);
-    std::string resString(resStr);
+    // leftover: std::string(resStr) is UB when getNApiArgsString returns 0
+    // after napi_throw_error. Adopt copies or returns "" so we never
+    // construct from nullptr; caller still delete[]s (no-op on null).
+    std::string resString = adopt_napi_cstr(resStr);
     delete[] resStr;
     return resString;
 }

--- a/core-render-ohos/src/test/cpp/napi_args_stdstring_host_test.cpp
+++ b/core-render-ohos/src/test/cpp/napi_args_stdstring_host_test.cpp
@@ -1,0 +1,48 @@
+// Host unit test for leftover getNApiArgsStdString null adopt.
+//
+// leftover getNApiArgsStdString did std::string(resStr) after
+// getNApiArgsString returned nullptr (post napi_throw_error). That is UB.
+// adopt_napi_cstr is NAPI-free so this can run on host g++/clang++ without
+// a Harmony device or real NAPI.
+//
+// Build + run (from this directory):
+//   ./run_napi_args_stdstring_host_test.sh
+//   ./run_napi_args_stdstring_host_test.sh asan
+
+#include "NAPIStringAdopt.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+static int g_failed = 0;
+
+static void expect_eq(const char *name, const std::string &got, const std::string &want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got \"%s\" want \"%s\"\n", name, got.c_str(), want.c_str());
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+int main() {
+    // leftover: constructing std::string from nullptr is the bug;
+    // helper adopt_napi_cstr(nullptr) returns empty, does not crash.
+    expect_eq("adopt_napi_cstr(nullptr)", kuikly::util::adopt_napi_cstr(nullptr), "");
+
+    // leftover: helper on a real C string copies then caller can free.
+    char *owned = new char[6];
+    std::memcpy(owned, "hello", 6);
+    std::string copied = kuikly::util::adopt_napi_cstr(owned);
+    expect_eq("adopt_napi_cstr(hello)", copied, "hello");
+    delete[] owned;
+    expect_eq("adopt copy independent after free", copied, "hello");
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_napi_args_stdstring_host_test.sh
+++ b/core-render-ohos/src/test/cpp/run_napi_args_stdstring_host_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Compile + run leftover getNApiArgsStdString adopt host tests (no Harmony device).
+#
+# Usage:
+#   ./run_napi_args_stdstring_host_test.sh          # g++ default
+#   ./run_napi_args_stdstring_host_test.sh asan     # Address+UB sanitizers
+#
+# adopt_napi_cstr is NAPI-free. Host g++/clang++ is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UTIL_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/utils"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$UTIL_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/napi_args_stdstring_host_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/napi_args_stdstring_host_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/napi_args_stdstring_host_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

OHOS leftover `getNApiArgsStdString` did `std::string(resStr)` after `getNApiArgsString` returned `0` (`nullptr`) following `napi_throw_error`. Constructing `std::string` from nullptr is UB and crashes live callers (`napi_init.cpp` Launch/UpdateConfig/Create/Destroy/SizeChanged, `KRRenderManager.cpp`). Safer sibling `GetNApiArgsStdString` (vector-based) already exists in the same file.

Extract NAPI-free `adopt_napi_cstr`: on null return `""`. Call sites unchanged.

Host test (no Harmony device): `core-render-ohos/src/test/cpp/run_napi_args_stdstring_host_test.sh`

Does not touch KRDate, KRBase64Util, KREncodeURLComponent, KRThread, or KRJSONObject.

Signed-off-by: Tony Coder <407243179@qq.com>
