### PR TITLE
fix(ohos): preserve context worker semantics with an 8 MiB stack

### DIFF
--- a/core-render-ohos/.gitignore
+++ b/core-render-ohos/.gitignore
@@ -9,3 +9,6 @@ BuildProfile.ets
 
 # Kotlin/Native LLDB helpers (auto-generated, do not commit)
 /.kuikly/
+
+# Host unit-test binaries
+/src/test/cpp/build/

--- a/core-render-ohos/src/main/cpp/libohos_render/foundation/thread/KRSizedThread.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/foundation/thread/KRSizedThread.h
@@ -1,0 +1,148 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_KRSIZEDTHREAD_H
+#define CORE_RENDER_OHOS_KRSIZEDTHREAD_H
+
+#include <pthread.h>
+
+#include <cerrno>
+#include <cstddef>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+
+// OpenHarmony context workers can inherit a small platform-default stack
+// (about 132 KiB on API 23). Deep Compose measure/place chains need the same
+// 8 MiB stack budget recommended for Kuikly's Android context thread.
+inline constexpr std::size_t kKRContextWorkerStackSize = 8U * 1024U * 1024U;
+
+// Narrow std::thread-compatible wrapper used by the Kuikly context worker.
+// It intentionally keeps the construct/join/joinable/native_handle surface
+// used by KRThread while owning the platform-specific stack-size setup.
+class KRSizedThread {
+ public:
+    using native_handle_type = pthread_t;
+
+    KRSizedThread() noexcept = default;
+
+    template <typename Callable,
+              typename = std::enable_if_t<!std::is_same_v<std::decay_t<Callable>, KRSizedThread>>>
+    explicit KRSizedThread(Callable &&callable) {
+        using TaskType = Task<std::decay_t<Callable>>;
+        auto task = std::make_unique<TaskType>(std::forward<Callable>(callable));
+        const int error = CreateWithStack(&thread_, &TaskType::Run, task.get());
+        if (error != 0) {
+            throw std::system_error(error, std::generic_category(), "KRSizedThread pthread_create");
+        }
+        task.release();
+        joinable_ = true;
+    }
+
+    ~KRSizedThread() {
+        if (joinable_) {
+            std::terminate();
+        }
+    }
+
+    KRSizedThread(const KRSizedThread &) = delete;
+    KRSizedThread &operator=(const KRSizedThread &) = delete;
+
+    KRSizedThread(KRSizedThread &&other) noexcept
+        : thread_(other.thread_), joinable_(std::exchange(other.joinable_, false)) {
+        other.thread_ = pthread_t{};
+    }
+
+    KRSizedThread &operator=(KRSizedThread &&other) noexcept {
+        // Match std::thread move assignment: assigning to any joinable target,
+        // including itself, terminates instead of silently losing ownership.
+        if (joinable_) {
+            std::terminate();
+        }
+        thread_ = other.thread_;
+        joinable_ = std::exchange(other.joinable_, false);
+        other.thread_ = pthread_t{};
+        return *this;
+    }
+
+    bool joinable() const noexcept {
+        return joinable_;
+    }
+
+    void join() {
+        if (!joinable_) {
+            throw std::system_error(EINVAL, std::generic_category(), "KRSizedThread::join");
+        }
+        if (pthread_equal(thread_, pthread_self()) != 0) {
+            throw std::system_error(EDEADLK, std::generic_category(), "KRSizedThread::join self");
+        }
+
+        const int error = pthread_join(thread_, nullptr);
+        if (error != 0) {
+            // Match std::thread: a failed join must not discard ownership of a
+            // thread whose termination and native resources are still unknown.
+            throw std::system_error(error, std::generic_category(), "KRSizedThread pthread_join");
+        }
+        joinable_ = false;
+        thread_ = pthread_t{};
+    }
+
+    native_handle_type native_handle() noexcept {
+        return thread_;
+    }
+
+ private:
+    template <typename Callable>
+    struct Task {
+        template <typename Source>
+        explicit Task(Source &&source) : callable(std::forward<Source>(source)) {}
+
+        static void *Run(void *rawTask) {
+            std::unique_ptr<Task> task(static_cast<Task *>(rawTask));
+            // Do not catch here. KRThread deliberately lets Kotlin/Native
+            // unhandled hooks observe the exception before std::terminate,
+            // matching the previous std::thread entry behavior.
+            std::invoke(std::move(task->callable));
+            return nullptr;
+        }
+
+        Callable callable;
+    };
+
+    static int CreateWithStack(pthread_t *thread, void *(*startRoutine)(void *), void *argument) noexcept {
+        pthread_attr_t attributes;
+        int error = pthread_attr_init(&attributes);
+        if (error != 0) {
+            return error;
+        }
+
+        error = pthread_attr_setstacksize(&attributes, kKRContextWorkerStackSize);
+        if (error == 0) {
+            error = pthread_create(thread, &attributes, startRoutine, argument);
+        }
+        // pthread_create copies the attributes, so destroy failure cannot
+        // invalidate a successfully created thread.
+        static_cast<void>(pthread_attr_destroy(&attributes));
+        return error;
+    }
+
+    pthread_t thread_{};
+    bool joinable_{false};
+};
+
+#endif  // CORE_RENDER_OHOS_KRSIZEDTHREAD_H

--- a/core-render-ohos/src/main/cpp/libohos_render/foundation/thread/KRThread.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/foundation/thread/KRThread.cpp
@@ -40,7 +40,7 @@ constexpr auto kDirectRunFastFailWindow = std::chrono::milliseconds{100};
 }  // namespace
 
 KRThread::KRThread(const std::string &name) {
-    m_workerThread = std::thread([this, name]() {this->WorkerLoop(name); });
+    m_workerThread = KRSizedThread([this, name]() { this->WorkerLoop(name); });
     pthread_setname_np(m_workerThread.native_handle(), name.c_str());
 
     // 等 worker 线程把 uv_loop_init / uv_async_init 完成后再返回，
@@ -197,7 +197,7 @@ void KRThread::OnAsync() {
             auto fn = std::move(local.front());
             local.pop();
             if (fn) {
-                // 任何未捕获异常都会一路冒到 std::thread 入口触发 std::terminate，
+                // 任何未捕获异常都会一路冒到 worker 线程入口触发 std::terminate，
                 // 同时让 m_taskMutex / m_isExecutingTask 来不及落回干净状态——
                 // 这里不套 C++ catch，为的是让 K/N unhandled hook 能先于 std::terminate
                 // 触发、打出完整 Kotlin 侧崩溃栈（catch 会让 K/N 观察到 "C++ 已处理"

--- a/core-render-ohos/src/main/cpp/libohos_render/foundation/thread/KRThread.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/foundation/thread/KRThread.h
@@ -27,6 +27,8 @@
 #include <string>
 #include <thread>
 
+#include "libohos_render/foundation/thread/KRSizedThread.h"
+
 // KRThread：基于自建 uv_loop_t 的工作线程。
 // 关键约束（HarmonyOS libuv）：
 //   * uv_loop_init / uv_run / 所有非线程安全 uv_* 接口必须在 loop 线程；
@@ -105,7 +107,7 @@ class KRThread {
     void StartTimerInLoop(std::function<void()> task, int delayMs);
 
     // ---- 线程与 loop ----
-    std::thread m_workerThread;
+    KRSizedThread m_workerThread;
     std::thread::id m_workerThreadId;
     uv_loop_t m_loop{};
     uv_async_t m_async{};

--- a/core-render-ohos/src/test/cpp/run_krthread_stack.sh
+++ b/core-render-ohos/src/test/cpp/run_krthread_stack.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Compile and run the no-device context-worker stack regression.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOURCE="$SCRIPT_DIR/test_krthread_worker_stack.cpp"
+INCLUDE_DIR="$SCRIPT_DIR/../../main/cpp"
+KRTHREAD_SOURCE="$INCLUDE_DIR/libohos_render/foundation/thread/KRThread.cpp"
+OUTPUT_DIR="$SCRIPT_DIR/build"
+OUTPUT="$OUTPUT_DIR/test_krthread_worker_stack"
+CXX="${CXX:-clang++}"
+
+if ! grep -q 'm_workerThread = KRSizedThread' "$KRTHREAD_SOURCE"; then
+    echo "FAIL: KRThread does not construct its context worker with KRSizedThread"
+    exit 1
+fi
+if grep -Eq 'm_workerThread = std::thread|pthread_(create|join)|pthread_attr_setstacksize' "$KRTHREAD_SOURCE"; then
+    echo "FAIL: KRThread bypasses the sized-thread wrapper"
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+"$CXX" -std=c++17 -O0 -g -Wall -Wextra -Werror -pthread \
+    -I "$INCLUDE_DIR" \
+    "$SOURCE" -o "$OUTPUT"
+
+# Keep the host default below the explicit worker stack so the regression is
+# visible even on development machines whose normal pthread default is large.
+ulimit -s 256
+"$OUTPUT"

--- a/core-render-ohos/src/test/cpp/test_krthread_worker_stack.cpp
+++ b/core-render-ohos/src/test/cpp/test_krthread_worker_stack.cpp
@@ -1,0 +1,154 @@
+// Host regression test for the OpenHarmony context-worker thread wrapper.
+
+#include "libohos_render/foundation/thread/KRSizedThread.h"
+
+#include <pthread.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <string>
+#include <system_error>
+
+namespace {
+
+struct ParkState {
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool ready{false};
+    bool stop{false};
+};
+
+void Park(ParkState *state) {
+    std::unique_lock<std::mutex> lock(state->mutex);
+    state->ready = true;
+    state->condition.notify_all();
+    state->condition.wait(lock, [state]() { return state->stop; });
+}
+
+void WaitUntilReady(ParkState *state) {
+    std::unique_lock<std::mutex> lock(state->mutex);
+    state->condition.wait(lock, [state]() { return state->ready; });
+}
+
+void Stop(ParkState *state) {
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        state->stop = true;
+    }
+    state->condition.notify_all();
+}
+
+std::size_t ReadStackSize(pthread_t thread) {
+#if defined(__APPLE__)
+    return pthread_get_stacksize_np(thread);
+#elif defined(__linux__)
+    pthread_attr_t attributes;
+    const int getAttributeError = pthread_getattr_np(thread, &attributes);
+    if (getAttributeError != 0) {
+        throw std::system_error(getAttributeError, std::generic_category(), "pthread_getattr_np");
+    }
+    std::size_t stackSize = 0;
+    const int getSizeError = pthread_attr_getstacksize(&attributes, &stackSize);
+    static_cast<void>(pthread_attr_destroy(&attributes));
+    if (getSizeError != 0) {
+        throw std::system_error(getSizeError, std::generic_category(), "pthread_attr_getstacksize");
+    }
+    return stackSize;
+#else
+#error "The KRThread host regression test supports Linux and macOS."
+#endif
+}
+
+bool TestStackSize() {
+    ParkState state;
+    KRSizedThread worker([&state]() { Park(&state); });
+    WaitUntilReady(&state);
+    const std::size_t stackSize = ReadStackSize(worker.native_handle());
+    Stop(&state);
+    worker.join();
+
+    std::printf("context worker stack: %zu bytes\n", stackSize);
+    return stackSize >= kKRContextWorkerStackSize && !worker.joinable();
+}
+
+struct SelfJoinState {
+    std::mutex mutex;
+    std::condition_variable condition;
+    KRSizedThread *worker{nullptr};
+    bool start{false};
+    bool finished{false};
+    bool rejectedSelfJoin{false};
+    bool reportedDeadlock{false};
+    bool retainedOwnership{false};
+};
+
+bool TestFailedJoinRetainsOwnership() {
+    SelfJoinState state;
+    KRSizedThread worker([&state]() {
+        KRSizedThread *self = nullptr;
+        {
+            std::unique_lock<std::mutex> lock(state.mutex);
+            state.condition.wait(lock, [&state]() { return state.start; });
+            self = state.worker;
+        }
+
+        try {
+            self->join();
+        } catch (const std::system_error &error) {
+            state.rejectedSelfJoin = true;
+            state.reportedDeadlock =
+                error.code() == std::make_error_code(std::errc::resource_deadlock_would_occur);
+            state.retainedOwnership = self->joinable();
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(state.mutex);
+            state.finished = true;
+        }
+        state.condition.notify_all();
+    });
+
+    {
+        std::lock_guard<std::mutex> lock(state.mutex);
+        state.worker = &worker;
+        state.start = true;
+    }
+    state.condition.notify_all();
+
+    {
+        std::unique_lock<std::mutex> lock(state.mutex);
+        const bool finished = state.condition.wait_for(
+            lock, std::chrono::seconds(5), [&state]() { return state.finished; });
+        if (!finished) {
+            std::fprintf(stderr, "FAIL: self-join did not fail within 5 seconds\n");
+            // A worker blocked in pthread_join cannot be safely joined or
+            // destroyed. End only this test process so the regression remains
+            // bounded and the operating system reclaims the test thread.
+            std::_Exit(EXIT_FAILURE);
+        }
+    }
+
+    const bool failureStateWasCorrect =
+        state.rejectedSelfJoin && state.reportedDeadlock && state.retainedOwnership && worker.joinable();
+    worker.join();
+    return failureStateWasCorrect && !worker.joinable();
+}
+
+}  // namespace
+
+int main() {
+    if (!TestStackSize()) {
+        std::fprintf(stderr, "FAIL: context worker stack is smaller than 8 MiB\n");
+        return EXIT_FAILURE;
+    }
+    if (!TestFailedJoinRetainsOwnership()) {
+        std::fprintf(stderr, "FAIL: failed join discarded thread ownership\n");
+        return EXIT_FAILURE;
+    }
+
+    std::printf("PASS: stack size and join ownership semantics\n");
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

- create the OpenHarmony Kuikly context worker through a narrow `std::thread`-shaped pthread wrapper;
- set its stack to 8 MiB, matching the device-validated fix reported in #1641;
- preserve thread ownership when `pthread_join` fails and reject self-join with `EDEADLK` before entering a platform deadlock;
- align move/destructor behavior with the `std::thread` surface used by `KRThread`;
- add a bounded Linux/macOS/OpenHarmony lifecycle regression that checks the live stack and failed-join ownership.

Fixes #1641. Related alternative: #1646.

## Attribution and relationship to #1646

This PR keeps the contribution timeline explicit:

- `Lau-Daniel` opened #1641 at `2026-08-20T01:26:34Z` and reported the completed root-cause/device closure at `2026-08-20T22:11:31Z`: the OpenHarmony context worker had an approximately 132 KiB default stack, and an 8 MiB renderer worker passed the API 23 long-list/stability matrix ([root-cause comment](https://github.com/Tencent-TDS/KuiklyUI/issues/1641#issuecomment-5362608648)).
- #1646 was authored afterwards and contributed the first `KRSizedThread` wrapper implementation requested by the maintainer. That wrapper direction is sound and is credited here.
- This alternative is based directly on current `Tencent-TDS/KuiklyUI:main`, not on the competing branch. It adds the unresolved join ownership, self-join, move-assignment, Kotlin/Native exception-boundary, and bounded-regression semantics described below.

The goal is to give maintainers a mechanically verified complete alternative, not to erase #1646's wrapper contribution.

## Why another implementation is needed

At exact #1646 head `33e262761f24ad8b32b70bb53efd73079fde85c5`, the 8 MiB stack test passes, but `join()` clears its state before checking whether `pthread_join` succeeded:

```cpp
int err = pthread_join(thread_, nullptr);
joinable_ = false;
thread_ = pthread_t{};
if (err != 0) {
    throw ...;
}
```

That can make an unconfirmed live thread look fully reclaimed. On the issue device, `pthread_join(self)` also blocks instead of returning `EDEADLK`.

This PR therefore uses the fail-closed order:

1. reject a non-joinable call;
2. reject self-join before entering `pthread_join`;
3. keep the handle and `joinable` ownership after any join error;
4. clear ownership only after a successful join.

The worker entry intentionally does not add a C++ catch. `KRThread` relies on Kotlin/Native unhandled hooks observing an escaping task exception before `std::terminate`, matching the previous `std::thread` boundary.

## OpenHarmony 6.1 / API 23 validation

Device environment:

```text
OpenHarmony 6.1.0.31
API 23
aarch64
```

This PR's test binary:

```text
SHA-256: B14583FC381A09DA99633CE51C3ECFE386C15863F6C7F7824E4CA767819C54A1
device readback SHA-256: identical
context worker stack: 8391264 bytes
PASS: stack size and join ownership semantics
```

Bounded negative control built against exact #1646 head `33e2627`:

```text
SHA-256: 993A123449681783C04E0D67C86902EEBAC379FD952EB19FE1C6D9372D03448F
device readback SHA-256: identical
context worker stack: 8391264 bytes
FAIL: self-join did not fail within 5 seconds
REMOTE_EXIT=1
elapsed=5.304s
```

Additional checks completed:

- OpenHarmony API 23 cross-compilation of the regression with `-Wall -Wextra -Werror`;
- OpenHarmony API 23 cross-compilation of the production `KRThread.cpp` translation unit;
- runner `bash -n` syntax check;
- `git diff --check`;
- independent read-only re-review with no remaining blocking findings.

The regression uses an in-process five-second deadline and `_Exit(EXIT_FAILURE)` only on the deadlocked test path, so a lifecycle regression fails deterministically instead of hanging CI indefinitely.

## Scope

This change contains only the reusable Kuikly OpenHarmony thread wrapper, the `KRThread` integration, and its focused regression. It does not include MNIS application code, private OpenHarmony compatibility changes, signing/device configuration, UI flattening, or product workarounds.

The submitting account cannot add repository labels; please classify this as `🐞 bug` / `s: need triage` if appropriate.