### PR TITLE
fix(ohos): leftover isEqual2 treating NULL==NULL as unequal

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRCstringEqual.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRCstringEqual.h
@@ -12,22 +12,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef CORE_RENDER_OHOS_KRSTRINGUTIL_H
-#define CORE_RENDER_OHOS_KRSTRINGUTIL_H
-#include <string>
-#include <vector>
-#include "KRCstringEqual.h"
-#include "libohos_render/foundation/KRCommon.h"
+#ifndef CORE_RENDER_OHOS_KRCSTRINGEQUAL_H
+#define CORE_RENDER_OHOS_KRCSTRINGEQUAL_H
+
+#include <cstring>
 
 namespace kuikly {
 namespace util {
-std::vector<std::string_view> SplitStringView(const std::string_view &str, std::string separator);
-std::vector<std::string> SplitString(const std::string &str, std::string separator);
 
-bool isEqual(const std::string &str1, const char *str2);
-
-std::vector<KRAnyValue> SplitString(const std::string &str, char delimiter);
+// C-string equality with NULL polarity: both-null is equal, xor-null is not.
+// Header-only so host tests can compile without Harmony NDK headers.
+inline bool isEqual2(const char *str1, const char *str2) {
+    if (!str1 || !str2) {
+        return str1 == str2;
+    }
+    return std::strcmp(str1, str2) == 0;
+}
 
 }  // namespace util
 }  // namespace kuikly
-#endif  // CORE_RENDER_OHOS_KRSTRINGUTIL_H
+
+#endif  // CORE_RENDER_OHOS_KRCSTRINGEQUAL_H

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRStringUtil.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRStringUtil.cpp
@@ -55,17 +55,6 @@ std::vector<std::string> SplitString(const std::string &str, std::string separat
     return result;
 }
 
-bool isEqual2(const char *str1, const char *str2) {
-    if ((str1 == NULL && str2) || (str1 && str2 == NULL) || (str1 == NULL && str2 == NULL)) {
-        return false;
-    }
-    if (std::strcmp(str1, str2) == 0) {
-        return true;
-    } else {
-        return false;
-    }
-}
-
 bool isEqual(const std::string &str1, const char *str2) {
     return isEqual2(str1.c_str(), str2);
 }

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_isequal2_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_isequal2_test.cpp
@@ -1,0 +1,50 @@
+// Host unit test for leftover isEqual2 NULL==NULL polarity.
+//
+// Production isEqual2 treated both-null as unequal. Both-null is now
+// equal; xor-null is not; otherwise strcmp. KRCstringEqual.h is
+// header-only (no Harmony NDK), so host g++/clang++ is enough.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_kr_isequal2_test.sh
+//   ./run_kr_isequal2_test.sh asan
+
+#include "KRCstringEqual.h"
+
+#include <cstdio>
+
+using kuikly::util::isEqual2;
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void check_pair(const char *label, const char *a, const char *b, bool want) {
+    expect_true(label, isEqual2(a, b) == want);
+}
+
+int main() {
+    // Required leftover polarity.
+    check_pair("isEqual2(nullptr, nullptr) == true", nullptr, nullptr, true);
+    check_pair("isEqual2(nullptr, \"a\") == false", nullptr, "a", false);
+    check_pair("isEqual2(\"a\", nullptr) == false", "a", nullptr, false);
+    check_pair("isEqual2(\"a\", \"a\") == true", "a", "a", true);
+
+    // Extra strcmp / empty cases.
+    check_pair("isEqual2(\"a\", \"b\") == false", "a", "b", false);
+    check_pair("isEqual2(\"\", \"\") == true", "", "", true);
+    check_pair("isEqual2(\"\", nullptr) == false", "", nullptr, false);
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_isequal2_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_isequal2_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Compile + run leftover isEqual2 NULL==NULL host tests (no Harmony device).
+#
+# Usage:
+#   ./run_kr_isequal2_test.sh          # g++ default
+#   ./run_kr_isequal2_test.sh asan     # Address+UB sanitizers
+#
+# KRCstringEqual.h is header-only and has no OHOS APIs. Host g++/clang++
+# includes it directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UTIL_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/utils"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$UTIL_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_isequal2_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_isequal2_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_isequal2_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"

--- a/ohosApp/entry/src/main/cpp/napi_init.cpp
+++ b/ohosApp/entry/src/main/cpp/napi_init.cpp
@@ -125,14 +125,10 @@ static napi_value SetResfileDir(napi_env env, napi_callback_info info) {
 }
 
 static bool isEqual2(const char *str1, const char *str2) {
-    if ((str1 == NULL && str2) || (str1 && str2 == NULL) || (str1 == NULL && str2 == NULL)) {
-        return false;
+    if (!str1 || !str2) {
+        return str1 == str2;
     }
-    if (std::strcmp(str1, str2) == 0) {
-        return true;
-    } else {
-        return false;
-    }
+    return std::strcmp(str1, str2) == 0;
 }
 
 static bool isEqual(const std::string &str1, const char *str2) {


### PR DESCRIPTION
## leftover

`isEqual2` treated both-null as unequal:

```cpp
if ((str1 == NULL && str2) || (str1 && str2 == NULL) || (str1 == NULL && str2 == NULL)) {
    return false;
}
```

Fix: both-null → true; xor-null → false; else `strcmp`. Shared via `KRCstringEqual.h`; also fixed the duplicate in `ohosApp/entry/.../napi_init.cpp`.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_isequal2_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
