### PR TITLE
fix(ohos): guard leftover ConvertSplit/SplitString OOB on short props

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerContentInset.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerContentInset.h
@@ -17,19 +17,19 @@
 #define CORE_RENDER_OHOS_KRSCROLLERCONTENTINSET_H
 
 #include "libohos_render/foundation/KRCommon.h"
-#include "libohos_render/utils/KRStringUtil.h"
+#include "libohos_render/utils/KRSplitTokens.h"
 
 class KRScrollerContentInset {
  public:
     explicit KRScrollerContentInset(const KRAnyValue &value) {
-        auto content_inset_splits = kuikly::util::SplitString(value->toString(), ' ');
-        top = content_inset_splits[0]->toFloat();
-        start = content_inset_splits[1]->toFloat();
-        bottom = content_inset_splits[2]->toFloat();
-        end = content_inset_splits[3]->toFloat();
-        if (content_inset_splits.size() >= 5) {
-            animate = content_inset_splits[4]->toBool();
-        }
+        // leftover: SplitString on "10 20" / "" has <4 tokens. Pad missing
+        // top/start/bottom/end with 0 (see KRSplitTokens.h).
+        auto parts = kuikly::util::ParseContentInsetParts(value->toString());
+        top = parts.top;
+        start = parts.start;
+        bottom = parts.bottom;
+        end = parts.end;
+        animate = parts.animate;
     }
 
     bool animate = false;

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRConvertUtil.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRConvertUtil.cpp
@@ -270,12 +270,6 @@ std::string ConvertSizeToString(const KRSize &size) {
     return std::string(buffer.data());
 }
 
-KRBorderRadiuses ConverToBorderRadiuses(const std::string &borderRadiusString) {
-    auto splits = ConvertSplit(borderRadiusString, ",");
-    return KRBorderRadiuses(ConvertToFloat(splits[0]), ConvertToFloat(splits[1]), ConvertToFloat(splits[2]),
-                            ConvertToFloat(splits[3]));
-}
-
 std::string ConvertToPathCommand(const std::string &pathProp) {
     if (pathProp.empty()) {
         return "";

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRConvertUtil.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRConvertUtil.h
@@ -22,6 +22,7 @@
 #include "libohos_render/foundation/KRBorderRadiuses.h"
 #include "libohos_render/foundation/KRSize.h"
 #include "libohos_render/foundation/type/KRRenderValue.h"
+#include "libohos_render/utils/KRSplitTokens.h"
 
 namespace kuikly {
 namespace util {

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRSplitTokens.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRSplitTokens.h
@@ -1,0 +1,147 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_KRSPLITTOKENS_H
+#define CORE_RENDER_OHOS_KRSPLITTOKENS_H
+
+#include <string>
+#include <vector>
+
+#include "libohos_render/foundation/KRBorderRadiuses.h"
+
+namespace kuikly {
+namespace util {
+
+// Leftover ConvertSplit / SplitString callers indexed [0]..[3] without a size
+// check. Short CSS-like props ("8", "", "10 20", "1 2 3") produced <4 tokens
+// and OOB. Strategy (documented for the leftover fix):
+//   * pad-to-4 with "0" for border radiuses / content inset so a short list
+//     degrades to defined zeros instead of crashing;
+//   * skip update when boxShadow / textShadow has <4 tokens, and when border
+//     has <3 tokens (width style color — kotlin Border.toString / iOS
+//     CSSBorder). That matches sibling skip-if-short patterns
+//     (KRTransformParser, KRImageView capInsets, iOS CSSBoxShadow).
+// Header-only so host tests compile without ArkUI / Harmony headers.
+
+inline std::vector<std::string> SplitByDelimiters(const std::string &str, const std::string &delimiters) {
+    std::vector<std::string> result;
+    std::size_t start = 0;
+    std::size_t end = str.find_first_of(delimiters);
+
+    while (end != std::string::npos) {
+        result.push_back(str.substr(start, end - start));
+        start = end + 1;
+        end = str.find_first_of(delimiters, start);
+    }
+
+    result.push_back(str.substr(start));
+    return result;
+}
+
+inline void PadTokensTo(std::vector<std::string> &tokens, std::size_t n, const std::string &fill = "0") {
+    while (tokens.size() < n) {
+        tokens.push_back(fill);
+    }
+}
+
+inline float TokenToFloat(const std::string &string) {
+    if (string.length() == 1 && string == "0") {
+        return 0;
+    }
+    try {
+        return std::stof(string);
+    } catch (...) {
+        return 0;
+    }
+}
+
+// leftover: "8" / "" must not index past splits.size(). Missing corners stay 0.
+inline KRBorderRadiuses ConverToBorderRadiuses(const std::string &borderRadiusString) {
+    auto splits = SplitByDelimiters(borderRadiusString, ",");
+    PadTokensTo(splits, 4, "0");
+    return KRBorderRadiuses(TokenToFloat(splits[0]), TokenToFloat(splits[1]), TokenToFloat(splits[2]),
+                            TokenToFloat(splits[3]));
+}
+
+struct ContentInsetParts {
+    float top = 0;
+    float start = 0;
+    float bottom = 0;
+    float end = 0;
+    bool animate = false;
+};
+
+// leftover: "10 20" / "" pad missing top/start/bottom/end with 0.
+// Optional 5th token is animate (kotlin sends 0/1).
+inline ContentInsetParts ParseContentInsetParts(const std::string &value) {
+    auto splits = SplitByDelimiters(value, " ");
+    PadTokensTo(splits, 4, "0");
+    ContentInsetParts parts;
+    parts.top = TokenToFloat(splits[0]);
+    parts.start = TokenToFloat(splits[1]);
+    parts.bottom = TokenToFloat(splits[2]);
+    parts.end = TokenToFloat(splits[3]);
+    if (splits.size() >= 5) {
+        parts.animate = TokenToFloat(splits[4]) != 0;
+    }
+    return parts;
+}
+
+struct BoxShadowParts {
+    float x = 0;
+    float y = 0;
+    float radius = 0;
+    std::string color;
+    bool fill = true;
+};
+
+// leftover: short boxShadow ("1 2 3", "") has <4 tokens — skip, do not index.
+inline bool TryParseBoxShadowParts(const std::string &css_box_shadow, BoxShadowParts &out) {
+    auto splits = SplitByDelimiters(css_box_shadow, " ");
+    if (splits.size() < 4) {
+        return false;
+    }
+    out.x = TokenToFloat(splits[0]);
+    out.y = TokenToFloat(splits[1]);
+    out.radius = TokenToFloat(splits[2]);
+    out.color = splits[3];
+    out.fill = !(splits.size() > 4 && splits[4] == "0");
+    return true;
+}
+
+struct BorderParts {
+    float width = 0;
+    std::string style;
+    std::string color;
+};
+
+// leftover: border is "width style color" (3 tokens). Skip if shorter.
+// Not pad-to-4: kotlin Border.toString and the reset path ("0 solid 0") are 3
+// tokens; requiring 4 would drop valid updates.
+inline bool TryParseBorderParts(const std::string &borderStr, BorderParts &out) {
+    auto splits = SplitByDelimiters(borderStr, " ");
+    if (splits.size() < 3) {
+        return false;
+    }
+    out.width = TokenToFloat(splits[0]);
+    out.style = splits[1];
+    out.color = splits[2];
+    return true;
+}
+
+}  // namespace util
+}  // namespace kuikly
+
+#endif  // CORE_RENDER_OHOS_KRSPLITTOKENS_H

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewUtil.cpp
@@ -445,14 +445,19 @@ void UpdateNodeOverflow(ArkUI_NodeHandle node, int overflow) {
 }
 
 void UpdateNodeBoxShadow(ArkUI_NodeHandle node, const std::string &css_box_shadow) {
+    BoxShadowParts parts;
+    // leftover: short boxShadow has <4 tokens. Skip like iOS CSSBoxShadow /
+    // KRImageView capInsets instead of indexing [0]..[3].
+    if (!TryParseBoxShadowParts(css_box_shadow, parts)) {
+        return;
+    }
     auto nodeAPI = GetNodeApi();
-    auto splits = ConvertSplit(css_box_shadow, " ");
     auto dpi = KRConfig::GetDpi();
-    float x = ConvertToFloat(splits[0]) * dpi;
-    float y = ConvertToFloat(splits[1]) * dpi;
-    float radius = ConvertToFloat(splits[2]) * dpi;
-    uint32_t color = ConvertToHexColor(splits[3]);
-    int fill = splits.size() > 4 && splits[4] == "0" ? 0 : 1;
+    float x = parts.x * dpi;
+    float y = parts.y * dpi;
+    float radius = parts.radius * dpi;
+    uint32_t color = ConvertToHexColor(parts.color);
+    int fill = parts.fill ? 1 : 0;
     ArkUI_NumberValue value[] = {
         {.f32 = radius},
         {.i32 = 0},
@@ -467,11 +472,15 @@ void UpdateNodeBoxShadow(ArkUI_NodeHandle node, const std::string &css_box_shado
 }
 
 void SetTextShadow(OH_Drawing_TextShadow *shadow, const std::string &css_box_shadow) {
-    auto splits = ConvertSplit(css_box_shadow, " ");
-    float x = ConvertToFloat(splits[0]);
-    float y = ConvertToFloat(splits[1]);
-    float radius = ConvertToFloat(splits[2]);
-    uint32_t color = ConvertToHexColor(splits[3]);
+    BoxShadowParts parts;
+    // leftover: short text-shadow has <4 tokens. Skip instead of [0]..[3] OOB.
+    if (!TryParseBoxShadowParts(css_box_shadow, parts)) {
+        return;
+    }
+    float x = parts.x;
+    float y = parts.y;
+    float radius = parts.radius;
+    uint32_t color = ConvertToHexColor(parts.color);
     auto offset = OH_Drawing_PointCreate(x, y);
     OH_Drawing_SetTextShadow(shadow, color, offset, radius);
     OH_Drawing_PointDestroy(offset);
@@ -636,20 +645,25 @@ void UpdateNodeAccessibilityActions(ArkUI_NodeHandle node, const std::string &in
 }
 
 void UpdateNodeBorder(ArkUI_NodeHandle node, std::string borderStr) {
+    BorderParts parts;
+    // leftover: short border ("1", "1 solid") has <3 tokens. Skip instead of
+    // indexing width/style/color. 3-token "0 solid 0" reset stays valid.
+    if (!TryParseBorderParts(borderStr, parts)) {
+        return;
+    }
     auto nodeAPI = GetNodeApi();
-    auto splits = ConvertSplit(borderStr, " ");
-    auto boderWidth = ConvertToFloat(splits[0]);
+    auto boderWidth = parts.width;
     ArkUI_NumberValue value[] = {{.f32 = boderWidth}, {.f32 = boderWidth}, {.f32 = boderWidth}, {.f32 = boderWidth}};
     ArkUI_AttributeItem borderWidthItem = {value, 4};
     nodeAPI->setAttribute(node, NODE_BORDER_WIDTH, &borderWidthItem);
     {
-        auto hexColor = ConvertToHexColor(splits[2]);
+        auto hexColor = ConvertToHexColor(parts.color);
         ArkUI_NumberValue value[] = {{.u32 = hexColor}, {.u32 = hexColor}, {.u32 = hexColor}, {.u32 = hexColor}};
         ArkUI_AttributeItem borderColorItem = {value, 4};
         nodeAPI->setAttribute(node, NODE_BORDER_COLOR, &borderColorItem);
     }
     {
-        auto style = ConverToBorderStyle(splits[1]);  // style
+        auto style = ConverToBorderStyle(parts.style);  // style
 
         ArkUI_NumberValue value[] = {{.u32 = style}, {.u32 = style}, {.u32 = style}, {.u32 = style}};
         ArkUI_AttributeItem borderStyleItem = {value, 4};

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_split_tokens_oob_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_split_tokens_oob_test.cpp
@@ -1,0 +1,119 @@
+// Host unit test for leftover ConvertSplit / SplitString OOB on short props.
+//
+// ConverToBorderRadiuses / content-inset / boxShadow / border indexed
+// splits[0]..[3] after ConvertSplit / SplitString. Short strings ("8", "",
+// "10 20", "1 2 3") produce <4 tokens. Helpers pad-to-4 with "0" for
+// radiuses/inset, and skip shadow/border when the token count is short.
+// Header-only KRSplitTokens.h so this compiles without ArkUI / Harmony.
+//
+// Build + run (from this directory):
+//   ./run_kr_split_tokens_oob_test.sh
+//   ./run_kr_split_tokens_oob_test.sh asan
+
+#include "libohos_render/foundation/KRBorderRadiuses.h"
+#include "libohos_render/utils/KRSplitTokens.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+using kuikly::util::BorderParts;
+using kuikly::util::BoxShadowParts;
+using kuikly::util::ContentInsetParts;
+using kuikly::util::ConverToBorderRadiuses;
+using kuikly::util::ParseContentInsetParts;
+using kuikly::util::TryParseBorderParts;
+using kuikly::util::TryParseBoxShadowParts;
+
+static int g_failed = 0;
+
+static bool feq(float a, float b) {
+    return std::fabs(a - b) < 0.0001f;
+}
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_radius(const char *name, const KRBorderRadiuses &got, float tl, float tr, float bl, float br) {
+    if (feq(got.topLeft, tl) && feq(got.topRight, tr) && feq(got.bottomLeft, bl) && feq(got.bottomRight, br)) {
+        std::printf("PASS %s\n", name);
+    } else {
+        std::fprintf(stderr, "FAIL %s: got %g,%g,%g,%g want %g,%g,%g,%g\n", name, got.topLeft, got.topRight,
+                     got.bottomLeft, got.bottomRight, tl, tr, bl, br);
+        ++g_failed;
+    }
+}
+
+static void expect_inset(const char *name, const ContentInsetParts &got, float top, float start, float bottom,
+                         float end, bool animate) {
+    if (feq(got.top, top) && feq(got.start, start) && feq(got.bottom, bottom) && feq(got.end, end) &&
+        got.animate == animate) {
+        std::printf("PASS %s\n", name);
+    } else {
+        std::fprintf(stderr, "FAIL %s: got %g,%g,%g,%g animate=%d want %g,%g,%g,%g animate=%d\n", name, got.top,
+                     got.start, got.bottom, got.end, got.animate ? 1 : 0, top, start, bottom, end, animate ? 1 : 0);
+        ++g_failed;
+    }
+}
+
+int main() {
+    // leftover: ConverToBorderRadiuses("8") used to index splits[1]..[3] OOB.
+    // pad-to-4 with "0" → 8,0,0,0 (defined defaults, no crash).
+    expect_radius("ConverToBorderRadiuses(\"8\")", ConverToBorderRadiuses("8"), 8, 0, 0, 0);
+
+    // leftover: ConverToBorderRadiuses("") was ConvertSplit → [""] then [1]..[3] OOB.
+    expect_radius("ConverToBorderRadiuses(\"\")", ConverToBorderRadiuses(""), 0, 0, 0, 0);
+
+    // full 4-token path unchanged
+    expect_radius("ConverToBorderRadiuses(\"1,2,3,4\")", ConverToBorderRadiuses("1,2,3,4"), 1, 2, 3, 4);
+    expect_radius("ConverToBorderRadiuses(\"8,16\")", ConverToBorderRadiuses("8,16"), 8, 16, 0, 0);
+
+    // leftover: content-inset "10 20" used to index [2]..[3] OOB.
+    expect_inset("content-inset \"10 20\"", ParseContentInsetParts("10 20"), 10, 20, 0, 0, false);
+    expect_inset("content-inset \"\"", ParseContentInsetParts(""), 0, 0, 0, 0, false);
+    expect_inset("content-inset \"1 2 3 4 1\"", ParseContentInsetParts("1 2 3 4 1"), 1, 2, 3, 4, true);
+    expect_inset("content-inset \"1 2 3 4 0\"", ParseContentInsetParts("1 2 3 4 0"), 1, 2, 3, 4, false);
+
+    // leftover: short boxShadow must skip (no [0]..[3] OOB), not invent color.
+    {
+        BoxShadowParts parts;
+        expect_true("short boxShadow \"1 2 3\" skip", !TryParseBoxShadowParts("1 2 3", parts));
+        expect_true("short boxShadow \"\" skip", !TryParseBoxShadowParts("", parts));
+        expect_true("short boxShadow \"1\" skip", !TryParseBoxShadowParts("1", parts));
+
+        expect_true("boxShadow \"1 2 3 4\" parse", TryParseBoxShadowParts("1 2 3 4", parts));
+        expect_true("boxShadow x", feq(parts.x, 1));
+        expect_true("boxShadow y", feq(parts.y, 2));
+        expect_true("boxShadow radius", feq(parts.radius, 3));
+        expect_true("boxShadow color", parts.color == "4");
+        expect_true("boxShadow fill default", parts.fill);
+
+        expect_true("boxShadow \"1 2 3 #00 0\" parse", TryParseBoxShadowParts("1 2 3 #00 0", parts));
+        expect_true("boxShadow fill 0", !parts.fill);
+    }
+
+    // leftover: short border skip; 3-token reset / kotlin Border.toString stay valid.
+    {
+        BorderParts parts;
+        expect_true("short border \"1\" skip", !TryParseBorderParts("1", parts));
+        expect_true("short border \"1 solid\" skip", !TryParseBorderParts("1 solid", parts));
+        expect_true("short border \"\" skip", !TryParseBorderParts("", parts));
+        expect_true("border \"0 solid 0\" parse", TryParseBorderParts("0 solid 0", parts));
+        expect_true("border width 0", feq(parts.width, 0));
+        expect_true("border style solid", parts.style == "solid");
+        expect_true("border color 0", parts.color == "0");
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_split_tokens_oob_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_split_tokens_oob_test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Compile + run leftover ConvertSplit/SplitString OOB host unit tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_kr_split_tokens_oob_test.sh          # g++ default
+#   ./run_kr_split_tokens_oob_test.sh asan     # Address+UB sanitizers
+#
+# KRSplitTokens.h is header-only std C++ (plus KRBorderRadiuses.h).
+# Host g++/clang++ is enough — no ArkUI.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CPP_ROOT="$SCRIPT_DIR/../../main/cpp"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$CPP_ROOT"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_split_tokens_oob_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_split_tokens_oob_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_split_tokens_oob_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

Short prop strings produce <4 tokens, but leftover OHOS callers indexed `[0]..[3]` unconditionally after `ConvertSplit` / `SplitString`:

- `ConverToBorderRadiuses` (`"8"`, `""`)
- content inset (`"10 20"`)
- `UpdateNodeBoxShadow` / `SetTextShadow`
- `UpdateNodeBorder`

Strategy:

- pad-to-4 with `"0"` for border radiuses and content inset
- skip boxShadow / textShadow when size < 4
- skip border when size < 3 (valid `"0 solid 0"` is 3 tokens)

Does not touch returnKeyType / signed-char leftovers in `KRConvertUtil`.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_split_tokens_oob_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
