### PR TITLE
fix(ohos): leftover APNG disposeOp PREVIOUS never restores previousBuffer

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGDisposeBuffer.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGDisposeBuffer.h
@@ -1,0 +1,59 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_APNG_DISPOSE_BUFFER_H
+#define CORE_RENDER_OHOS_APNG_DISPOSE_BUFFER_H
+
+#include <cstdint>
+#include <vector>
+
+// APNG fcTL dispose_op (https://wiki.mozilla.org/APNG_Specification#fcTL:_The_Frame_Control_Chunk)
+constexpr int APNG_DISPOSE_OP_NONE = 0;
+constexpr int APNG_DISPOSE_OP_BACKGROUND = 1;
+constexpr int APNG_DISPOSE_OP_PREVIOUS = 2;
+
+// Save the pre-frame canvas before blending a DISPOSE_OP_PREVIOUS frame.
+// Host tests inject vectors; no PixelMap / OHOS APIs.
+inline void SavePreviousCanvas(std::vector<uint8_t> &previousBuffer, const std::vector<uint8_t> &curBitmapBuffer) {
+    previousBuffer = curBitmapBuffer;
+}
+
+// Restore the pre-frame canvas after a DISPOSE_OP_PREVIOUS frame is displayed.
+//
+// leftover polarity: HandlePostFrameDisposeOp used to assign
+// previousBuffer = curBitmapBuffer (overwrite the pre-blend save with the
+// post-blend canvas and never read previousBuffer back). Restore is
+// curBitmapBuffer = previousBuffer.
+inline void RestorePreviousCanvas(std::vector<uint8_t> &curBitmapBuffer, const std::vector<uint8_t> &previousBuffer) {
+    curBitmapBuffer = previousBuffer;
+}
+
+// Before blending: snapshot the canvas when this frame will revert after display.
+inline void SaveCanvasIfDisposePrevious(int disposeOp, std::vector<uint8_t> &previousBuffer,
+                                        const std::vector<uint8_t> &curBitmapBuffer) {
+    if (disposeOp == APNG_DISPOSE_OP_PREVIOUS) {
+        SavePreviousCanvas(previousBuffer, curBitmapBuffer);
+    }
+}
+
+// After the frame has been displayed/committed: revert the canvas for PREVIOUS.
+inline void RestoreCanvasIfDisposePrevious(int disposeOp, std::vector<uint8_t> &curBitmapBuffer,
+                                           const std::vector<uint8_t> &previousBuffer) {
+    if (disposeOp == APNG_DISPOSE_OP_PREVIOUS) {
+        RestorePreviousCanvas(curBitmapBuffer, previousBuffer);
+    }
+}
+
+#endif  // CORE_RENDER_OHOS_APNG_DISPOSE_BUFFER_H

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGStructs.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGStructs.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "libohos_render/expand/components/apng/APNGStructs.h"
+#include "libohos_render/expand/components/apng/APNGDisposeBuffer.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -148,9 +149,9 @@ bool APNG::DidAddFrame(std::shared_ptr<Frame> frame, int index) {
             this->lazyBeforeNextFrameTask();
             this->lazyBeforeNextFrameTask = nullptr;
         }
-        if (frame->disposeOp == 2) {  // 保存上一帧到缓冲区
-            previousBuffer = curBitmapBuffer;
-        }
+        // DISPOSE_OP_PREVIOUS: snapshot the pre-blend canvas, then restore
+        // it in HandlePostFrameDisposeOp after the blended frame is committed.
+        SaveCanvasIfDisposePrevious(frame->disposeOp, previousBuffer, curBitmapBuffer);
         HandleFrameBlendOp(frame, index);
         HandlePostFrameDisposeOp(frame);
         didHandled = true;
@@ -222,7 +223,7 @@ void APNG::HandleFrameBlendOp(std::shared_ptr<Frame> frame, int index) {
 }
 
 void APNG::HandlePostFrameDisposeOp(std::shared_ptr<Frame> frame) {
-    if (frame->disposeOp == 1) {  // 清理当前区域
+    if (frame->disposeOp == APNG_DISPOSE_OP_BACKGROUND) {  // 清理当前区域
         auto &drawingBuffer = this->curBitmapBuffer;
         // 清除当前帧区域
         for (int y = 0; y < frame->height; ++y) {
@@ -234,8 +235,10 @@ void APNG::HandlePostFrameDisposeOp(std::shared_ptr<Frame> frame) {
                 drawingBuffer[dstIdx + 3] = 0;
             }
         }
-    } else if (frame->disposeOp == 2) {
-        previousBuffer = this->curBitmapBuffer;
+    } else if (frame->disposeOp == APNG_DISPOSE_OP_PREVIOUS) {
+        // Restore the pre-blend snapshot. Do not overwrite previousBuffer
+        // with the post-blend canvas (leftover write-only polarity).
+        RestoreCanvasIfDisposePrevious(frame->disposeOp, this->curBitmapBuffer, this->previousBuffer);
     }
 }
 

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGStructs.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGStructs.h
@@ -91,6 +91,8 @@ class APNG {
     std::atomic_bool isParsing = true;
     std::function<void()> lazyBeforeNextFrameTask = nullptr;
     std::vector<uint8_t> curBitmapBuffer;
+    // Pre-blend canvas snapshot for APNG_DISPOSE_OP_PREVIOUS. Saved before
+    // blending; restored onto curBitmapBuffer after the frame is committed.
     std::vector<uint8_t> previousBuffer;
     std::mutex drawableMutex;
 

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host C++ test binaries
+build/

--- a/core-render-ohos/src/test/cpp/apng_dispose_previous_host_test.cpp
+++ b/core-render-ohos/src/test/cpp/apng_dispose_previous_host_test.cpp
@@ -1,0 +1,114 @@
+// Host unit test for leftover APNG DISPOSE_OP_PREVIOUS (disposeOp==2).
+//
+// leftover polarity: previousBuffer was only written. After blending,
+// HandlePostFrameDisposeOp assigned previousBuffer = curBitmapBuffer, which
+// overwrote the pre-blend save and never restored curBitmapBuffer.
+//
+// This test injects vectors into the save/restore helpers (no Harmony device,
+// no OH PixelMap, does not compile APNGStructs.cpp).
+//
+// Build + run (from this directory):
+//   ./run_apng_dispose_previous_host_test.sh
+//   ./run_apng_dispose_previous_host_test.sh asan
+
+#include "APNGDisposeBuffer.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool cond) {
+    if (!cond) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+// leftover sequence used by DidAddFrame for a non-first frame:
+// save (if op==2) -> blend into cur -> restore after the frame is committed.
+static void SimulateDisposeSequence(int disposeOp, std::vector<uint8_t> &cur, std::vector<uint8_t> &prev,
+                                    const std::vector<uint8_t> &blended) {
+    SaveCanvasIfDisposePrevious(disposeOp, prev, cur);
+    cur = blended;
+    RestoreCanvasIfDisposePrevious(disposeOp, cur, prev);
+}
+
+int main() {
+    const std::vector<uint8_t> preFrame = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
+    const std::vector<uint8_t> blended = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x01, 0x02};
+
+    // leftover op=2: restore cur to the pre-blend canvas after commit.
+    {
+        std::vector<uint8_t> cur = preFrame;
+        std::vector<uint8_t> prev;
+        SimulateDisposeSequence(APNG_DISPOSE_OP_PREVIOUS, cur, prev, blended);
+        expect_true("op=2 cur restored to pre-frame", cur == preFrame);
+        expect_true("op=2 previousBuffer still pre-frame", prev == preFrame);
+        expect_true("op=2 previousBuffer not overwritten with blend", prev != blended);
+        expect_true("op=2 cur is not left as blended", cur != blended);
+    }
+
+    // leftover overwrite polarity: the old post-op assignment would leave
+    // cur==blended and previousBuffer==blended. Restore must not do that.
+    {
+        std::vector<uint8_t> cur = preFrame;
+        std::vector<uint8_t> prev;
+        SaveCanvasIfDisposePrevious(APNG_DISPOSE_OP_PREVIOUS, prev, cur);
+        cur = blended;
+        const std::vector<uint8_t> savedBeforeRestore = prev;
+        RestoreCanvasIfDisposePrevious(APNG_DISPOSE_OP_PREVIOUS, cur, prev);
+        expect_true("op=2 restore does not write previousBuffer", prev == savedBeforeRestore);
+        expect_true("op=2 restore reads previousBuffer into cur", cur == savedBeforeRestore);
+    }
+
+    // leftover two-frame sequence: after op=2, the next blend starts from
+    // the restored pre-frame canvas, not the committed blended frame.
+    {
+        std::vector<uint8_t> cur = preFrame;
+        std::vector<uint8_t> prev;
+        SimulateDisposeSequence(APNG_DISPOSE_OP_PREVIOUS, cur, prev, blended);
+        const std::vector<uint8_t> nextBlend = {0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38};
+        SimulateDisposeSequence(APNG_DISPOSE_OP_NONE, cur, prev, nextBlend);
+        expect_true("next frame after op=2 starts from restored canvas", cur == nextBlend);
+        expect_true("op=0 does not clobber previousBuffer", prev == preFrame);
+    }
+
+    // leftover op=0: no save, no restore; canvas stays at the blended frame.
+    {
+        std::vector<uint8_t> cur = preFrame;
+        std::vector<uint8_t> prev = {0xFE};
+        SimulateDisposeSequence(APNG_DISPOSE_OP_NONE, cur, prev, blended);
+        expect_true("op=0 cur stays blended", cur == blended);
+        expect_true("op=0 previousBuffer untouched", prev.size() == 1 && prev[0] == 0xFE);
+    }
+
+    // leftover op=1: save/restore helpers are no-ops (BACKGROUND clear is
+    // a separate region wipe in HandlePostFrameDisposeOp).
+    {
+        std::vector<uint8_t> cur = preFrame;
+        std::vector<uint8_t> prev = {0xFE};
+        SimulateDisposeSequence(APNG_DISPOSE_OP_BACKGROUND, cur, prev, blended);
+        expect_true("op=1 helpers do not restore", cur == blended);
+        expect_true("op=1 previousBuffer untouched", prev.size() == 1 && prev[0] == 0xFE);
+    }
+
+    // leftover empty pre-frame canvas: restore still copies previousBuffer.
+    {
+        std::vector<uint8_t> cur;
+        std::vector<uint8_t> prev;
+        SimulateDisposeSequence(APNG_DISPOSE_OP_PREVIOUS, cur, prev, blended);
+        expect_true("empty pre-frame restore yields empty cur", cur.empty());
+        expect_true("empty pre-frame previousBuffer stays empty", prev.empty());
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_apng_dispose_previous_host_test.sh
+++ b/core-render-ohos/src/test/cpp/run_apng_dispose_previous_host_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Compile + run leftover APNG DISPOSE_OP_PREVIOUS host unit tests (no Harmony device).
+#
+# Usage:
+#   ./run_apng_dispose_previous_host_test.sh          # g++ default
+#   ./run_apng_dispose_previous_host_test.sh asan     # Address+UB sanitizers
+#
+# Does not compile APNGStructs.cpp or call OH PixelMap APIs.
+# Host g++/clang++ is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APNG_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/components/apng"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -I"$APNG_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/apng_dispose_previous_host_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/apng_dispose_previous_host_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/apng_dispose_previous_host_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

APNG `disposeOp == 2` (`APNG_DISPOSE_OP_PREVIOUS`) saved into `previousBuffer` before blend, then `HandlePostFrameDisposeOp` did `previousBuffer = curBitmapBuffer` — overwriting the pre-blend snapshot and never restoring `curBitmapBuffer`. Write-only polarity; PREVIOUS dispose was incomplete.

Fix: keep the pre-blend save; after the frame is committed, `curBitmapBuffer = previousBuffer`.

Distinct from #1660 (`reserve` → `resize`).

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_apng_dispose_previous_host_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
