### PR TITLE
fix(ohos): stop mapping returnKeyType none to NEW_LINE

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRConvertUtil.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRConvertUtil.cpp
@@ -15,6 +15,7 @@
 
 #include "libohos_render/utils/KRConvertUtil.h"
 #include "libohos_render/foundation/KRConfig.h"
+#include "libohos_render/utils/KREnterKeyTypeMap.h"
 #include <codecvt>
 #include <iostream>
 #include <locale>
@@ -24,47 +25,11 @@ namespace kuikly {
 namespace util {
 
 ArkUI_EnterKeyType ConvertToEnterKeyType(const std::string &enter_key_type) {
-    if (enter_key_type == "search") {
-        return ARKUI_ENTER_KEY_TYPE_SEARCH;
-    }
-    if (enter_key_type == "send") {
-        return ARKUI_ENTER_KEY_TYPE_SEND;
-    }
-    if (enter_key_type == "go") {
-        return ARKUI_ENTER_KEY_TYPE_GO;
-    }
-    if (enter_key_type == "done") {
-        return ARKUI_ENTER_KEY_TYPE_DONE;
-    }
-    if (enter_key_type == "next") {
-        return ARKUI_ENTER_KEY_TYPE_NEXT;
-    }
-    if (enter_key_type == "previous") {
-        return ARKUI_ENTER_KEY_TYPE_PREVIOUS;
-    }
-    if (enter_key_type == "none") {
-        return ARKUI_ENTER_KEY_TYPE_NEW_LINE;
-    }
-    return ARKUI_ENTER_KEY_TYPE_DONE;
+    return static_cast<ArkUI_EnterKeyType>(MapEnterKeyTypeName(enter_key_type));
 }
 
 const std::string ConvertEnterKeyTypeToString(ArkUI_EnterKeyType enter_key_type) {
-    switch (enter_key_type) {
-        case ARKUI_ENTER_KEY_TYPE_SEARCH:
-            return "search";
-        case ARKUI_ENTER_KEY_TYPE_SEND:
-            return "send";
-        case ARKUI_ENTER_KEY_TYPE_GO:
-            return "go";
-        case ARKUI_ENTER_KEY_TYPE_DONE:
-            return "done";
-        case ARKUI_ENTER_KEY_TYPE_NEXT:
-            return "next";
-        case ARKUI_ENTER_KEY_TYPE_PREVIOUS:
-            return "previous";
-        default:
-            return "";
-    }
+    return EnterKeyTypeCodeToName(static_cast<int>(enter_key_type));
 }
 
 ArkUI_TextInputType ConvertToInputType(const std::string &input_type) {

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KREnterKeyTypeMap.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KREnterKeyTypeMap.h
@@ -1,0 +1,92 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_KRENTERKEYTYPEMAP_H
+#define CORE_RENDER_OHOS_KRENTERKEYTYPEMAP_H
+
+#include <string>
+
+namespace kuikly {
+namespace util {
+
+// Integer codes match ArkUI_EnterKeyType (native_type.h / API 12+):
+//   GO=2, SEARCH=3, SEND=4, NEXT=5, DONE=6, PREVIOUS=7, NEW_LINE=8
+// ArkUI has no NONE. Host tests include this header without the Harmony SDK.
+constexpr int kEnterKeyTypeGo = 2;
+constexpr int kEnterKeyTypeSearch = 3;
+constexpr int kEnterKeyTypeSend = 4;
+constexpr int kEnterKeyTypeNext = 5;
+constexpr int kEnterKeyTypeDone = 6;
+constexpr int kEnterKeyTypePrevious = 7;
+constexpr int kEnterKeyTypeNewLine = 8;
+
+// Single-line TextInput missing-attr default. Official ArkUI enterKeyType
+// default is Done. NEW_LINE was a leftover stand-in (same leftover as mapping
+// "none" → NEW_LINE). Multi-line TextArea may still default to NEW_LINE.
+constexpr int kEnterKeyTypeMissingAttrDefault = kEnterKeyTypeDone;
+
+inline int MapEnterKeyTypeName(const std::string &enter_key_type) {
+    if (enter_key_type == "search") {
+        return kEnterKeyTypeSearch;
+    }
+    if (enter_key_type == "send") {
+        return kEnterKeyTypeSend;
+    }
+    if (enter_key_type == "go") {
+        return kEnterKeyTypeGo;
+    }
+    if (enter_key_type == "done") {
+        return kEnterKeyTypeDone;
+    }
+    if (enter_key_type == "next") {
+        return kEnterKeyTypeNext;
+    }
+    if (enter_key_type == "previous") {
+        return kEnterKeyTypePrevious;
+    }
+    // Explicit newline aliases only. Do NOT map "none" → NEW_LINE.
+    // Android maps "none" → IME_ACTION_NONE; ArkUI has no NONE, so fall
+    // through to DONE (ArkUI default / "no special enter action").
+    if (enter_key_type == "newline" || enter_key_type == "newLine") {
+        return kEnterKeyTypeNewLine;
+    }
+    return kEnterKeyTypeDone;
+}
+
+inline const char *EnterKeyTypeCodeToName(int enter_key_type) {
+    switch (enter_key_type) {
+        case kEnterKeyTypeSearch:
+            return "search";
+        case kEnterKeyTypeSend:
+            return "send";
+        case kEnterKeyTypeGo:
+            return "go";
+        case kEnterKeyTypeDone:
+            return "done";
+        case kEnterKeyTypeNext:
+            return "next";
+        case kEnterKeyTypePrevious:
+            return "previous";
+        case kEnterKeyTypeNewLine:
+            return "newline";
+        default:
+            return "";
+    }
+}
+
+}  // namespace util
+}  // namespace kuikly
+
+#endif  // CORE_RENDER_OHOS_KRENTERKEYTYPEMAP_H

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.cpp
@@ -1342,7 +1342,9 @@ void UpdateInputNodeEnterKeyType(ArkUI_NodeHandle node, ArkUI_EnterKeyType enter
 
 ArkUI_EnterKeyType GetInputNodeEnterKeyType(ArkUI_NodeHandle node) {
     auto item = GetNodeApi()->getAttribute(node, NODE_TEXT_INPUT_ENTER_KEY_TYPE);
-    return item ? static_cast<ArkUI_EnterKeyType>(item->value[0].i32) : ARKUI_ENTER_KEY_TYPE_NEW_LINE;
+    // Single-line TextInput: ArkUI enterKeyType default is Done. NEW_LINE was a
+    // leftover stand-in (same leftover as mapping returnKeyType "none" → NEW_LINE).
+    return item ? static_cast<ArkUI_EnterKeyType>(item->value[0].i32) : ARKUI_ENTER_KEY_TYPE_DONE;
 }
 
 void UpdateInputNodeMaxLength(ArkUI_NodeHandle node, int32_t max_length) {

--- a/core-render-ohos/src/test/cpp/kr_enter_key_type_map_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_enter_key_type_map_test.cpp
@@ -1,0 +1,88 @@
+// Host unit test for leftover returnKeyType mapping.
+//
+// KREnterKeyTypeMap.h has no Harmony SDK dependency. Host g++/clang++ is enough.
+//
+// Build + run (from this directory):
+//   ./run_kr_enter_key_type_map_test.sh
+//   ./run_kr_enter_key_type_map_test.sh asan
+
+#include "libohos_render/utils/KREnterKeyTypeMap.h"
+
+#include <cstdio>
+#include <string>
+
+using kuikly::util::EnterKeyTypeCodeToName;
+using kuikly::util::kEnterKeyTypeDone;
+using kuikly::util::kEnterKeyTypeGo;
+using kuikly::util::kEnterKeyTypeNewLine;
+using kuikly::util::kEnterKeyTypeNext;
+using kuikly::util::kEnterKeyTypePrevious;
+using kuikly::util::kEnterKeyTypeSearch;
+using kuikly::util::kEnterKeyTypeSend;
+using kuikly::util::MapEnterKeyTypeName;
+
+static int g_failed = 0;
+
+static void expect_eq_int(const char *name, int got, int want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got %d want %d\n", name, got, want);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_eq_str(const char *name, const char *got, const char *want) {
+    if (std::string(got) != want) {
+        std::fprintf(stderr, "FAIL %s: got \"%s\" want \"%s\"\n", name, got, want);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+int main() {
+    // Leftover bug: "none" must not map to NEW_LINE (IME shows "New Line"
+    // and can insert newlines on single-line fields). Android maps "none"
+    // → IME_ACTION_NONE; ArkUI has no NONE, so fall through to DONE.
+    expect_true("none != NEW_LINE", MapEnterKeyTypeName("none") != kEnterKeyTypeNewLine);
+    expect_eq_int("none == DONE", MapEnterKeyTypeName("none"), kEnterKeyTypeDone);
+
+    // Explicit newline aliases only.
+    expect_eq_int("newline == NEW_LINE", MapEnterKeyTypeName("newline"), kEnterKeyTypeNewLine);
+    expect_eq_int("newLine == NEW_LINE", MapEnterKeyTypeName("newLine"), kEnterKeyTypeNewLine);
+
+    // Known returnKeyType strings keep their ArkUI counterparts.
+    expect_eq_int("search", MapEnterKeyTypeName("search"), kEnterKeyTypeSearch);
+    expect_eq_int("send", MapEnterKeyTypeName("send"), kEnterKeyTypeSend);
+    expect_eq_int("go", MapEnterKeyTypeName("go"), kEnterKeyTypeGo);
+    expect_eq_int("done", MapEnterKeyTypeName("done"), kEnterKeyTypeDone);
+    expect_eq_int("next", MapEnterKeyTypeName("next"), kEnterKeyTypeNext);
+    expect_eq_int("previous", MapEnterKeyTypeName("previous"), kEnterKeyTypePrevious);
+
+    // Unknown / empty also fall through to DONE (ArkUI default).
+    expect_eq_int("empty == DONE", MapEnterKeyTypeName(""), kEnterKeyTypeDone);
+    expect_eq_int("unknown == DONE", MapEnterKeyTypeName("continue"), kEnterKeyTypeDone);
+
+    // Reverse map: NEW_LINE must not be empty (was default → "").
+    expect_true("NEW_LINE reverse not empty", EnterKeyTypeCodeToName(kEnterKeyTypeNewLine)[0] != '\0');
+    expect_eq_str("NEW_LINE → newline", EnterKeyTypeCodeToName(kEnterKeyTypeNewLine), "newline");
+    expect_eq_str("DONE → done", EnterKeyTypeCodeToName(kEnterKeyTypeDone), "done");
+    expect_eq_str("SEARCH → search", EnterKeyTypeCodeToName(kEnterKeyTypeSearch), "search");
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_enter_key_type_map_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_enter_key_type_map_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Compile + run leftover returnKeyType mapping host unit tests (no Harmony device).
+#
+# Usage:
+#   ./run_kr_enter_key_type_map_test.sh          # g++ default
+#   ./run_kr_enter_key_type_map_test.sh asan     # Address+UB sanitizers
+#
+# KREnterKeyTypeMap.h has no OHOS APIs. Host g++/clang++ is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CPP_ROOT="$SCRIPT_DIR/../../main/cpp"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$CPP_ROOT"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_enter_key_type_map_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_enter_key_type_map_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_enter_key_type_map_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

OHOS ConvertToEnterKeyType mapped leftover returnKeyType "none" to ARKUI_ENTER_KEY_TYPE_NEW_LINE. ArkUI C enum has Go/Search/Send/Next/Done/Previous/NewLine — no NONE. The leftover stand-in made the IME show New Line and can insert newlines on single-line fields.

Android maps "none" to EditorInfo.IME_ACTION_NONE. Reverse map had no NEW_LINE case, so it returned empty.

- Do not map "none" to NEW_LINE. Fall through to DONE.
- Keep NEW_LINE only for explicit "newline" / "newLine".
- Add NEW_LINE to "newline" so round-trip is not empty.
- Single-line GetInputNodeEnterKeyType missing-attr default was the same leftover (NEW_LINE); now DONE. Multi-line TextArea default left as NEW_LINE.

Host test (no Harmony device): core-render-ohos/src/test/cpp/run_kr_enter_key_type_map_test.sh

Does not touch KRDate, KRBase64Util, KREncodeURLComponent, or KRThread.

Signed-off-by: Tony Coder <407243179@qq.com>
