### PR TITLE
fix(ohos): leftover canvas SetFont/processColorStops bare stoi/stof

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/canvas/KRCanvasNumericParse.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/canvas/KRCanvasNumericParse.h
@@ -1,0 +1,96 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_KRCANVASNUMERICPARSE_H
+#define CORE_RENDER_OHOS_KRCANVASNUMERICPARSE_H
+
+#include <string>
+#include <vector>
+
+namespace kuikly {
+namespace util {
+
+// Leftover canvas SetFont / processColorStops helpers. Bare std::stoi /
+// std::stof throw std::invalid_argument on empty or non-numeric tokens
+// ("", "bold", location "abc" from "#f00 abc"). Header-only so host g++
+// can compile without Harmony drawing APIs.
+
+inline bool ParseCanvasFontWeight(const std::string &weight_str, int &out) {
+    if (weight_str.empty()) {
+        return false;
+    }
+    try {
+        out = std::stoi(weight_str);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+inline bool ParseCanvasColorStopLocation(const std::string &location_str, float &out) {
+    if (location_str.empty()) {
+        return false;
+    }
+    try {
+        out = std::stof(location_str);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+// Same split as ConvertSplit (KRConvertUtil.cpp). Host tests cannot compile
+// that translation unit (Harmony headers).
+inline std::vector<std::string> SplitCanvasTokens(const std::string &str, const std::string &delimiters) {
+    std::vector<std::string> result;
+    std::size_t start = 0;
+    std::size_t end = str.find_first_of(delimiters);
+
+    while (end != std::string::npos) {
+        result.push_back(str.substr(start, end - start));
+        start = end + 1;
+        end = str.find_first_of(delimiters, start);
+    }
+
+    result.push_back(str.substr(start));
+    return result;
+}
+
+// Parse leftover canvas "color location,..." list. On a bad location token,
+// skip that stop (do not throw; do not push a mismatched color).
+inline void ProcessCanvasColorStops(const std::string &color_stops_str, std::vector<std::string> &colors,
+                                    std::vector<float> &locations) {
+    const std::vector<std::string> splits = SplitCanvasTokens(color_stops_str, ",");
+    for (const auto &color_stop_str : splits) {
+        if (color_stop_str.empty()) {
+            continue;
+        }
+        const std::vector<std::string> color_and_stop = SplitCanvasTokens(color_stop_str, " ");
+        if (color_and_stop.size() < 2) {
+            continue;
+        }
+        float location = 0.f;
+        if (!ParseCanvasColorStopLocation(color_and_stop[1], location)) {
+            continue;
+        }
+        colors.push_back(color_and_stop[0]);
+        locations.push_back(location);
+    }
+}
+
+}  // namespace util
+}  // namespace kuikly
+
+#endif  // CORE_RENDER_OHOS_KRCANVASNUMERICPARSE_H

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/canvas/KRCanvasView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/canvas/KRCanvasView.cpp
@@ -28,6 +28,7 @@
 #include <native_drawing/drawing_types.h>
 #include <native_drawing/drawing_matrix.h>
 
+#include "KRCanvasNumericParse.h"
 #include "libohos_render/expand/modules/cache/KRMemoryCacheModule.h"
 #include "libohos_render/utils/KRColor.h"
 #include "libohos_render/utils/KRJSONObject.h"
@@ -180,18 +181,11 @@ void KRCanvasView::SetLineDash(const std::string &params) {
 }
 
 void processColorStops(const std::string &colorStopsStr, std::vector<uint32_t> &colors, std::vector<float> &locations) {
-    std::vector<std::string> splits = kuikly::util::ConvertSplit(colorStopsStr, ",");
-
-    for (const auto &colorStopStr : splits) {
-        if (colorStopStr.empty()) {
-            continue;
-        }
-        std::vector<std::string> colorAndStop = kuikly::util::ConvertSplit(colorStopStr, " ");
-        if (colorAndStop.size() < 2) {
-            continue;
-        }
-        colors.push_back(kuikly::util::ConvertToHexColor(colorAndStop[0]));
-        locations.push_back(std::stof(colorAndStop[1]));
+    std::vector<std::string> color_tokens;
+    kuikly::util::ProcessCanvasColorStops(colorStopsStr, color_tokens, locations);
+    colors.reserve(color_tokens.size());
+    for (const auto &color_token : color_tokens) {
+        colors.push_back(kuikly::util::ConvertToHexColor(color_token));
     }
 }
 
@@ -366,11 +360,15 @@ void KRCanvasView::SetTextAlign(const std::string &params) {
 
 void KRCanvasView::SetFont(const std::string &params) {
     auto paramObj = kuikly::util::JSONObject::Parse(params);
+    if (!paramObj) {
+        return;
+    }
     auto size = paramObj->GetNumber("size");
     auto style = paramObj->GetString("style");
-    auto weight = std::stoi(paramObj->GetString("weight"));
     auto family = paramObj->GetString("family");
-    
+    int weight = 0;
+    const bool have_weight = kuikly::util::ParseCanvasFontWeight(paramObj->GetString("weight"), weight);
+
     float scale = 1.0;
     if (auto root = GetRootView().lock()) {
         scale = root->GetContext()->Config()->GetFontWeightScale();
@@ -378,7 +376,9 @@ void KRCanvasView::SetFont(const std::string &params) {
 
     text_feature_.fontSize = size;
     text_feature_.fontStyle = kuikly::util::ConvertToFontStyle(style);
-    text_feature_.fontWeight = kuikly::util::ConvertFontWeight(weight, scale);
+    if (have_weight) {
+        text_feature_.fontWeight = kuikly::util::ConvertFontWeight(weight, scale);
+    }
     text_feature_.fontFamily = family;
 }
 

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_canvas_numeric_parse_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_canvas_numeric_parse_test.cpp
@@ -1,0 +1,158 @@
+// Host unit test for leftover canvas SetFont / processColorStops stoi/stof.
+//
+// Leftover:
+//   SetFont:           auto weight = std::stoi(paramObj->GetString("weight"));
+//   processColorStops: locations.push_back(std::stof(colorAndStop[1]));
+//
+// Empty / non-numeric tokens ("", "bold", location "abc" from "#f00 abc")
+// throw std::invalid_argument. Helpers keep the prior weight / skip that stop.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_kr_canvas_numeric_parse_test.sh
+//   ./run_kr_canvas_numeric_parse_test.sh asan
+
+#include "KRCanvasNumericParse.h"
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void leftover_stoi_throws(const char *name, const std::string &s) {
+    bool threw = false;
+    try {
+        (void)std::stoi(s);
+    } catch (const std::invalid_argument &) {
+        threw = true;
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: leftover stoi threw %s\n", name, e.what());
+        ++g_failed;
+        return;
+    }
+    expect_true(name, threw);
+}
+
+static void leftover_stof_throws(const char *name, const std::string &s) {
+    bool threw = false;
+    try {
+        (void)std::stof(s);
+    } catch (const std::invalid_argument &) {
+        threw = true;
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: leftover stof threw %s\n", name, e.what());
+        ++g_failed;
+        return;
+    }
+    expect_true(name, threw);
+}
+
+static void expect_weight_fail_keep_prior(const char *name, const std::string &s, int prior) {
+    int weight = prior;
+    bool ok = true;
+    try {
+        ok = kuikly::util::ParseCanvasFontWeight(s, weight);
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: threw std::exception: %s\n", name, e.what());
+        ++g_failed;
+        return;
+    } catch (...) {
+        std::fprintf(stderr, "FAIL %s: threw unknown exception\n", name);
+        ++g_failed;
+        return;
+    }
+    if (ok) {
+        std::fprintf(stderr, "FAIL %s: expected parse fail, got weight=%d\n", name, weight);
+        ++g_failed;
+        return;
+    }
+    if (weight != prior) {
+        std::fprintf(stderr, "FAIL %s: prior weight %d overwritten to %d\n", name, prior, weight);
+        ++g_failed;
+        return;
+    }
+    std::printf("PASS %s (keep prior %d, no throw)\n", name, prior);
+}
+
+static void expect_weight_ok(const char *name, const std::string &s, int want) {
+    int weight = -1;
+    bool ok = false;
+    try {
+        ok = kuikly::util::ParseCanvasFontWeight(s, weight);
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: threw std::exception: %s\n", name, e.what());
+        ++g_failed;
+        return;
+    } catch (...) {
+        std::fprintf(stderr, "FAIL %s: threw unknown exception\n", name);
+        ++g_failed;
+        return;
+    }
+    if (!ok || weight != want) {
+        std::fprintf(stderr, "FAIL %s: ok=%d weight=%d want %d\n", name, static_cast<int>(ok), weight, want);
+        ++g_failed;
+        return;
+    }
+    std::printf("PASS %s (weight=%d)\n", name, want);
+}
+
+static void expect_stops(const char *name, const std::string &color_stops, size_t want) {
+    std::vector<std::string> colors;
+    std::vector<float> locations;
+    try {
+        kuikly::util::ProcessCanvasColorStops(color_stops, colors, locations);
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: threw std::exception: %s\n", name, e.what());
+        ++g_failed;
+        return;
+    } catch (...) {
+        std::fprintf(stderr, "FAIL %s: threw unknown exception\n", name);
+        ++g_failed;
+        return;
+    }
+    if (colors.size() != want || locations.size() != want) {
+        std::fprintf(stderr, "FAIL %s: colors=%zu locations=%zu want %zu\n", name, colors.size(), locations.size(),
+                     want);
+        ++g_failed;
+        return;
+    }
+    std::printf("PASS %s (stops=%zu, no throw)\n", name, want);
+}
+
+int main() {
+    // Document leftover abort polarity: bare stoi/stof throw on these tokens.
+    leftover_stoi_throws("leftover stoi(\"\")", "");
+    leftover_stoi_throws("leftover stoi(\"bold\")", "bold");
+    leftover_stof_throws("leftover stof(\"abc\") from #f00 abc", "abc");
+
+    // Required leftover inputs: no invalid_argument abort; defaults / skip.
+    expect_weight_fail_keep_prior("weight \"\"", "", 400);
+    expect_weight_fail_keep_prior("weight \"bold\"", "bold", 700);
+    expect_stops("location \"#f00 abc\"", "#f00 abc", 0);
+
+    // Valid leftover-adjacent production tokens still parse.
+    expect_weight_ok("weight \"400\"", "400", 400);
+    expect_weight_ok("weight \"700\"", "700", 700);
+    expect_stops("valid #f00 0", "#f00 0", 1);
+    expect_stops("valid production pair", "4294901760 0.0,4278255360 1.0", 2);
+
+    // Mixed leftover: skip only the bad stop, keep the rest aligned.
+    expect_stops("mixed skip abc", "#f00 0,#0f0 abc,#00f 1", 2);
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_canvas_numeric_parse_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_canvas_numeric_parse_test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Compile + run leftover canvas SetFont / processColorStops host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_kr_canvas_numeric_parse_test.sh          # g++ default
+#   ./run_kr_canvas_numeric_parse_test.sh asan     # Address+UB sanitizers
+#
+# Parse helpers live in header-only KRCanvasNumericParse.h (no ArkUI).
+# Host g++/clang++ includes it directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CANVAS_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/components/canvas"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$CANVAS_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_canvas_numeric_parse_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_canvas_numeric_parse_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_canvas_numeric_parse_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

Beyond #1654 (Parse-null), canvas still had bare numeric parses:

- `SetFont`: `std::stoi(paramObj->GetString("weight"))` — empty / `"bold"` throws
- `processColorStops`: `std::stof(colorAndStop[1])` — bad location tokens throw

Fix: parse helpers keep prior font weight / skip that color stop on failure. Also keep the Parse-null guard on `SetFont`.

Distinct from #1664 (`KRLinearGradientParser`).

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_canvas_numeric_parse_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
