### PR TITLE
fix(ohos): guard leftover calendar cJSON valuestring adopt

### DIFF
--- a/core-render-ohos/.gitignore
+++ b/core-render-ohos/.gitignore
@@ -9,3 +9,6 @@ BuildProfile.ets
 
 # Kotlin/Native LLDB helpers (auto-generated, do not commit)
 /.kuikly/
+
+# Host unit-test binaries
+/src/test/cpp/build/

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRCJsonStringAdopt.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRCJsonStringAdopt.h
@@ -1,0 +1,63 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_KRCJSONSTRINGADOPT_H
+#define CORE_RENDER_OHOS_KRCJSONSTRINGADOPT_H
+
+#include <string>
+
+#include "thirdparty/cJSON/cJSON.h"
+
+namespace kuikly {
+namespace module {
+
+// Leftover adopt helper (host-testable, NDK-free). Same contract as #1651
+// AdoptCJsonStringValue: cJSON sets valuestring only for string items. A
+// number/bool/null field has valuestring == NULL. std::string(NULL) is UB —
+// never construct std::string from a null C string.
+inline std::string AdoptCJsonStringValue(const char *value, const std::string &default_value = "") {
+    if (value == nullptr) {
+        return default_value;
+    }
+    return std::string(value);
+}
+
+// Require cJSON_IsString before reading valuestring. cJSON_IsString(NULL) is
+// false, so a missing item also defaults.
+inline const char *CJsonItemValuestring(const cJSON *item) {
+    if (!cJSON_IsString(item)) {
+        return nullptr;
+    }
+    return item->valuestring;
+}
+
+inline std::string AdoptCJsonItemValuestring(const cJSON *item, const std::string &default_value = "") {
+    return AdoptCJsonStringValue(CJsonItemValuestring(item), default_value);
+}
+
+// leftover CalDate/Format/Parse: skip GetObjectItem when Parse failed
+// (opObject / paramObj is nullptr).
+inline std::string AdoptCalendarObjectString(cJSON *object, const char *key,
+                                            const std::string &default_value = "") {
+    if (object == nullptr || key == nullptr) {
+        return default_value;
+    }
+    return AdoptCJsonItemValuestring(cJSON_GetObjectItemCaseSensitive(object, key), default_value);
+}
+
+}  // namespace module
+}  // namespace kuikly
+
+#endif  // CORE_RENDER_OHOS_KRCJSONSTRINGADOPT_H

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRCalendarModule.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRCalendarModule.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "KRCalendarModule.h"
+#include "KRCJsonStringAdopt.h"
 
 #include "thirdparty/cJSON/cJSON.h"
 
@@ -62,10 +63,16 @@ void KRCalendarModule::OnDestroy() {
 util::Date KRCalendarModule::CalDate(util::Date &date, const std::string &op) {
     // KLOG_INFO(TAG) << "calDate: op = " << op;
     cJSON *opObject = cJSON_Parse(op.data());
+    // leftover: cJSON_Parse of bad JSON leaves opObject null. Do not
+    // GetObjectItem on null; skip/default.
+    if (opObject == nullptr) {
+        return util::Date();
+    }
 
-    cJSON *optPtr = cJSON_GetObjectItemCaseSensitive(opObject, "opt");
-    std::string opt = optPtr != nullptr ? optPtr->valuestring : "";
+    // leftover: {"opt":1} has valuestring == NULL. Require IsString before adopt.
+    std::string opt = AdoptCalendarObjectString(opObject, "opt");
     if (opt != this->OP_SET && opt != this->OP_ADD) {
+        cJSON_Delete(opObject);
         return util::Date();
     }
 
@@ -130,17 +137,20 @@ std::string KRCalendarModule::CurrentTimestamp(const KRAnyValue &params) {
 std::string KRCalendarModule::GetField(const KRAnyValue &params) {
     // KLOG_INFO(TAG) << "getField: " << params.ToStringChecked();
     cJSON *paramObj = cJSON_Parse(params->toString().data());
+    if (paramObj == nullptr) {
+        return "";
+    }
     cJSON *dateMillisPtr = cJSON_GetObjectItemCaseSensitive(paramObj, this->PARAM_TIME_MILLIS);
     std::int64_t dateMillis = (dateMillisPtr != nullptr) ? static_cast<std::int64_t>(dateMillisPtr->valuedouble) : 0;
     util::Date date = util::Date(dateMillis);
     cJSON *operationPtr = cJSON_GetObjectItemCaseSensitive(paramObj, this->PARAM_OPERATIONS);
-    if (operationPtr != nullptr) {
-        cJSON *opsObj = cJSON_Parse(operationPtr->valuestring);
+    if (cJSON_IsString(operationPtr)) {
+        cJSON *opsObj = cJSON_Parse(AdoptCJsonItemValuestring(operationPtr).data());
         int opsSize = cJSON_GetArraySize(opsObj);
         for (auto i = 0; i < opsSize; i++) {
             cJSON *valuePtr = cJSON_GetArrayItem(opsObj, i);
             if (valuePtr != nullptr) {
-                date = this->CalDate(date, valuePtr->valuestring);
+                date = this->CalDate(date, AdoptCJsonItemValuestring(valuePtr));
             }
         }
         cJSON_Delete(opsObj);
@@ -178,20 +188,23 @@ std::string KRCalendarModule::GetField(const KRAnyValue &params) {
 std::string KRCalendarModule::GetTimeMillis(const KRAnyValue &params) {
     // KLOG_INFO(TAG) << "getTimeMillis: " << params.ToStringChecked();
     cJSON *paramObj = cJSON_Parse(params->toString().data());
+    if (paramObj == nullptr) {
+        return std::to_string(util::Date(0).GetTime());
+    }
     cJSON *dateMillisPtr = cJSON_GetObjectItemCaseSensitive(paramObj, this->PARAM_TIME_MILLIS);
     std::int64_t dateMillis = (dateMillisPtr != nullptr) ? static_cast<std::int64_t>(dateMillisPtr->valuedouble) : 0;
     util::Date date = util::Date(dateMillis);
     // KLOG_INFO(TAG) << "startTime" << date.GetTime();
     cJSON *operationPtr = cJSON_GetObjectItemCaseSensitive(paramObj, this->PARAM_OPERATIONS);
     // KLOG_INFO(TAG) << "getTimeMillis:  operation = " << operationPtr->valuestring;
-    if (operationPtr != nullptr) {
-        cJSON *opsObj = cJSON_Parse(operationPtr->valuestring);
+    if (cJSON_IsString(operationPtr)) {
+        cJSON *opsObj = cJSON_Parse(AdoptCJsonItemValuestring(operationPtr).data());
         auto opsSize = cJSON_GetArraySize(opsObj);
         // KLOG_INFO(TAG) << "getTimeMillis: opsSize = " << opsSize;
         for (auto i = 0; i < opsSize; i++) {
             cJSON *valuePtr = cJSON_GetArrayItem(opsObj, i);
             if (valuePtr != nullptr) {
-                date = this->CalDate(date, valuePtr->valuestring);
+                date = this->CalDate(date, AdoptCJsonItemValuestring(valuePtr));
             }
         }
         cJSON_Delete(opsObj);
@@ -209,11 +222,14 @@ std::string KRCalendarModule::ZeroPadded(int num, int digits) {
 std::string KRCalendarModule::Format(const KRAnyValue &params) {
     // KLOG_INFO(TAG) << "format: " << params.ToStringChecked();
     cJSON *paramObj = cJSON_Parse(params->toString().data());
-    cJSON *dateMillisPtr = cJSON_GetObjectItemCaseSensitive(paramObj, this->PARAM_TIME_MILLIS);
-    std::int64_t dateMillis = (dateMillisPtr != nullptr) ? static_cast<std::int64_t>(dateMillisPtr->valuedouble) : 0;
+    std::int64_t dateMillis = 0;
+    if (paramObj != nullptr) {
+        cJSON *dateMillisPtr = cJSON_GetObjectItemCaseSensitive(paramObj, this->PARAM_TIME_MILLIS);
+        dateMillis = (dateMillisPtr != nullptr) ? static_cast<std::int64_t>(dateMillisPtr->valuedouble) : 0;
+    }
     util::Date date = util::Date(dateMillis);
-    cJSON *formatPtr = cJSON_GetObjectItemCaseSensitive(paramObj, this->PARAM_FORMAT);
-    std::string formatStr = (formatPtr != nullptr) ? formatPtr->valuestring : "";
+    // leftover: {"format":1} has valuestring == NULL. Require IsString before adopt.
+    std::string formatStr = AdoptCalendarObjectString(paramObj, this->PARAM_FORMAT);
     cJSON_Delete(paramObj);
     std::string result = formatStr;
 
@@ -244,11 +260,10 @@ std::string KRCalendarModule::Format(const KRAnyValue &params) {
 std::string KRCalendarModule::Parse(const KRAnyValue &params) {
     // KLOG_INFO(TAG) << "parse: " << params.ToStringChecked();
     cJSON *paramObj = cJSON_Parse(params->toString().data());
-    cJSON *dateStrPtr = cJSON_GetObjectItemCaseSensitive(paramObj, this->PARAM_FORMATTED_TIME);
-    std::string dateStr = (dateStrPtr != nullptr) ? dateStrPtr->valuestring : "";
+    // leftover: numeric formattedTime / format have valuestring == NULL.
+    std::string dateStr = AdoptCalendarObjectString(paramObj, this->PARAM_FORMATTED_TIME);
     // KLOG_INFO(TAG) << "parse: " << dateStr;
-    cJSON *formatStrPtr = cJSON_GetObjectItemCaseSensitive(paramObj, this->PARAM_FORMAT);
-    std::string formatStr = (formatStrPtr != nullptr) ? formatStrPtr->valuestring : "";
+    std::string formatStr = AdoptCalendarObjectString(paramObj, this->PARAM_FORMAT);
     cJSON_Delete(paramObj);
     // Only supports date and format consistency
     util::Date date = util::Date();

--- a/core-render-ohos/src/test/cpp/kr_calendar_valuestring_adopt_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_calendar_valuestring_adopt_test.cpp
@@ -1,0 +1,123 @@
+// Host unit test for leftover KRCalendarModule valuestring adopt.
+//
+// Leftover CalDate/Format/Parse constructed std::string from
+// item->valuestring whenever the key existed. cJSON sets valuestring only
+// for string items; a number/bool/null field has valuestring == NULL.
+// std::string(NULL) is UB — same adopt #1651 fixed in JSONObject::GetString.
+// cJSON_Parse of bad JSON also leaves the object null; leftover CalDate then
+// called GetObjectItem on null.
+//
+// AdoptCJsonStringValue / AdoptCalendarObjectString are NDK-free so this
+// runs on host g++/clang++ without a Harmony device.
+//
+// Build + run (from this directory):
+//   ./run_kr_calendar_valuestring_adopt_test.sh
+//   ./run_kr_calendar_valuestring_adopt_test.sh asan
+
+#include "KRCJsonStringAdopt.h"
+#include "thirdparty/cJSON/cJSON.h"
+
+#include <cstdio>
+#include <string>
+
+using kuikly::module::AdoptCJsonItemValuestring;
+using kuikly::module::AdoptCJsonStringValue;
+using kuikly::module::AdoptCalendarObjectString;
+using kuikly::module::CJsonItemValuestring;
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_eq(const char *name, const std::string &got, const std::string &want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got \"%s\" want \"%s\"\n", name, got.c_str(), want.c_str());
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+int main() {
+    // leftover: {"opt":1} → valuestring null → helper returns "" not crash
+    {
+        cJSON *opObject = cJSON_Parse(R"({"opt":1})");
+        expect_true("Parse({\"opt\":1}) non-null", opObject != nullptr);
+        cJSON *optPtr = cJSON_GetObjectItemCaseSensitive(opObject, "opt");
+        expect_true("opt item exists", optPtr != nullptr);
+        expect_true("leftover opt valuestring is null", optPtr != nullptr && optPtr->valuestring == nullptr);
+        expect_true("CJsonItemValuestring(number) is null", CJsonItemValuestring(optPtr) == nullptr);
+        expect_eq("AdoptCJsonStringValue(null from number)", AdoptCJsonStringValue(optPtr->valuestring), "");
+        expect_eq("AdoptCJsonItemValuestring({\"opt\":1})", AdoptCJsonItemValuestring(optPtr), "");
+        expect_eq("AdoptCalendarObjectString opt number", AdoptCalendarObjectString(opObject, "opt"), "");
+        cJSON_Delete(opObject);
+    }
+
+    // leftover: Format with {"timeMillis":0,"format":1} does not construct
+    // std::string from null
+    {
+        cJSON *paramObj = cJSON_Parse(R"({"timeMillis":0,"format":1})");
+        expect_true("Parse Format leftover JSON non-null", paramObj != nullptr);
+        cJSON *formatPtr = cJSON_GetObjectItemCaseSensitive(paramObj, "format");
+        expect_true("format item exists", formatPtr != nullptr);
+        expect_true("leftover format valuestring is null", formatPtr != nullptr && formatPtr->valuestring == nullptr);
+        expect_eq("Format leftover AdoptCJsonStringValue", AdoptCJsonStringValue(formatPtr->valuestring), "");
+        expect_eq("Format leftover AdoptCalendarObjectString", AdoptCalendarObjectString(paramObj, "format"), "");
+        cJSON_Delete(paramObj);
+    }
+
+    // leftover: Parse with numeric formattedTime does not crash
+    {
+        cJSON *paramObj = cJSON_Parse(R"({"formattedTime":1,"format":1})");
+        expect_true("Parse leftover JSON non-null", paramObj != nullptr);
+        cJSON *dateStrPtr = cJSON_GetObjectItemCaseSensitive(paramObj, "formattedTime");
+        expect_true("formattedTime item exists", dateStrPtr != nullptr);
+        expect_true("leftover formattedTime valuestring is null",
+                    dateStrPtr != nullptr && dateStrPtr->valuestring == nullptr);
+        expect_eq("Parse leftover formattedTime adopt", AdoptCJsonItemValuestring(dateStrPtr), "");
+        expect_eq("Parse leftover format adopt", AdoptCalendarObjectString(paramObj, "format"), "");
+        expect_eq("Parse leftover formattedTime object adopt",
+                  AdoptCalendarObjectString(paramObj, "formattedTime"), "");
+        cJSON_Delete(paramObj);
+    }
+
+    // leftover: CalDate with bad JSON "{" does not GetObjectItem on null
+    {
+        cJSON *opObject = cJSON_Parse("{");
+        expect_true("CalDate Parse(\"{\") is nullptr", opObject == nullptr);
+        // Call-site contract: skip GetObjectItem when parse failed.
+        expect_eq("CalDate leftover AdoptCalendarObjectString(null)", AdoptCalendarObjectString(opObject, "opt"), "");
+        expect_eq("AdoptCJsonStringValue(nullptr) default empty", AdoptCJsonStringValue(nullptr), "");
+        if (opObject != nullptr) {
+            std::fprintf(stderr, "FAIL CalDate must not GetObjectItem on null\n");
+            ++g_failed;
+            cJSON_Delete(opObject);
+        } else {
+            std::printf("PASS CalDate does not GetObjectItem on null\n");
+        }
+    }
+
+    // String items still adopt (IsString + valuestring).
+    {
+        cJSON *opObject = cJSON_Parse(R"({"opt":"set"})");
+        expect_eq("AdoptCalendarObjectString opt set", AdoptCalendarObjectString(opObject, "opt"), "set");
+        expect_eq("AdoptCJsonStringValue(set)",
+                  AdoptCJsonStringValue(CJsonItemValuestring(cJSON_GetObjectItemCaseSensitive(opObject, "opt"))),
+                  "set");
+        cJSON_Delete(opObject);
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_calendar_valuestring_adopt_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_calendar_valuestring_adopt_test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Compile + run leftover KRCalendarModule valuestring adopt host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_kr_calendar_valuestring_adopt_test.sh          # g++ default
+#   ./run_kr_calendar_valuestring_adopt_test.sh asan     # Address+UB sanitizers
+#
+# The leftover adopt helper is NDK-free. Host g++/clang++ + bundled cJSON
+# (compiled as C) is enough. Do not pass -std=c++17 to cJSON.c.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CPP_DIR="$SCRIPT_DIR/../../main/cpp"
+CALENDAR_DIR="$CPP_DIR/libohos_render/expand/modules/calendar"
+CJSON_DIR="$CPP_DIR/thirdparty/cJSON"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+CC="${CC:-gcc}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$CALENDAR_DIR"
+    -I"$CPP_DIR"
+)
+
+C_FLAGS=(
+    -Wall
+    -Wextra
+    -I"$CPP_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_calendar_valuestring_adopt_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_calendar_valuestring_adopt_test"
+        CJSON_OBJ="$OUT_DIR/cJSON.o"
+        echo ">>> [$CC] compile $CJSON_OBJ"
+        "$CC" "${C_FLAGS[@]}" -O2 -c "$CJSON_DIR/cJSON.c" -o "$CJSON_OBJ"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" "$CJSON_OBJ" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_calendar_valuestring_adopt_test_asan"
+        CJSON_OBJ="$OUT_DIR/cJSON_asan.o"
+        echo ">>> [$CC] ASan/UBSan compile $CJSON_OBJ"
+        "$CC" "${C_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined -c "$CJSON_DIR/cJSON.c" -o "$CJSON_OBJ"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" "$CJSON_OBJ" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

OHOS `KRCalendarModule` adopted `item->valuestring` into `std::string` whenever the key existed (`CalDate` opt, `Format` format, `Parse` formattedTime/format).

cJSON sets `valuestring` only for string items. A number field (`{"opt":1}`, `{"format":1}`) has `valuestring == NULL`. `std::string(NULL)` is UB — same adopt #1651 fixed in `JSONObject::GetString`.

`cJSON_Parse` of bad JSON also leaves `opObject` null, then leftover `CalDate` called `GetObjectItem` on null.

Host test (no Harmony device): `core-render-ohos/src/test/cpp/run_kr_calendar_valuestring_adopt_test.sh`

Does not touch KRDate.cpp (#1649).

Signed-off-by: Tony Coder <407243179@qq.com>
