### PR TITLE
fix(ohos): initialize leftover Color::FromString on empty/malformed

### DIFF
--- a/core-render-ohos/.gitignore
+++ b/core-render-ohos/.gitignore
@@ -9,3 +9,6 @@ BuildProfile.ets
 
 # Kotlin/Native LLDB helpers (auto-generated, do not commit)
 /.kuikly/
+
+# Host unit-test binaries
+/src/test/cpp/build/

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRColor.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRColor.h
@@ -15,6 +15,8 @@
 
 #ifndef CORE_RENDER_OHOS_KRCOLOR_H
 #define CORE_RENDER_OHOS_KRCOLOR_H
+#include <cstdint>
+#include <cstdlib>
 #include <string>
 
 #include "KRStringUtil.h"
@@ -46,6 +48,10 @@ struct Color {
 
     static struct Color FromString(const std::string &colorString) {
         struct Color ret;
+        // Transparent black. Matches ConvertToHexColor's parse-failure fallback
+        // so empty / non-matching strings return a defined ARGB instead of
+        // leaving the union uninitialized.
+        ret.value = 0;
         // ets侧给的颜色字符串示例：rgba(0,0,0,0.9411764705882353)
         if (colorString.length() > 0) {
             std::string prefix("rgba(");

--- a/core-render-ohos/src/test/cpp/host_stubs/KRStringUtil.h
+++ b/core-render-ohos/src/test/cpp/host_stubs/KRStringUtil.h
@@ -1,0 +1,40 @@
+/*
+ * Host-only stub of KRStringUtil.h for Color::FromString tests.
+ *
+ * Production KRStringUtil.h includes KRCommon.h, which pulls Harmony NDK
+ * headers. Color::FromString only needs SplitString for the rgba() path.
+ * This stub matches the KRStringUtil.cpp SplitString(string, string) body
+ * so host g++ can include KRColor.h without a Harmony device.
+ */
+#ifndef CORE_RENDER_OHOS_KRSTRINGUTIL_H
+#define CORE_RENDER_OHOS_KRSTRINGUTIL_H
+
+#include <string>
+#include <vector>
+
+namespace kuikly {
+namespace util {
+
+inline std::vector<std::string> SplitString(const std::string &str, std::string separator) {
+    size_t offset = 0;
+    const size_t sz = str.size();
+    std::vector<std::string> result;
+    do {
+        size_t pos = str.find(separator, offset);
+        if (pos < sz) {
+            result.push_back(str.substr(offset, pos - offset));
+            offset = pos + separator.size();
+        } else {
+            break;
+        }
+    } while (offset < sz);
+    if (offset < sz) {
+        result.push_back(str.substr(offset));
+    }
+    return result;
+}
+
+}  // namespace util
+}  // namespace kuikly
+
+#endif  // CORE_RENDER_OHOS_KRSTRINGUTIL_H

--- a/core-render-ohos/src/test/cpp/kr_color_from_string_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_color_from_string_test.cpp
@@ -1,0 +1,61 @@
+// Host unit test for leftover Color::FromString uninitialized return.
+//
+// KRColor.h is header-only. Empty / non-matching strings used to return an
+// uninitialized Color union (indeterminate ARGB). Default is now 0
+// (transparent black), matching ConvertToHexColor's parse-failure fallback.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_kr_color_from_string_test.sh
+//   ./run_kr_color_from_string_test.sh asan
+
+// Quoted include of KRStringUtil.h from KRColor.h searches the header's own
+// directory first, so the production (Harmony) header wins over -I. Include
+// the host stub first; matching include guards skip the NDK-backed header.
+#include "KRStringUtil.h"
+#include "KRColor.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+static int g_failed = 0;
+
+static void expect_eq_u32(const char *name, std::uint32_t got, std::uint32_t want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got 0x%08x want 0x%08x\n", name, got, want);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s (0x%08x)\n", name, got);
+    }
+}
+
+int main() {
+    using kuikly::graphics::Color;
+
+    // Leftover: empty string skipped every branch and returned uninitialized.
+    const Color empty = Color::FromString("");
+    expect_eq_u32("FromString(\"\")", empty.value, 0u);
+
+    // Non-matching text takes the atoi fallback; atoi("not-a-color") is 0.
+    const Color malformed = Color::FromString("not-a-color");
+    expect_eq_u32("FromString(\"not-a-color\")", malformed.value, 0u);
+
+    // rgba() with the wrong arity also used to leave ret uninitialized.
+    const Color bad_rgba = Color::FromString("rgba(1,2,3)");
+    expect_eq_u32("FromString(\"rgba(1,2,3)\")", bad_rgba.value, 0u);
+
+    // Valid #RRGGBB: opaque red.
+    const Color hex = Color::FromString("#FF0000");
+    expect_eq_u32("FromString(\"#FF0000\")", hex.value, 0xFFFF0000u);
+
+    // Valid rgba sample (ets-side form).
+    const Color rgba = Color::FromString("rgba(255,0,0,1)");
+    expect_eq_u32("FromString(\"rgba(255,0,0,1)\")", rgba.value, 0xFFFF0000u);
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_color_from_string_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_color_from_string_test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Compile + run leftover Color::FromString host tests (no Harmony device).
+#
+# Usage:
+#   ./run_kr_color_from_string_test.sh          # g++ default
+#   ./run_kr_color_from_string_test.sh asan     # Address+UB sanitizers
+#
+# KRColor.h is header-only. Host g++/clang++ includes it directly. Production
+# KRStringUtil.h pulls Harmony NDK headers, so the test includes a host stub
+# first (same include guard) that implements only SplitString (rgba path).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UTIL_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/utils"
+STUB_DIR="$SCRIPT_DIR/host_stubs"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$STUB_DIR"
+    -I"$UTIL_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_color_from_string_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_color_from_string_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_color_from_string_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`Color::FromString` declared `struct Color ret;` without initializing `ret.value`. Empty / non-matching strings skipped every branch and returned indeterminate ARGB (UB / wrong paint). Used from canvas fill.

Fix: `ret.value = 0;` (transparent black, same fallback as `ConvertToHexColor` parse failure) before branches.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_color_from_string_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
