### PR TITLE
fix(ohos): guard leftover Parse-null deref (back_press/scroller/trace/prefs)

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerView.cpp
@@ -348,6 +348,9 @@ static ArkUI_ScrollNestedMode ParseOption(const std::string &option) {
 bool KRScrollerView::SetNestedScroll(const KRAnyValue &value) {
     const std::string &str = value->toString();
     auto paramObj = kuikly::util::JSONObject::Parse(str);
+    if (!paramObj) {
+        return false;
+    }
     const std::string &forwardStr = paramObj->GetString(kPropKeyNestedScrollForward);
     const std::string &backwardStr = paramObj->GetString(kPropKeyNestedScrollBackward);
     ArkUI_ScrollNestedMode forward = ParseOption(forwardStr);

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/back_press/KRBackPressModule.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/back_press/KRBackPressModule.cpp
@@ -35,6 +35,9 @@ KRAnyValue KRBackPressModule::CallMethod(bool sync, const std::string &method, K
 
 void KRBackPressModule::BackHandle(const KRAnyValue &params) {
     auto jsonObj = kuikly::util::JSONObject::Parse(params->toString());
+    if (!jsonObj) {
+        return;
+    }
     is_back_consumed.store(jsonObj->GetNumber("consumed", 0) == 1);
 }
 

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/performance/KRPageCreateTrace.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/performance/KRPageCreateTrace.cpp
@@ -28,6 +28,9 @@ constexpr char kEventOnCreateEnd[] = "on_create_end";
 
 KRPageCreateTrace::KRPageCreateTrace(std::string json_str) {
     auto json = kuikly::util::JSONObject::Parse(json_str);
+    if (!json) {
+        return;
+    }
     create_start_timeMills = json->GetNumber(kEventOnCreateStart);
     newPage_start_timeMills = json->GetNumber(kEventOnNewPageStart);
     newPage_end_timeMills = json->GetNumber(kEventOnNewPageEnd);

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/preferences/KROhSharedPreferencesModule.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/preferences/KROhSharedPreferencesModule.cpp
@@ -65,6 +65,9 @@ std::string KROhSharedPreferencesModule::GetItem(const KRAnyValue &params) {
 std::string KROhSharedPreferencesModule::SetItem(const KRAnyValue &params) {
     InitIfNeeded();
     auto jsonObj = util::JSONObject::Parse(params->toString());
+    if (!jsonObj) {
+        return "";
+    }
     std::string key = jsonObj->GetString("key");
     std::string value = jsonObj->GetString("value");
     this->preferences->SetSync(key, value);

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_leftover_parse_null_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_leftover_parse_null_test.cpp
@@ -1,0 +1,170 @@
+// Host unit test for leftover JSONObject::Parse-null deref
+// (back_press / scroller / page-create-trace / OH prefs).
+//
+// JSONObject::Parse returns nullptr on bad JSON. These leftover call
+// sites used to deref that pointer. Thin wrappers mimic each
+// Parse+use path so the harness compiles without Harmony / NAPI.
+// KRPageCreateTrace.cpp has no OHOS APIs and is compiled for real.
+//
+// Build + run (from this directory):
+//   ./run_kr_leftover_parse_null_test.sh
+//   ./run_kr_leftover_parse_null_test.sh asan
+
+#include "KRPageCreateTrace.h"
+#include "KRJSONObject.h"
+
+#include <cstdio>
+#include <string>
+
+using kuikly::util::JSONObject;
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_eq(const char *name, const std::string &got, const std::string &want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got \"%s\" want \"%s\"\n", name, got.c_str(), want.c_str());
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_eq_i64(const char *name, int64_t got, int64_t want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got %lld want %lld\n", name, static_cast<long long>(got),
+                     static_cast<long long>(want));
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+// Mimic KRBackPressModule::BackHandle: Parse then GetNumber("consumed").
+// Leftover unguarded: jsonObj->GetNumber after a failed Parse.
+static bool leftover_back_handle(const std::string &params, bool prior) {
+    auto jsonObj = JSONObject::Parse(params);
+    if (!jsonObj) {
+        return prior;
+    }
+    return jsonObj->GetNumber("consumed", 0) == 1;
+}
+
+// Mimic KRScrollerView::SetNestedScroll: Parse then GetString forward/backward.
+// Leftover unguarded: paramObj->GetString after a failed Parse.
+struct NestedScrollAdopt {
+    bool applied = false;
+    std::string forward;
+    std::string backward;
+};
+
+static NestedScrollAdopt leftover_set_nested_scroll(const std::string &str) {
+    NestedScrollAdopt out;
+    auto paramObj = JSONObject::Parse(str);
+    if (!paramObj) {
+        return out;
+    }
+    out.forward = paramObj->GetString("forward");
+    out.backward = paramObj->GetString("backward");
+    out.applied = true;
+    return out;
+}
+
+// Mimic KROhSharedPreferencesModule::SetItem: Parse then GetString key/value.
+// Leftover unguarded: jsonObj->GetString after a failed Parse.
+// (KRSharedPreferencesModule was fixed in #1651; this is the OH sibling.)
+struct PrefsSetItemAdopt {
+    bool applied = false;
+    std::string key;
+    std::string value;
+};
+
+static PrefsSetItemAdopt leftover_oh_prefs_set_item(const std::string &params) {
+    PrefsSetItemAdopt out;
+    auto jsonObj = JSONObject::Parse(params);
+    if (!jsonObj) {
+        return out;
+    }
+    out.key = jsonObj->GetString("key");
+    out.value = jsonObj->GetString("value");
+    out.applied = true;
+    return out;
+}
+
+int main() {
+    // leftover: Parse("{") / Parse("") is nullptr. Unguarded deref would crash.
+    {
+        expect_true("Parse(\"{\") is nullptr", JSONObject::Parse("{") == nullptr);
+        expect_true("Parse(\"\") is nullptr", JSONObject::Parse("") == nullptr);
+        expect_true("Parse(\"not-json\") is nullptr", JSONObject::Parse("not-json") == nullptr);
+    }
+
+    // 1) leftover back_press BackHandle
+    {
+        expect_true("BackHandle(\"{\") keeps prior false", leftover_back_handle("{", false) == false);
+        expect_true("BackHandle(\"\") keeps prior true", leftover_back_handle("", true) == true);
+        expect_true("BackHandle({\"consumed\":1}) sets consumed", leftover_back_handle(R"({"consumed":1})", false));
+        expect_true("BackHandle({\"consumed\":0}) clears consumed",
+                    leftover_back_handle(R"({"consumed":0})", true) == false);
+    }
+
+    // 2) leftover scroller SetNestedScroll
+    {
+        const NestedScrollAdopt bad_brace = leftover_set_nested_scroll("{");
+        const NestedScrollAdopt bad_empty = leftover_set_nested_scroll("");
+        expect_true("SetNestedScroll(\"{\") not applied", !bad_brace.applied);
+        expect_true("SetNestedScroll(\"\") not applied", !bad_empty.applied);
+
+        const NestedScrollAdopt ok = leftover_set_nested_scroll(R"({"forward":"SELF_FIRST","backward":"SELF_ONLY"})");
+        expect_true("SetNestedScroll valid applied", ok.applied);
+        expect_eq("SetNestedScroll forward", ok.forward, "SELF_FIRST");
+        expect_eq("SetNestedScroll backward", ok.backward, "SELF_ONLY");
+    }
+
+    // 3) leftover KRPageCreateTrace ctor (real production .cpp)
+    {
+        KRPageCreateTrace bad_brace("{");
+        expect_eq_i64("trace(\"{\") create_start default", bad_brace.create_start_timeMills, 0);
+        expect_eq_i64("trace(\"{\") create_end default", bad_brace.create_end_timeMills, 0);
+        expect_eq_i64("trace(\"{\") on_build_start default", bad_brace.build_start_timeMills, 0);
+
+        KRPageCreateTrace bad_empty("");
+        expect_eq_i64("trace(\"\") create_start default", bad_empty.create_start_timeMills, 0);
+        expect_eq_i64("trace(\"\") newPage_end default", bad_empty.newPage_end_timeMills, 0);
+
+        KRPageCreateTrace ok(R"({"on_create_start":11,"on_create_end":22,"on_build_start":33})");
+        expect_eq_i64("trace valid on_create_start", ok.create_start_timeMills, 11);
+        expect_eq_i64("trace valid on_create_end", ok.create_end_timeMills, 22);
+        expect_eq_i64("trace valid on_build_start", ok.build_start_timeMills, 33);
+    }
+
+    // 4) leftover KROhSharedPreferencesModule::SetItem
+    {
+        const PrefsSetItemAdopt bad_brace = leftover_oh_prefs_set_item("{");
+        const PrefsSetItemAdopt bad_empty = leftover_oh_prefs_set_item("");
+        expect_true("OH prefs SetItem(\"{\") not applied", !bad_brace.applied);
+        expect_true("OH prefs SetItem(\"\") not applied", !bad_empty.applied);
+        expect_eq("OH prefs SetItem(\"{\") key empty", bad_brace.key, "");
+        expect_eq("OH prefs SetItem(\"{\") value empty", bad_brace.value, "");
+
+        const PrefsSetItemAdopt ok = leftover_oh_prefs_set_item(R"({"key":"k","value":"v"})");
+        expect_true("OH prefs SetItem valid applied", ok.applied);
+        expect_eq("OH prefs SetItem key", ok.key, "k");
+        expect_eq("OH prefs SetItem value", ok.value, "v");
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_leftover_parse_null_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_leftover_parse_null_test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Compile + run leftover JSONObject::Parse-null host unit tests (no Harmony device).
+#
+# Usage:
+#   ./run_kr_leftover_parse_null_test.sh          # g++ default
+#   ./run_kr_leftover_parse_null_test.sh asan     # Address+UB sanitizers
+#
+# BackPress / Scroller / OH prefs pull in NAPI. Thin wrappers in the
+# test mimic those Parse+use paths. KRPageCreateTrace.cpp has no OHOS
+# APIs and is compiled for real. KRJSONObject.cpp has no OHOS APIs, so
+# host g++/clang++ + bundled cJSON is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CPP_DIR="$SCRIPT_DIR/../../main/cpp"
+UTIL_DIR="$CPP_DIR/libohos_render/utils"
+TRACE_DIR="$CPP_DIR/libohos_render/expand/modules/performance"
+CJSON_DIR="$CPP_DIR/thirdparty/cJSON"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+CC="${CC:-gcc}"
+MODE="${1:-default}"
+
+# KRJSONObject.h uses std::shared_ptr / std::vector without including
+# <memory>/<vector> (fixed in leftover #1651). KRPageCreateTrace.h uses
+# int64_t without <cstdint>. Force-include so this leftover host test
+# compiles without touching those files.
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -include memory
+    -include vector
+    -include cstdint
+    -I"$TRACE_DIR"
+    -I"$UTIL_DIR"
+    -I"$CPP_DIR"
+)
+
+C_FLAGS=(
+    -Wall
+    -Wextra
+    -I"$CPP_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_leftover_parse_null_test.cpp"
+    "$UTIL_DIR/KRJSONObject.cpp"
+    "$TRACE_DIR/KRPageCreateTrace.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_leftover_parse_null_test"
+        CJSON_OBJ="$OUT_DIR/cJSON.o"
+        echo ">>> [$CC] compile $CJSON_OBJ"
+        "$CC" "${C_FLAGS[@]}" -O2 -c "$CJSON_DIR/cJSON.c" -o "$CJSON_OBJ"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" "$CJSON_OBJ" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_leftover_parse_null_test_asan"
+        CJSON_OBJ="$OUT_DIR/cJSON_asan.o"
+        echo ">>> [$CC] ASan/UBSan compile $CJSON_OBJ"
+        "$CC" "${C_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined -c "$CJSON_DIR/cJSON.c" -o "$CJSON_OBJ"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" "$CJSON_OBJ" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

Same `JSONObject::Parse` → deref pattern as #1651 / #1654, but these call sites were never guarded:

- `KRBackPressModule::BackHandle`
- `KRScrollerView::SetNestedScroll`
- `KRPageCreateTrace` ctor
- `KROhSharedPreferencesModule::SetItem` (OH sibling of the prefs path in #1651)

`Parse` returns `nullptr` on bad JSON → null deref / crash.

Fix: `if (!obj) return;` (or safe default) at each leftover site.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_leftover_parse_null_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
