### PR TITLE
fix(ohos): leftover KRImageView SetCapInsets bare stof

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRCapInsetsParse.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRCapInsetsParse.h
@@ -1,0 +1,82 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_KRCAPINSETSPARSE_H
+#define CORE_RENDER_OHOS_KRCAPINSETSPARSE_H
+
+#include <string>
+#include <vector>
+
+namespace kuikly {
+namespace util {
+
+// Leftover KRImageView::SetCapInsets helpers. ConvertSplit already checks
+// items.size() >= 4 (unlike #1663 short-prop OOB), but tokens still used
+// bare std::stof. Non-numeric tokens ("a", "x") throw std::invalid_argument.
+// Sibling SetColorFilter already try/catches stof and stores 0 on failure.
+// Header-only so host g++ can compile without Harmony / ArkUI.
+
+inline float ParseCapInsetFloat(const std::string &token) {
+    try {
+        return std::stof(token);
+    } catch (...) {
+        return 0.f;
+    }
+}
+
+// Same split as ConvertSplit (KRConvertUtil.cpp). Host tests cannot compile
+// that translation unit (Harmony headers).
+inline std::vector<std::string> SplitCapInsetTokens(const std::string &str, const std::string &delimiters) {
+    std::vector<std::string> result;
+    std::size_t start = 0;
+    std::size_t end = str.find_first_of(delimiters);
+
+    while (end != std::string::npos) {
+        result.push_back(str.substr(start, end - start));
+        start = end + 1;
+        end = str.find_first_of(delimiters, start);
+    }
+
+    result.push_back(str.substr(start));
+    return result;
+}
+
+struct KRCapInsetsValue {
+    float top = 0.f;
+    float left = 0.f;
+    float bottom = 0.f;
+    float right = 0.f;
+};
+
+// Parse leftover capInsets "top left bottom right".
+// Policy: size < 4 → return false (do not write outs, same skip as today).
+// size >= 4 → parse each token with try/catch; on failure that inset is 0
+// (SetColorFilter sibling). Return true so the caller still applies lattice.
+inline bool ParseCapInsets4(const std::string &value, KRCapInsetsValue &out) {
+    const std::vector<std::string> items = SplitCapInsetTokens(value, " ");
+    if (items.size() < 4) {
+        return false;
+    }
+    out.top = ParseCapInsetFloat(items[0]);
+    out.left = ParseCapInsetFloat(items[1]);
+    out.bottom = ParseCapInsetFloat(items[2]);
+    out.right = ParseCapInsetFloat(items[3]);
+    return true;
+}
+
+}  // namespace util
+}  // namespace kuikly
+
+#endif  // CORE_RENDER_OHOS_KRCAPINSETSPARSE_H

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.cpp
@@ -15,7 +15,7 @@
 
 #include "libohos_render/expand/components/image/KRImageView.h"
 
-#include "KRCapInsetsParse.h"
+#include "libohos_render/expand/components/image/KRCapInsetsParse.h"
 #include <deviceinfo.h>
 #include <resourcemanager/ohresmgr.h>
 #include <sstream>

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/image/KRImageView.cpp
@@ -15,6 +15,7 @@
 
 #include "libohos_render/expand/components/image/KRImageView.h"
 
+#include "KRCapInsetsParse.h"
 #include <deviceinfo.h>
 #include <resourcemanager/ohresmgr.h>
 #include <sstream>
@@ -451,8 +452,8 @@ bool KRImageView::SetCapInsets(const KRAnyValue &value) {
         kuikly::util::ResetArkUIImageCapInsets(GetNode());
         return true;
     }
-    std::vector<std::string> items = kuikly::util::ConvertSplit(valueStr, " ");
-    if (items.size() >= 4) {
+    kuikly::util::KRCapInsetsValue insets;
+    if (kuikly::util::ParseCapInsets4(valueStr, insets)) {
         // 单位约定：SetProp 阶段拿到的 top/left/bottom/right 单位就是**图片 vp**
         // 只记录 capInsets 数据，不在此处直接下发到 ArkUI：
         //   * lattice 精确九宫格（API 24+）依赖图片的真实像素分辨率来把 vp 边距
@@ -462,11 +463,15 @@ bool KRImageView::SetCapInsets(const KRAnyValue &value) {
         //
         // 真正下发在 FireOnImageCompleteEvent 里拿到 loaded_image_size_ 之后执行；
         // 因此这里必须确保 NODE_IMAGE_ON_COMPLETE 事件已注册，否则永远拿不到分辨率。
+        //
+        // Leftover: size was already checked (>=4) but tokens used bare stof.
+        // ParseCapInsets4 try/catches each token; a non-numeric inset is 0
+        // (SetColorFilter sibling). Lattice / FireOnImageComplete unchanged.
         has_cap_insets_ = true;
-        cap_insets_top_ = std::stof(items[0]);
-        cap_insets_left_ = std::stof(items[1]);
-        cap_insets_bottom_ = std::stof(items[2]);
-        cap_insets_right_ = std::stof(items[3]);
+        cap_insets_top_ = insets.top;
+        cap_insets_left_ = insets.left;
+        cap_insets_bottom_ = insets.bottom;
+        cap_insets_right_ = insets.right;
         EnsureLoadCompleteEventRegistered();
         // 兜底：capInsets 在 src 之后到达、且 src 已经加载完成的场景（例如 base64
         // 命中缓存的同步路径），此时 has_loaded_image_ 已是 true，可以立即下发。

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_cap_insets_parse_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_cap_insets_parse_test.cpp
@@ -1,0 +1,116 @@
+// Host unit test for leftover KRImageView::SetCapInsets bare std::stof.
+//
+// Leftover:
+//   items = ConvertSplit(valueStr, " ");
+//   if (items.size() >= 4) {
+//       cap_insets_* = std::stof(items[0..3]);
+//   }
+//
+// Size is already checked (unlike #1663), but non-numeric tokens
+// ("a b c d", "1 x 3 4") still throw std::invalid_argument. Policy: on
+// stof failure that inset is 0; size < 4 skips apply (same as today).
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_kr_cap_insets_parse_test.sh
+//   ./run_kr_cap_insets_parse_test.sh asan
+
+#include "KRCapInsetsParse.h"
+
+#include <cmath>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+static int g_failed = 0;
+
+static bool floats_eq(float a, float b) {
+    return std::fabs(a - b) <= 0.0001f;
+}
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void leftover_stof_throws(const char *name, const std::string &s) {
+    bool threw = false;
+    try {
+        (void)std::stof(s);
+    } catch (const std::invalid_argument &) {
+        threw = true;
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: leftover stof threw %s\n", name, e.what());
+        ++g_failed;
+        return;
+    }
+    expect_true(name, threw);
+}
+
+static void expect_parse(const char *name, const std::string &value, bool want_applied, float top, float left,
+                         float bottom, float right) {
+    kuikly::util::KRCapInsetsValue insets;
+    insets.top = -1.f;
+    insets.left = -1.f;
+    insets.bottom = -1.f;
+    insets.right = -1.f;
+    bool applied = false;
+    try {
+        applied = kuikly::util::ParseCapInsets4(value, insets);
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: threw std::exception: %s\n", name, e.what());
+        ++g_failed;
+        return;
+    } catch (...) {
+        std::fprintf(stderr, "FAIL %s: threw unknown exception\n", name);
+        ++g_failed;
+        return;
+    }
+    if (applied != want_applied) {
+        std::fprintf(stderr, "FAIL %s: applied=%d want %d\n", name, static_cast<int>(applied),
+                     static_cast<int>(want_applied));
+        ++g_failed;
+        return;
+    }
+    if (!want_applied) {
+        if (!floats_eq(insets.top, -1.f) || !floats_eq(insets.left, -1.f) || !floats_eq(insets.bottom, -1.f) ||
+            !floats_eq(insets.right, -1.f)) {
+            std::fprintf(stderr, "FAIL %s: size<4 wrote outs top=%.4f left=%.4f bottom=%.4f right=%.4f\n", name,
+                         insets.top, insets.left, insets.bottom, insets.right);
+            ++g_failed;
+            return;
+        }
+        std::printf("PASS %s (skip apply, no throw)\n", name);
+        return;
+    }
+    if (!floats_eq(insets.top, top) || !floats_eq(insets.left, left) || !floats_eq(insets.bottom, bottom) ||
+        !floats_eq(insets.right, right)) {
+        std::fprintf(stderr, "FAIL %s: got (%.4f %.4f %.4f %.4f) want (%.4f %.4f %.4f %.4f)\n", name, insets.top,
+                     insets.left, insets.bottom, insets.right, top, left, bottom, right);
+        ++g_failed;
+        return;
+    }
+    std::printf("PASS %s (%.4g %.4g %.4g %.4g, no throw)\n", name, insets.top, insets.left, insets.bottom,
+                insets.right);
+}
+
+int main() {
+    leftover_stof_throws("leftover stof(\"a\")", "a");
+    leftover_stof_throws("leftover stof(\"x\")", "x");
+
+    // Required leftover inputs: no invalid_argument abort.
+    expect_parse("\"a b c d\"", "a b c d", true, 0.f, 0.f, 0.f, 0.f);
+    expect_parse("\"1 x 3 4\"", "1 x 3 4", true, 1.f, 0.f, 3.f, 4.f);
+    expect_parse("\"1 2 3\" (size<4)", "1 2 3", false, 0.f, 0.f, 0.f, 0.f);
+    expect_parse("\"1 2 3 4\"", "1 2 3 4", true, 1.f, 2.f, 3.f, 4.f);
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_cap_insets_parse_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_cap_insets_parse_test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Compile + run leftover KRImageView::SetCapInsets host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_kr_cap_insets_parse_test.sh          # g++ default
+#   ./run_kr_cap_insets_parse_test.sh asan     # Address+UB sanitizers
+#
+# Parse helpers live in header-only KRCapInsetsParse.h (no ArkUI).
+# Host g++/clang++ includes it directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+IMAGE_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/components/image"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$IMAGE_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_cap_insets_parse_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_cap_insets_parse_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_cap_insets_parse_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`KRImageView::SetCapInsets` already guards `items.size() >= 4`, but still used bare `std::stof` on each token. Non-numeric leftovers (`"a b c d"`, `"1 x 3 4"`) throw `std::invalid_argument`. Sibling `SetColorFilter` already try/catches `stof`.

Fix: parse each token with try/catch (0 on failure). Logic in `KRCapInsetsParse.h` for host tests. Lattice / `FireOnImageComplete` unchanged.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_cap_insets_parse_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
