### PR TITLE
fix(ohos): cast leftover KRDecodeURLComponent digits as unsigned

### DIFF
--- a/core-render-ohos/.gitignore
+++ b/core-render-ohos/.gitignore
@@ -9,3 +9,6 @@ BuildProfile.ets
 
 # Kotlin/Native LLDB helpers (auto-generated, do not commit)
 /.kuikly/
+
+# Host unit-test binaries
+/src/test/cpp/build/

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/codec/KRCodec.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/codec/KRCodec.cpp
@@ -51,26 +51,8 @@ std::string KREncodeURLComponent(const std::string &in) {
     return out;
 }
 
-std::string KRDecodeURLComponent(const std::string &in) {
-    std::string res;
-    for (size_t i = 0; i < in.size(); ++i) {
-        if (in[i] == '%' && i + 2 < in.size()) {
-            char d1 = in[i + 1];
-            char d2 = in[i + 2];
-            if (std::isxdigit(d1) && std::isxdigit(d2)) {
-                char b = (std::isdigit(d1) ? (d1 - '0') : (std::toupper(d1) - 'A' + 10)) << 4;
-                b |= (std::isdigit(d2) ? (d2 - '0') : (std::toupper(d2) - 'A' + 10));
-                res.push_back(b);
-                i += 2;
-            } else {
-                res.push_back(in[i]);
-            }
-        } else {
-            res.push_back(in[i]);
-        }
-    }
-    return res;
-}
+// KRDecodeURLComponent is header-only in KRCodecDecode.h so host tests can
+// compile the leftover unsigned-char ctype path without Harmony or md5/sha256.
 
 std::string KRBase64Encode(const std::string &in) {
     std::string out;

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/codec/KRCodec.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/codec/KRCodec.h
@@ -16,11 +16,11 @@
 
 #include <string>
 
+#include "KRCodecDecode.h"
+
 namespace kuikly {
 inline namespace model_util {
 std::string KREncodeURLComponent(const std::string &str);
-
-std::string KRDecodeURLComponent(const std::string &str);
 
 std::string KRBase64Encode(const std::string &str);
 std::string KRBase64Encode(const std::string_view in);

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/codec/KRCodecDecode.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/codec/KRCodecDecode.h
@@ -1,0 +1,61 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cctype>
+#include <string>
+
+namespace kuikly {
+inline namespace model_util {
+
+// Decode one leftover hex nibble. C isxdigit/isdigit/toupper require
+// unsigned char or EOF; leftover KRDecodeURLComponent passed raw char
+// (signed on OHOS aarch64/x86_64), so high bytes like 0x80 were UB.
+// Returns 0..15, or -1 when c is not a hex digit.
+inline int KRDecodeHexNibble(unsigned char c) {
+    if (!std::isxdigit(c)) {
+        return -1;
+    }
+    if (std::isdigit(c)) {
+        return static_cast<int>(c - '0');
+    }
+    return static_cast<int>(std::toupper(c) - 'A' + 10);
+}
+
+// Percent-decode. Invalid %xx (including leftover high bytes) is kept as
+// a literal '%'; the following two bytes are then scanned as usual.
+inline std::string KRDecodeURLComponent(const std::string &in) {
+    std::string res;
+    for (size_t i = 0; i < in.size(); ++i) {
+        if (in[i] == '%' && i + 2 < in.size()) {
+            unsigned char d1 = static_cast<unsigned char>(in[i + 1]);
+            unsigned char d2 = static_cast<unsigned char>(in[i + 2]);
+            int n1 = KRDecodeHexNibble(d1);
+            int n2 = KRDecodeHexNibble(d2);
+            if (n1 >= 0 && n2 >= 0) {
+                res.push_back(static_cast<char>((n1 << 4) | n2));
+                i += 2;
+            } else {
+                res.push_back(in[i]);
+            }
+        } else {
+            res.push_back(in[i]);
+        }
+    }
+    return res;
+}
+
+}  //  namespace util
+}  //  namespace kuikly

--- a/core-render-ohos/src/test/cpp/kr_decode_url_component_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_decode_url_component_test.cpp
@@ -1,0 +1,88 @@
+// Host unit test for leftover KRDecodeURLComponent signed-char ctype.
+//
+// leftover KRDecodeURLComponent passed raw char to isxdigit/isdigit/toupper.
+// Those require unsigned char or EOF; on OHOS aarch64/x86_64 char is signed,
+// so high bytes like "%\x80\x80" were UB, not a clean reject.
+//
+// KRCodecDecode.h is Harmony-free (and md5/sha256-free) so this builds with
+// host g++/clang++. Forced -fsigned-char matches OHOS.
+//
+// Build + run (from this directory):
+//   ./run_kr_decode_url_test.sh
+//   ./run_kr_decode_url_test.sh asan
+
+#include "KRCodecDecode.h"
+
+#include <climits>
+#include <cstdio>
+#include <string>
+
+static_assert(CHAR_MIN < 0, "test requires signed char (use -fsigned-char)");
+
+using kuikly::KRDecodeHexNibble;
+using kuikly::KRDecodeURLComponent;
+
+static int g_failed = 0;
+
+static void dump_bytes(FILE *fp, const std::string &s) {
+    for (unsigned char c : s) {
+        std::fprintf(fp, "%02X", c);
+    }
+}
+
+static void expect_eq(const char *name, const std::string &got, const std::string &want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got ", name);
+        dump_bytes(stderr, got);
+        std::fprintf(stderr, " want ");
+        dump_bytes(stderr, want);
+        std::fprintf(stderr, "\n");
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_int(const char *name, int got, int want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got %d want %d\n", name, got, want);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+int main() {
+    // leftover: raw char 0x80 fails the isxdigit contract on signed-char hosts.
+    // Helper takes unsigned char, so 0x80 is a clean non-hex reject, not UB.
+    expect_int("nibble high byte", KRDecodeHexNibble(0x80), -1);
+    expect_int("nibble A", KRDecodeHexNibble(static_cast<unsigned char>('A')), 10);
+    expect_int("nibble f", KRDecodeHexNibble(static_cast<unsigned char>('f')), 15);
+
+    // leftover: "%\x80\x80" must not UB; invalid %xx is kept as literal '%'.
+    {
+        std::string in;
+        in.push_back('%');
+        in.push_back(static_cast<char>(0x80));
+        in.push_back(static_cast<char>(0x80));
+        expect_eq("high-byte percent", KRDecodeURLComponent(in), in);
+    }
+
+    // Valid percent-decoding, including a high decoded byte.
+    expect_eq("%41", KRDecodeURLComponent("%41"), "A");
+    expect_eq("%4f", KRDecodeURLComponent("%4f"), "O");
+    {
+        std::string want(1, static_cast<char>(0xFF));
+        expect_eq("%FF", KRDecodeURLComponent("%FF"), want);
+    }
+
+    // leftover: invalid %GG kept as literal '%'.
+    expect_eq("%GG", KRDecodeURLComponent("%GG"), "%GG");
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_decode_url_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_decode_url_test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Compile + run leftover KRDecodeURLComponent host unit tests (no Harmony device).
+#
+# Usage:
+#   ./run_kr_decode_url_test.sh          # g++ default
+#   ./run_kr_decode_url_test.sh asan     # Address+UB sanitizers
+#
+# KRCodecDecode.h is Harmony-free. Host g++/clang++ is enough.
+# -fsigned-char matches OHOS aarch64/x86_64 so leftover raw-char ctype is exercised.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CODEC_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/modules/codec"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -fsigned-char
+    -I"$CODEC_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_decode_url_component_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_decode_url_component_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_decode_url_component_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

On OpenHarmony aarch64/x86_64, char is signed. Leftover KRDecodeURLComponent passed raw char digits to std::isxdigit / std::isdigit / std::toupper. Those C functions require unsigned char or EOF, so high bytes like percent plus 0x80 were UB instead of a clean reject.

#1648 already casts encode bytes as unsigned. Decode is the leftover.

Cast d1/d2 to unsigned char before ctype. Invalid percent-xx stays a literal percent.

Host test (no Harmony device, -fsigned-char): core-render-ohos/src/test/cpp/run_kr_decode_url_test.sh

Does not rewrite KREncodeURLComponent (#1648). Does not touch KRBase64Util.cpp (#1650).

Signed-off-by: Tony Coder <407243179@qq.com>
