### PR TITLE
fix(ohos): leftover GetSelectedContent start/end clamp before substr

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
@@ -29,6 +29,7 @@
 #include "libohos_render/expand/components/base/KRCustomUserCallback.h"
 #include "libohos_render/expand/components/richtext/KRCustomEmojiPixmapCache.h"
 #include "libohos_render/expand/components/richtext/KRRichTextShadow.h"
+#include "libohos_render/expand/components/richtext/KRSelectedContentClamp.h"
 #include "libohos_render/foundation/KRConfig.h"
 #include "libohos_render/foundation/thread/KRMainThread.h"
 #include "libohos_render/foundation/KRPoint.h"
@@ -754,24 +755,15 @@ KRParagraphInfo KRRichTextView::GetParagraphInfo() {
 
 std::string KRRichTextView::GetSelectedContent(std::string &pre, std::string &post) {
     std::u16string str16 = utf8_to_utf16(selection_rects_.text_content);
-
-    if (selection_rects_.start > 0) {
-        std::u16string pre_u16 = str16.substr(0, selection_rects_.start);
-        pre = utf16_to_utf8(pre_u16);
+    const auto parts =
+        kuikly::util::SliceSelectedUtf16Content(str16, selection_rects_.start, selection_rects_.end);
+    if (!parts.pre.empty()) {
+        pre = utf16_to_utf8(parts.pre);
     }
-    size_t sel_end = static_cast<size_t>(selection_rects_.end);
-    if (sel_end > str16.size()) {
-        sel_end = str16.size();
+    if (!parts.post.empty()) {
+        post = utf16_to_utf8(parts.post);
     }
-    std::u16string selected_u16 = str16.substr(selection_rects_.start, sel_end - selection_rects_.start);
-    std::string selected_u8 = utf16_to_utf8(selected_u16);
-
-    if (sel_end < str16.size()) {
-        std::u16string post_u16 = str16.substr(sel_end);
-        post = utf16_to_utf8(post_u16);
-    }
-
-    return selected_u8;
+    return utf16_to_utf8(parts.selected);
 }
 
 bool KRRichTextView::UpdateSelection(std::shared_ptr<IKRRenderViewExport> ancestor_view, KRPoint ancestor_point1,

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRSelectedContentClamp.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRSelectedContentClamp.h
@@ -1,0 +1,72 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_KRSELECTEDCONTENTCLAMP_H
+#define CORE_RENDER_OHOS_KRSELECTEDCONTENTCLAMP_H
+
+#include <cstddef>
+#include <string>
+#include <utility>
+
+namespace kuikly {
+namespace util {
+
+// Leftover GetSelectedContent only clamped `end`. `start > size` throws
+// std::out_of_range from substr; `start > end` underflows size_t on
+// (sel_end - start). Header-only so host g++ can compile without ArkUI.
+
+inline size_t ClampUtf16Index(int index, size_t size) {
+    if (index <= 0) {
+        return 0;
+    }
+    const size_t value = static_cast<size_t>(index);
+    return value > size ? size : value;
+}
+
+// Clamp start/end into [0, size] and force start <= end so later
+// substr(start, end - start) and substr(0, start) cannot throw or wrap.
+inline std::pair<size_t, size_t> ClampSelectedUtf16Range(int start, int end, size_t size) {
+    size_t sel_start = ClampUtf16Index(start, size);
+    size_t sel_end = ClampUtf16Index(end, size);
+    if (sel_start > sel_end) {
+        sel_start = sel_end;
+    }
+    return {sel_start, sel_end};
+}
+
+struct KRSelectedContentParts {
+    std::u16string pre;
+    std::u16string selected;
+    std::u16string post;
+};
+
+inline KRSelectedContentParts SliceSelectedUtf16Content(const std::u16string &str16, int start, int end) {
+    const auto [sel_start, sel_end] = ClampSelectedUtf16Range(start, end, str16.size());
+
+    KRSelectedContentParts parts;
+    if (sel_start > 0) {
+        parts.pre = str16.substr(0, sel_start);
+    }
+    parts.selected = str16.substr(sel_start, sel_end - sel_start);
+    if (sel_end < str16.size()) {
+        parts.post = str16.substr(sel_end);
+    }
+    return parts;
+}
+
+}  // namespace util
+}  // namespace kuikly
+
+#endif  // CORE_RENDER_OHOS_KRSELECTEDCONTENTCLAMP_H

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_selected_content_clamp_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_selected_content_clamp_test.cpp
@@ -1,0 +1,160 @@
+// Host unit test for leftover KRRichTextView::GetSelectedContent start/end OOB.
+//
+// Leftover:
+//   only clamps end; then
+//     pre      = str16.substr(0, start)
+//     selected = str16.substr(start, sel_end - start)
+//   start > size  → std::out_of_range
+//   start > end   → size_t underflow on (sel_end - start)
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_kr_selected_content_clamp_test.sh
+//   ./run_kr_selected_content_clamp_test.sh asan
+
+#include "KRSelectedContentClamp.h"
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+// Mirror leftover GetSelectedContent: clamp end only, then substr.
+static std::u16string leftover_selected(const std::u16string &str16, int start, int end) {
+    size_t sel_end = static_cast<size_t>(end);
+    if (sel_end > str16.size()) {
+        sel_end = str16.size();
+    }
+    return str16.substr(static_cast<size_t>(start), sel_end - static_cast<size_t>(start));
+}
+
+static std::u16string leftover_pre(const std::u16string &str16, int start) {
+    if (start > 0) {
+        return str16.substr(0, static_cast<size_t>(start));
+    }
+    return {};
+}
+
+static void leftover_start_gt_length_throws(const char *name, const std::u16string &str16, int start, int end) {
+    bool threw = false;
+    try {
+        (void)leftover_selected(str16, start, end);
+    } catch (const std::out_of_range &) {
+        threw = true;
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: leftover substr threw %s\n", name, e.what());
+        ++g_failed;
+        return;
+    }
+    expect_true(name, threw);
+}
+
+// leftover pre uses substr(0, start): pos is 0 so start>size does not throw
+// (count is truncated). Clamp still keeps pre aligned with the selected range.
+static void leftover_pre_start_gt_length_truncates(const char *name, const std::u16string &str16, int start) {
+    std::u16string pre;
+    try {
+        pre = leftover_pre(str16, start);
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: leftover pre substr threw %s\n", name, e.what());
+        ++g_failed;
+        return;
+    }
+    expect_true(name, pre == str16);
+}
+
+static void leftover_inverted_underflow(const char *name, int start, int end) {
+    const size_t sel_start = static_cast<size_t>(start);
+    size_t sel_end = static_cast<size_t>(end);
+    const size_t wrapped = sel_end - sel_start;
+    expect_true(name, start > end && wrapped > static_cast<size_t>(start));
+}
+
+static void expect_slice(const char *name, const std::u16string &str16, int start, int end,
+                         const std::u16string &want_pre, const std::u16string &want_selected,
+                         const std::u16string &want_post) {
+    kuikly::util::KRSelectedContentParts parts;
+    try {
+        parts = kuikly::util::SliceSelectedUtf16Content(str16, start, end);
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: threw std::exception: %s\n", name, e.what());
+        ++g_failed;
+        return;
+    } catch (...) {
+        std::fprintf(stderr, "FAIL %s: threw unknown exception\n", name);
+        ++g_failed;
+        return;
+    }
+    if (parts.pre != want_pre || parts.selected != want_selected || parts.post != want_post) {
+        std::fprintf(stderr, "FAIL %s: pre=%zu selected=%zu post=%zu\n", name, parts.pre.size(),
+                     parts.selected.size(), parts.post.size());
+        ++g_failed;
+        return;
+    }
+    std::printf("PASS %s (selected=%zu, no throw)\n", name, parts.selected.size());
+}
+
+static void expect_range(const char *name, int start, int end, size_t size, size_t want_start, size_t want_end) {
+    std::pair<size_t, size_t> range;
+    try {
+        range = kuikly::util::ClampSelectedUtf16Range(start, end, size);
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: threw std::exception: %s\n", name, e.what());
+        ++g_failed;
+        return;
+    } catch (...) {
+        std::fprintf(stderr, "FAIL %s: threw unknown exception\n", name);
+        ++g_failed;
+        return;
+    }
+    if (range.first != want_start || range.second != want_end || range.first > range.second ||
+        range.second > size) {
+        std::fprintf(stderr, "FAIL %s: got [%zu, %zu) want [%zu, %zu) size=%zu\n", name, range.first,
+                     range.second, want_start, want_end, size);
+        ++g_failed;
+        return;
+    }
+    std::printf("PASS %s ([%zu, %zu))\n", name, range.first, range.second);
+}
+
+int main() {
+    const std::u16string hello = u"hello";  // size 5
+    const std::u16string empty;
+
+    // Document leftover abort / wrap polarity.
+    leftover_start_gt_length_throws("leftover start>length throws", hello, 10, 12);
+    leftover_pre_start_gt_length_truncates("leftover pre start>length truncates", hello, 10);
+    leftover_inverted_underflow("leftover (5,3) size_t underflow", 5, 3);
+
+    // Required leftover inputs: empty/clamped, no out_of_range.
+    expect_range("clamp (5,3) size=5", 5, 3, 5, 3, 3);
+    expect_slice("(5,3) on hello", hello, 5, 3, u"hel", u"", u"lo");
+    expect_range("clamp start>length", 10, 12, 5, 5, 5);
+    expect_slice("start>length on hello", hello, 10, 12, u"hello", u"", u"");
+    expect_slice("pre path start>length", hello, 10, 3, u"hel", u"", u"lo");
+
+    // Adjacent valid / edge ranges still slice.
+    expect_slice("valid [1,4)", hello, 1, 4, u"h", u"ell", u"o");
+    expect_slice("full [0,5)", hello, 0, 5, u"", u"hello", u"");
+    expect_slice("empty [2,2)", hello, 2, 2, u"he", u"", u"llo");
+    expect_slice("end>length", hello, 2, 99, u"he", u"llo", u"");
+    expect_slice("negative start/end", hello, -1, -2, u"", u"", u"hello");
+    expect_slice("empty string (5,3)", empty, 5, 3, u"", u"", u"");
+    expect_slice("empty string start>length", empty, 1, 2, u"", u"", u"");
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_selected_content_clamp_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_selected_content_clamp_test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Compile + run leftover GetSelectedContent start/end clamp host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_kr_selected_content_clamp_test.sh          # g++ default
+#   ./run_kr_selected_content_clamp_test.sh asan     # Address+UB sanitizers
+#
+# Clamp helper lives in header-only KRSelectedContentClamp.h (no ArkUI).
+# Host g++/clang++ includes it directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RICHTEXT_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/components/richtext"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$RICHTEXT_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_selected_content_clamp_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_selected_content_clamp_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_selected_content_clamp_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`KRRichTextView::GetSelectedContent` only clamped `end`. If `start > str16.size()`, `substr(start, …)` throws `std::out_of_range`; if `start > end`, `sel_end - start` underflows `size_t`.

Fix: clamp both into `[0, size]` and force `start <= end` before slicing. Logic in `KRSelectedContentClamp.h` for host tests.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_selected_content_clamp_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
