### PR TITLE
fix(ohos): leftover APNG PixelmapToBitmapBuffer reserve instead of resize

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGBitmapBuffer.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGBitmapBuffer.h
@@ -1,0 +1,35 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_APNG_BITMAP_BUFFER_H
+#define CORE_RENDER_OHOS_APNG_BITMAP_BUFFER_H
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+// Prepare a writable leftover bitmap buffer of exactly bufferSize bytes.
+//
+// After clear()+reserve(), size()==0 and data() is not a writable
+// bufferSize region. OH_PixelmapNative_ReadPixels writes bufferSize bytes
+// into that pointer, which is leftover empty-buffer polarity (wrong result
+// / heap corruption). resize() makes size()==bufferSize so data() is a
+// real writable region. Host tests can call this without an OH PixelMap.
+inline void PrepareBitmapBuffer(std::vector<uint8_t> &buffer, size_t bufferSize) {
+    buffer.clear();
+    buffer.resize(bufferSize);
+}
+
+#endif  // CORE_RENDER_OHOS_APNG_BITMAP_BUFFER_H

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGStructs.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGStructs.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "libohos_render/expand/components/apng/APNGStructs.h"
+#include "libohos_render/expand/components/apng/APNGBitmapBuffer.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -67,8 +68,7 @@ static OH_PixelmapNative *CreatePixelMap(std::shared_ptr<Frame> frame) {
 }
 
 static bool PixelmapToBitmapBuffer(OH_PixelmapNative *pixelmap, size_t bufferSize, std::vector<uint8_t> &buffer) {
-    buffer.clear();
-    buffer.reserve(bufferSize);
+    PrepareBitmapBuffer(buffer, bufferSize);
     Image_ErrorCode errCode = OH_PixelmapNative_ReadPixels(pixelmap, buffer.data(), &bufferSize);
     if (errCode != IMAGE_SUCCESS) {
         KR_LOG_ERROR << "ImageSourceNativeCTest sourceTest PixelMapToBitmapBuffer failed, errCode: " << errCode;

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host C++ test binaries
+build/

--- a/core-render-ohos/src/test/cpp/apng_bitmap_buffer_host_test.cpp
+++ b/core-render-ohos/src/test/cpp/apng_bitmap_buffer_host_test.cpp
@@ -1,0 +1,116 @@
+// Host unit test for leftover APNG PixelmapToBitmapBuffer empty-buffer polarity.
+//
+// After clear()+reserve(), size()==0 and data() is not a writable bufferSize
+// region. PrepareBitmapBuffer must resize so size()==bufferSize and
+// capacity()>=bufferSize. This test does not call OH_PixelmapNative_ReadPixels;
+// it only exercises the leftover prep helper (no Harmony device / OH PixelMap).
+//
+// Build + run (from this directory):
+//   ./run_apng_bitmap_buffer_host_test.sh
+//   ./run_apng_bitmap_buffer_host_test.sh asan
+
+#include "APNGBitmapBuffer.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool cond) {
+    if (!cond) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_eq_size(const char *name, size_t got, size_t want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got %zu want %zu\n", name, got, want);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+// Simulate leftover ReadPixels writing bufferSize bytes into data().
+// ASan/UBSan would catch leftover reserve polarity (write past size()==0).
+static void SimulateReadPixels(std::vector<uint8_t> &buffer, size_t bufferSize) {
+    if (bufferSize == 0) {
+        return;
+    }
+    std::memset(buffer.data(), 0xAB, bufferSize);
+}
+
+static void AssertPrepared(const char *label, const std::vector<uint8_t> &buffer, size_t bufferSize) {
+    char sizeName[128];
+    char capName[128];
+    std::snprintf(sizeName, sizeof(sizeName), "%s size==bufferSize", label);
+    std::snprintf(capName, sizeof(capName), "%s capacity>=bufferSize", label);
+    expect_eq_size(sizeName, buffer.size(), bufferSize);
+    expect_true(capName, buffer.capacity() >= bufferSize);
+}
+
+int main() {
+    // leftover empty-buffer: fresh vector, typical 2x2 RGBA frame.
+    {
+        const size_t bufferSize = 2 * 2 * 4;
+        std::vector<uint8_t> buffer;
+        PrepareBitmapBuffer(buffer, bufferSize);
+        AssertPrepared("fresh 16", buffer, bufferSize);
+        SimulateReadPixels(buffer, bufferSize);
+        expect_eq_size("fresh 16 after simulated ReadPixels size", buffer.size(), bufferSize);
+        expect_true("fresh 16 data[0] written", buffer[0] == 0xAB);
+        expect_true("fresh 16 data[last] written", buffer[bufferSize - 1] == 0xAB);
+    }
+
+    // leftover reuse of a larger buffer must shrink size to bufferSize.
+    {
+        const size_t bufferSize = 8;
+        std::vector<uint8_t> buffer(64, 0xFF);
+        PrepareBitmapBuffer(buffer, bufferSize);
+        AssertPrepared("reuse-shrink 8", buffer, bufferSize);
+        SimulateReadPixels(buffer, bufferSize);
+        expect_true("reuse-shrink cleared leftover prefix", buffer[0] == 0xAB);
+    }
+
+    // leftover reuse of a smaller buffer must grow size to bufferSize.
+    {
+        const size_t bufferSize = 32;
+        std::vector<uint8_t> buffer(4, 0xFF);
+        PrepareBitmapBuffer(buffer, bufferSize);
+        AssertPrepared("reuse-grow 32", buffer, bufferSize);
+        SimulateReadPixels(buffer, bufferSize);
+        expect_true("reuse-grow last byte writable", buffer[bufferSize - 1] == 0xAB);
+    }
+
+    // leftover zero-size prep: size==0 is correct; data() is not written.
+    {
+        std::vector<uint8_t> buffer(12, 0xFF);
+        PrepareBitmapBuffer(buffer, 0);
+        AssertPrepared("zero", buffer, 0);
+        SimulateReadPixels(buffer, 0);
+        expect_eq_size("zero size stays 0", buffer.size(), 0);
+    }
+
+    // leftover 1x1 RGBA (4 bytes) — smallest real PixelmapToBitmapBuffer size.
+    {
+        const size_t bufferSize = 1 * 1 * 4;
+        std::vector<uint8_t> buffer;
+        PrepareBitmapBuffer(buffer, bufferSize);
+        AssertPrepared("1x1 rgba", buffer, bufferSize);
+        SimulateReadPixels(buffer, bufferSize);
+        expect_eq_size("1x1 rgba after write", buffer.size(), bufferSize);
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_apng_bitmap_buffer_host_test.sh
+++ b/core-render-ohos/src/test/cpp/run_apng_bitmap_buffer_host_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Compile + run leftover APNG PrepareBitmapBuffer host unit tests (no Harmony device).
+#
+# Usage:
+#   ./run_apng_bitmap_buffer_host_test.sh          # g++ default
+#   ./run_apng_bitmap_buffer_host_test.sh asan     # Address+UB sanitizers
+#
+# Does not compile APNGStructs.cpp or call OH_PixelmapNative_ReadPixels.
+# Host g++/clang++ is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APNG_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/components/apng"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -I"$APNG_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/apng_bitmap_buffer_host_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/apng_bitmap_buffer_host_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/apng_bitmap_buffer_host_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`PixelmapToBitmapBuffer` did:

```cpp
buffer.clear();
buffer.reserve(bufferSize);
OH_PixelmapNative_ReadPixels(pixelmap, buffer.data(), &bufferSize);
```

After `clear()`+`reserve()`, `size()==0` and `data()` is not a writable `bufferSize` region. `ReadPixels` writes `bufferSize` bytes into that pointer → wrong result / heap corruption (classic empty-buffer polarity).

Fix: `PrepareBitmapBuffer` uses `resize(bufferSize)` so `size()==bufferSize`.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_apng_bitmap_buffer_host_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
