### PR TITLE
fix(ohos): guard leftover canvas Parse-null deref

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/canvas/KRCanvasParsedJson.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/canvas/KRCanvasParsedJson.h
@@ -1,0 +1,50 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_KRCANVASPARSEDJSON_H
+#define CORE_RENDER_OHOS_KRCANVASPARSEDJSON_H
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "libohos_render/utils/KRJSONObject.h"
+
+namespace kuikly {
+namespace util {
+
+// Leftover Parse-null helper. JSONObject::Parse returns nullptr on bad JSON
+// ("{", "", "not-json"). Canvas ops must adopt through this helper and
+// no-op when null — never deref GetString/GetNumber on a failed parse.
+// Header-only so host tests compile without Harmony drawing APIs.
+inline std::shared_ptr<JSONObject> AdoptParsedJson(const std::string &params) {
+    return JSONObject::Parse(params);
+}
+
+// Apply fn only when parse succeeds. Leftover unguarded deref would crash.
+template <typename Fn>
+inline bool AdoptParsedJson(const std::string &params, Fn &&fn) {
+    auto obj = JSONObject::Parse(params);
+    if (!obj) {
+        return false;
+    }
+    std::forward<Fn>(fn)(obj);
+    return true;
+}
+
+}  // namespace util
+}  // namespace kuikly
+
+#endif  // CORE_RENDER_OHOS_KRCANVASPARSEDJSON_H

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/canvas/KRCanvasView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/canvas/KRCanvasView.cpp
@@ -31,6 +31,7 @@
 #include "libohos_render/expand/modules/cache/KRMemoryCacheModule.h"
 #include "libohos_render/utils/KRColor.h"
 #include "libohos_render/utils/KRJSONObject.h"
+#include "KRCanvasParsedJson.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -144,7 +145,10 @@ void KRCanvasView::OnCustomEvent(ArkUI_NodeCustomEvent *event, const ArkUI_NodeC
 }
 
 void KRCanvasView::SetLineCap(const std::string &params) {
-    auto obj = kuikly::util::JSONObject::Parse(params);
+    auto obj = kuikly::util::AdoptParsedJson(params);
+    if (!obj) {
+        return;
+    }
     std::string str = obj->GetString("style");
     OH_Drawing_PenLineCapStyle style = LINE_FLAT_CAP;
     if (str == "round") {
@@ -157,7 +161,10 @@ void KRCanvasView::SetLineCap(const std::string &params) {
 }
 
 void KRCanvasView::SetLineWidth(const std::string &params) {
-    auto obj = kuikly::util::JSONObject::Parse(params);
+    auto obj = kuikly::util::AdoptParsedJson(params);
+    if (!obj) {
+        return;
+    }
     float width = obj->GetNumber("width");
 
     CreatePenIfNeeded();
@@ -165,7 +172,10 @@ void KRCanvasView::SetLineWidth(const std::string &params) {
 }
 
 void KRCanvasView::SetLineDash(const std::string &params) {
-    auto obj = kuikly::util::JSONObject::Parse(params);
+    auto obj = kuikly::util::AdoptParsedJson(params);
+    if (!obj) {
+        return;
+    }
     auto intervalsVector = obj->GetNumberArray("intervals");
     int count = intervalsVector.size();
     CreatePenIfNeeded();
@@ -263,7 +273,10 @@ void KRCanvasView::MoveTo(const std::string &params) {
     if (drawingPath_ == nullptr) {
         return;
     }
-    auto obj = kuikly::util::JSONObject::Parse(params);
+    auto obj = kuikly::util::AdoptParsedJson(params);
+    if (!obj) {
+        return;
+    }
     float x = obj->GetNumber("x");
     float y = obj->GetNumber("y");
 
@@ -274,7 +287,10 @@ void KRCanvasView::LineTo(const std::string &params) {
     if (drawingPath_ == nullptr) {
         return;
     }
-    auto obj = kuikly::util::JSONObject::Parse(params);
+    auto obj = kuikly::util::AdoptParsedJson(params);
+    if (!obj) {
+        return;
+    }
     float x = obj->GetNumber("x");
     float y = obj->GetNumber("y");
     OH_Drawing_PathLineTo(drawingPath_, x, y);
@@ -365,7 +381,10 @@ void KRCanvasView::SetTextAlign(const std::string &params) {
 }
 
 void KRCanvasView::SetFont(const std::string &params) {
-    auto paramObj = kuikly::util::JSONObject::Parse(params);
+    auto paramObj = kuikly::util::AdoptParsedJson(params);
+    if (!paramObj) {
+        return;
+    }
     auto size = paramObj->GetNumber("size");
     auto style = paramObj->GetString("style");
     auto weight = std::stoi(paramObj->GetString("weight"));
@@ -395,6 +414,10 @@ void KRCanvasView::StrokeText(const std::string &params) {
 }
 
 void KRCanvasView::DrawText(std::string params, std::string_view type) {
+    auto paramObj = kuikly::util::AdoptParsedJson(params);
+    if (!paramObj) {
+        return;
+    }
     OH_Drawing_TextStyle *txtStyle = OH_Drawing_CreateTextStyle();
     // 设置文字大小、字重等属性
     float fontSizeScale = 1;
@@ -436,7 +459,6 @@ void KRCanvasView::DrawText(std::string params, std::string_view type) {
         OH_Drawing_SetTextStyleForegroundPen(txtStyle, pen_);
     }
 
-    auto paramObj = kuikly::util::JSONObject::Parse(params);
     auto text = paramObj->GetString("text");
     auto x = paramObj->GetNumber("x");
     auto y = paramObj->GetNumber("y");
@@ -481,7 +503,10 @@ void KRCanvasView::QuadraticCurveTo(const std::string &params) {
     if (drawingPath_ == nullptr) {
         return;
     }
-    auto obj = kuikly::util::JSONObject::Parse(params);
+    auto obj = kuikly::util::AdoptParsedJson(params);
+    if (!obj) {
+        return;
+    }
     float cpx = obj->GetNumber("cpx");
     float cpy = obj->GetNumber("cpy");
     float x = obj->GetNumber("x");
@@ -493,7 +518,10 @@ void KRCanvasView::BezierCurveTo(const std::string &params) {
     if (drawingPath_ == nullptr) {
         return;
     }
-    auto obj = kuikly::util::JSONObject::Parse(params);
+    auto obj = kuikly::util::AdoptParsedJson(params);
+    if (!obj) {
+        return;
+    }
     float cp1x = obj->GetNumber("cp1x");
     float cp1y = obj->GetNumber("cp1y");
     float cp2x = obj->GetNumber("cp2x");
@@ -511,7 +539,10 @@ void KRCanvasView::Save() {
 
 void KRCanvasView::SaveLayer(const std::string &params) {
     if (canvas_) {
-        auto obj = kuikly::util::JSONObject::Parse(params);
+        auto obj = kuikly::util::AdoptParsedJson(params);
+        if (!obj) {
+            return;
+        }
         float x = obj->GetNumber("x");
         float y = obj->GetNumber("y");
         float width = obj->GetNumber("width");
@@ -530,7 +561,10 @@ void KRCanvasView::Restore() {
 
 void KRCanvasView::clip(const std::string &params) {
     if (canvas_ && drawingPath_) {
-        auto obj = kuikly::util::JSONObject::Parse(params);
+        auto obj = kuikly::util::AdoptParsedJson(params);
+        if (!obj) {
+            return;
+        }
         auto op = obj->GetNumber("intersect") ? OH_Drawing_CanvasClipOp::INTERSECT
                                               : OH_Drawing_CanvasClipOp::DIFFERENCE;
         OH_Drawing_CanvasClipPath(canvas_, drawingPath_, op, true);
@@ -539,7 +573,10 @@ void KRCanvasView::clip(const std::string &params) {
 
 void KRCanvasView::Translate(const std::string &params) {
     if (canvas_) {
-        auto obj = kuikly::util::JSONObject::Parse(params);
+        auto obj = kuikly::util::AdoptParsedJson(params);
+        if (!obj) {
+            return;
+        }
         float x = obj->GetNumber("x");
         float y = obj->GetNumber("y");
         OH_Drawing_CanvasTranslate(canvas_, x, y);
@@ -548,7 +585,10 @@ void KRCanvasView::Translate(const std::string &params) {
 
 void KRCanvasView::Scale(const std::string &params) {
     if (canvas_) {
-        auto obj = kuikly::util::JSONObject::Parse(params);
+        auto obj = kuikly::util::AdoptParsedJson(params);
+        if (!obj) {
+            return;
+        }
         float x = obj->GetNumber("x");
         float y = obj->GetNumber("y");
         OH_Drawing_CanvasScale(canvas_, x, y);
@@ -557,7 +597,10 @@ void KRCanvasView::Scale(const std::string &params) {
 
 void KRCanvasView::Rotate(const std::string &params) {
     if (canvas_) {
-        auto obj = kuikly::util::JSONObject::Parse(params);
+        auto obj = kuikly::util::AdoptParsedJson(params);
+        if (!obj) {
+            return;
+        }
         float degrees = obj->GetNumber("angle") * 180 / M_PI;
         OH_Drawing_CanvasRotate(canvas_, degrees, 0, 0);
     }
@@ -565,7 +608,10 @@ void KRCanvasView::Rotate(const std::string &params) {
 
 void KRCanvasView::Skew(const std::string &params) {
     if (canvas_) {
-        auto obj = kuikly::util::JSONObject::Parse(params);
+        auto obj = kuikly::util::AdoptParsedJson(params);
+        if (!obj) {
+            return;
+        }
         float x = obj->GetNumber("x");
         float y = obj->GetNumber("y");
         OH_Drawing_CanvasSkew(canvas_, x, y);
@@ -574,7 +620,10 @@ void KRCanvasView::Skew(const std::string &params) {
 
 void KRCanvasView::Transform(const std::string &params) {
     if (canvas_) {
-        auto obj = kuikly::util::JSONObject::Parse(params);
+        auto obj = kuikly::util::AdoptParsedJson(params);
+        if (!obj) {
+            return;
+        }
         auto values = obj->GetNumberArray("values");
         if (values.size() < 9) {
             return;
@@ -591,7 +640,10 @@ void KRCanvasView::Transform(const std::string &params) {
 
 void KRCanvasView::DrawImage(const std::string &params) {
     if (canvas_) {
-        auto obj = kuikly::util::JSONObject::Parse(params);
+        auto obj = kuikly::util::AdoptParsedJson(params);
+        if (!obj) {
+            return;
+        }
         std::string cacheKey = obj->GetString("cacheKey");
         auto module = std::dynamic_pointer_cast<KRMemoryCacheModule>(GetModule(kMemoryCacheModuleName));
         auto pixelmap = module->GetImage(cacheKey);

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_canvas_parsed_json_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_canvas_parsed_json_test.cpp
@@ -1,0 +1,96 @@
+// Host unit test for leftover canvas JSONObject::Parse-null deref.
+//
+// JSONObject::Parse returns nullptr on bad JSON. Leftover canvas ops
+// (SetLineCap / MoveTo / DrawText / Transform / ...) deref'd that pointer
+// for GetString/GetNumber. Siblings SetStrokeStyle / SetFillStyle / Arc
+// already guard if (paramObj). AdoptParsedJson no-ops on nullptr so host
+// tests compile without Harmony drawing APIs.
+//
+// Build + run (from this directory):
+//   ./run_kr_canvas_parsed_json_test.sh
+//   ./run_kr_canvas_parsed_json_test.sh asan
+
+#include "KRCanvasParsedJson.h"
+
+#include <cstdio>
+#include <string>
+
+using kuikly::util::AdoptParsedJson;
+using kuikly::util::JSONObject;
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_eq(const char *name, const std::string &got, const std::string &want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got \"%s\" want \"%s\"\n", name, got.c_str(), want.c_str());
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+int main() {
+    // leftover: Parse("{") / Parse("") / Parse("not-json") is nullptr.
+    // A leftover unguarded deref (obj->GetString / obj->GetNumber) would crash.
+    // Helper must no-op.
+    {
+        expect_true("Parse(\"{\") is nullptr", JSONObject::Parse("{") == nullptr);
+        expect_true("Parse(\"\") is nullptr", JSONObject::Parse("") == nullptr);
+        expect_true("Parse(\"not-json\") is nullptr", JSONObject::Parse("not-json") == nullptr);
+
+        expect_true("AdoptParsedJson(\"{\") is nullptr", AdoptParsedJson("{") == nullptr);
+        expect_true("AdoptParsedJson(\"\") is nullptr", AdoptParsedJson("") == nullptr);
+        expect_true("AdoptParsedJson(\"not-json\") is nullptr", AdoptParsedJson("not-json") == nullptr);
+
+        bool invoked_brace = false;
+        bool invoked_empty = false;
+        bool invoked_not_json = false;
+        expect_true("AdoptParsedJson(\"{\") no-op",
+                    !AdoptParsedJson("{", [&](auto &) { invoked_brace = true; }) && !invoked_brace);
+        expect_true("AdoptParsedJson(\"\") no-op",
+                    !AdoptParsedJson("", [&](auto &) { invoked_empty = true; }) && !invoked_empty);
+        expect_true("AdoptParsedJson(\"not-json\") no-op",
+                    !AdoptParsedJson("not-json", [&](auto &) { invoked_not_json = true; }) &&
+                        !invoked_not_json);
+
+        // Call-site contract: only GetString/GetNumber after a non-null adopt.
+        auto bad = AdoptParsedJson("{");
+        if (bad) {
+            // leftover unguarded: bad->GetString("style") would crash
+            std::fprintf(stderr, "FAIL leftover unguarded deref skipped\n");
+            ++g_failed;
+        } else {
+            std::printf("PASS leftover unguarded deref skipped\n");
+        }
+    }
+
+    // leftover: valid {"style":"round"} still adopts
+    {
+        auto obj = AdoptParsedJson(R"({"style":"round"})");
+        expect_true("AdoptParsedJson({\"style\":\"round\"}) non-null", obj != nullptr);
+        expect_eq("GetString style", obj ? obj->GetString("style") : "", "round");
+
+        std::string adopted_style;
+        bool adopted = AdoptParsedJson(R"({"style":"round"})", [&](auto parsed) {
+            adopted_style = parsed->GetString("style");
+        });
+        expect_true("AdoptParsedJson({\"style\":\"round\"}) applies", adopted);
+        expect_eq("adopted style", adopted_style, "round");
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_canvas_parsed_json_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_canvas_parsed_json_test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Compile + run leftover canvas Parse-null host unit tests (no Harmony device).
+#
+# Usage:
+#   ./run_kr_canvas_parsed_json_test.sh          # g++ default
+#   ./run_kr_canvas_parsed_json_test.sh asan     # Address+UB sanitizers
+#
+# KRCanvasView.cpp needs Harmony drawing APIs. AdoptParsedJson is header-only
+# and KRJSONObject.cpp has no OHOS APIs, so host g++/clang++ + bundled cJSON
+# is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CPP_DIR="$SCRIPT_DIR/../../main/cpp"
+UTIL_DIR="$CPP_DIR/libohos_render/utils"
+CANVAS_DIR="$CPP_DIR/libohos_render/expand/components/canvas"
+CJSON_DIR="$CPP_DIR/thirdparty/cJSON"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+CC="${CC:-gcc}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -I"$CANVAS_DIR"
+    -I"$UTIL_DIR"
+    -I"$CPP_DIR"
+)
+
+C_FLAGS=(
+    -Wall
+    -Wextra
+    -I"$CPP_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_canvas_parsed_json_test.cpp"
+    "$UTIL_DIR/KRJSONObject.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_canvas_parsed_json_test"
+        CJSON_OBJ="$OUT_DIR/cJSON.o"
+        echo ">>> [$CC] compile $CJSON_OBJ"
+        "$CC" "${C_FLAGS[@]}" -O2 -c "$CJSON_DIR/cJSON.c" -o "$CJSON_OBJ"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" "$CJSON_OBJ" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_canvas_parsed_json_test_asan"
+        CJSON_OBJ="$OUT_DIR/cJSON_asan.o"
+        echo ">>> [$CC] ASan/UBSan compile $CJSON_OBJ"
+        "$CC" "${C_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined -c "$CJSON_DIR/cJSON.c" -o "$CJSON_OBJ"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" "$CJSON_OBJ" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"

--- a/core-render-ohos/src/test/cpp/run_kr_canvas_parsed_json_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_canvas_parsed_json_test.sh
@@ -23,10 +23,15 @@ CXX="${CXX:-g++}"
 CC="${CC:-gcc}"
 MODE="${1:-default}"
 
+# KRJSONObject.h uses std::shared_ptr / std::vector without including
+# <memory>/<vector> (fixed in leftover #1651). Force-include so this
+# leftover canvas host test compiles without touching KRJSONObject.cpp.
 COMMON_FLAGS=(
     -std=c++17
     -Wall
     -Wextra
+    -include memory
+    -include vector
     -I"$CANVAS_DIR"
     -I"$UTIL_DIR"
     -I"$CPP_DIR"


### PR DESCRIPTION
## leftover

OHOS `JSONObject::Parse` returns nullptr on bad JSON. Canvas siblings `SetStrokeStyle` / `SetFillStyle` / `Arc` already guard `if (paramObj)`. Leftover unguarded callers deref'd that pointer:

- SetLineCap, SetLineWidth, SetLineDash
- MoveTo, LineTo
- SetFont, DrawText
- QuadraticCurveTo, BezierCurveTo
- SaveLayer, clip, Translate, Scale, Rotate, Skew, Transform, DrawImage

#1651 already patched prefs/file Parse-null. This is the leftover canvas call-site guard. Does not touch `KRJSONObject.cpp`.

Host test (no Harmony device): `core-render-ohos/src/test/cpp/run_kr_canvas_parsed_json_test.sh`

Signed-off-by: Tony Coder <407243179@qq.com>
