### PR TITLE
fix(ohos): leftover KRNodeAnimation parseAnimation split OOB + bare stoi/stof

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/base/animation/KRNodeAnimation.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/base/animation/KRNodeAnimation.h
@@ -18,10 +18,10 @@
 
 #include "libohos_render/expand/components/base/KRBasePropsHandler.h"
 #include "libohos_render/expand/components/base/animation/IKRNodeAnimation.h"
+#include "libohos_render/expand/components/base/animation/KRNodeAnimationParse.h"
 #include "libohos_render/expand/components/base/animation/KRNodeNativeAnimationV2.h"
 #include "libohos_render/expand/components/base/animation/KRNodePlainAnimation.h"
 #include "libohos_render/expand/components/base/animation/KRNodeSpringAnimation.h"
-#include "libohos_render/utils/KRConvertUtil.h"
 #include "libohos_render/utils/KRRenderLoger.h"
 
 class KRNodeAnimation : public IKRNodeAnimation {
@@ -213,16 +213,6 @@ class KRNodeAnimation : public IKRNodeAnimation {
 #endif
 
  private:
-    // 动画配置字符串中各个属性的位置索引，空格分割
-    static const int ANIMATION_TYPE_INDEX = 0;
-    static const int TIMING_FUNC_TYPE_INDEX = 1;
-    static const int DURATION_INDEX = 2;
-    static const int DAMPING_INDEX = 3;
-    static const int VELOCITY_INDEX = 4;
-    static const int DELAY_INDEX = 5;
-    static const int REPEAT_INDEX = 6;
-    static const int ANIMATION_KEY_INDEX = 7;
-
     KRNodeAnimationOperationEndCallback operationCallback_;
 
     /**
@@ -230,23 +220,17 @@ class KRNodeAnimation : public IKRNodeAnimation {
      * @param animation
      */
     void parseAnimation(const std::string &animation) {
-        std::vector<std::string> animationSpilt = kuikly::util::ConvertSplit(animation, " ");
-        animationType = std::stoi(animationSpilt[ANIMATION_TYPE_INDEX]);
-        timingFuncType = std::stoi(animationSpilt[TIMING_FUNC_TYPE_INDEX]);
-        duration = std::stof(animationSpilt[DURATION_INDEX]);
-        damping = std::stof(animationSpilt[DAMPING_INDEX]);
-        velocity = std::stof(animationSpilt[VELOCITY_INDEX]);
-        // 兼容旧版本
-        if (animationSpilt.size() > DELAY_INDEX) {
-            delay = std::stof(animationSpilt[DELAY_INDEX]);
-        }
-        if (animationSpilt.size() > REPEAT_INDEX) {
-            repeatForever = std::stoi(animationSpilt[REPEAT_INDEX]) == 1;
-        }
-        if (animationSpilt.size() > ANIMATION_KEY_INDEX) {
-            animationKey = animationSpilt[ANIMATION_KEY_INDEX];
-        }
-        nativeV2 = KRNodeNativeAnimationV2::Parse(animationSpilt);
+        const auto parsed = kuikly::util::ParseNodeAnimation(animation);
+        animationType = parsed.animationType;
+        timingFuncType = parsed.timingFuncType;
+        duration = parsed.duration;
+        damping = parsed.damping;
+        velocity = parsed.velocity;
+        delay = parsed.delay;
+        repeatForever = parsed.repeatForever;
+        animationKey = parsed.animationKey;
+        // Keep upstream NativeAnimationV2 tokens (feat #1633) after safe base-field parse.
+        nativeV2 = KRNodeNativeAnimationV2::Parse(kuikly::util::SplitAnimationTokens(animation, " "));
     }
 
     /**

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/base/animation/KRNodeAnimationParse.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/base/animation/KRNodeAnimationParse.h
@@ -1,0 +1,133 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_KRNODEANIMATIONPARSE_H
+#define CORE_RENDER_OHOS_KRNODEANIMATIONPARSE_H
+
+#include <string>
+#include <vector>
+
+namespace kuikly {
+namespace util {
+
+// Space-split animation config indices. Same leftover layout as
+// KRNodeAnimation::parseAnimation.
+constexpr int kAnimationTypeIndex = 0;
+constexpr int kTimingFuncTypeIndex = 1;
+constexpr int kDurationIndex = 2;
+constexpr int kDampingIndex = 3;
+constexpr int kVelocityIndex = 4;
+constexpr int kDelayIndex = 5;
+constexpr int kRepeatIndex = 6;
+constexpr int kAnimationKeyIndex = 7;
+
+// Parsed fields. Defaults match KRNodeAnimation member initializers (0 / "").
+struct KRNodeAnimationParsed {
+    int animationType = 0;
+    int timingFuncType = 0;
+    float duration = 0;
+    float damping = 0;
+    float velocity = 0;
+    float delay = 0;
+    bool repeatForever = false;
+    std::string animationKey;
+};
+
+// Same split as ConvertSplit (KRConvertUtil.cpp). Host tests cannot compile
+// that translation unit (Harmony / ArkUI headers).
+inline std::vector<std::string> SplitAnimationTokens(const std::string &str, const std::string &delimiters) {
+    std::vector<std::string> result;
+    std::size_t start = 0;
+    std::size_t end = str.find_first_of(delimiters);
+
+    while (end != std::string::npos) {
+        result.push_back(str.substr(start, end - start));
+        start = end + 1;
+        end = str.find_first_of(delimiters, start);
+    }
+
+    result.push_back(str.substr(start));
+    return result;
+}
+
+inline bool ParseAnimationIntToken(const std::string &token, int &out) {
+    try {
+        out = std::stoi(token);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+inline bool ParseAnimationFloatToken(const std::string &token, float &out) {
+    try {
+        out = std::stof(token);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+// Leftover parseAnimation: short strings ("", "0", "1 2", "a b c") used to
+// OOB-index or throw std::invalid_argument via bare stoi/stof. Require 5
+// tokens before touching [0]..[4]. On a bad numeric token, keep default 0
+// and skip that field. Delay / repeat / key keep their size() guards.
+inline KRNodeAnimationParsed ParseNodeAnimation(const std::string &animation) {
+    KRNodeAnimationParsed parsed;
+    const std::vector<std::string> animationSpilt = SplitAnimationTokens(animation, " ");
+    if (animationSpilt.size() <= static_cast<std::size_t>(kVelocityIndex)) {
+        return parsed;
+    }
+
+    int int_value = 0;
+    float float_value = 0;
+
+    if (ParseAnimationIntToken(animationSpilt[kAnimationTypeIndex], int_value)) {
+        parsed.animationType = int_value;
+    }
+    if (ParseAnimationIntToken(animationSpilt[kTimingFuncTypeIndex], int_value)) {
+        parsed.timingFuncType = int_value;
+    }
+    if (ParseAnimationFloatToken(animationSpilt[kDurationIndex], float_value)) {
+        parsed.duration = float_value;
+    }
+    if (ParseAnimationFloatToken(animationSpilt[kDampingIndex], float_value)) {
+        parsed.damping = float_value;
+    }
+    if (ParseAnimationFloatToken(animationSpilt[kVelocityIndex], float_value)) {
+        parsed.velocity = float_value;
+    }
+
+    // Compatible with older animation strings that omit trailing fields.
+    if (animationSpilt.size() > static_cast<std::size_t>(kDelayIndex)) {
+        if (ParseAnimationFloatToken(animationSpilt[kDelayIndex], float_value)) {
+            parsed.delay = float_value;
+        }
+    }
+    if (animationSpilt.size() > static_cast<std::size_t>(kRepeatIndex)) {
+        if (ParseAnimationIntToken(animationSpilt[kRepeatIndex], int_value)) {
+            parsed.repeatForever = int_value == 1;
+        }
+    }
+    if (animationSpilt.size() > static_cast<std::size_t>(kAnimationKeyIndex)) {
+        parsed.animationKey = animationSpilt[kAnimationKeyIndex];
+    }
+    return parsed;
+}
+
+}  // namespace util
+}  // namespace kuikly
+
+#endif  // CORE_RENDER_OHOS_KRNODEANIMATIONPARSE_H

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_node_animation_parse_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_node_animation_parse_test.cpp
@@ -1,0 +1,153 @@
+// Host unit test for leftover KRNodeAnimation::parseAnimation split OOB + bare stoi/stof.
+//
+// Leftover:
+//   auto animationSpilt = kuikly::util::ConvertSplit(animation, " ");
+//   animationType = std::stoi(animationSpilt[ANIMATION_TYPE_INDEX]); // 0
+//   ...
+//   velocity = std::stof(animationSpilt[VELOCITY_INDEX]); // 4
+//   // only DELAY_INDEX / REPEAT_INDEX / ANIMATION_KEY_INDEX had size() guards
+//
+// Short strings ("", "0", "1 2", "a b c") OOB-index or throw std::invalid_argument.
+// Non-numeric 5-token strings ("x y z q w") throw on bare stoi/stof.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_kr_node_animation_parse_test.sh
+//   ./run_kr_node_animation_parse_test.sh asan
+
+#include "KRNodeAnimationParse.h"
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+static int g_failed = 0;
+
+static bool is_default(const kuikly::util::KRNodeAnimationParsed &p) {
+    return p.animationType == 0 && p.timingFuncType == 0 && p.duration == 0.f && p.damping == 0.f && p.velocity == 0.f &&
+           p.delay == 0.f && !p.repeatForever && p.animationKey.empty();
+}
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void leftover_stoi_throws(const char *name, const std::string &s) {
+    bool threw = false;
+    try {
+        (void)std::stoi(s);
+    } catch (const std::invalid_argument &) {
+        threw = true;
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: leftover stoi threw %s\n", name, e.what());
+        ++g_failed;
+        return;
+    }
+    expect_true(name, threw);
+}
+
+static void leftover_stof_throws(const char *name, const std::string &s) {
+    bool threw = false;
+    try {
+        (void)std::stof(s);
+    } catch (const std::invalid_argument &) {
+        threw = true;
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: leftover stof threw %s\n", name, e.what());
+        ++g_failed;
+        return;
+    }
+    expect_true(name, threw);
+}
+
+static kuikly::util::KRNodeAnimationParsed parse_no_throw(const char *name, const std::string &animation) {
+    try {
+        return kuikly::util::ParseNodeAnimation(animation);
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: threw std::exception: %s\n", name, e.what());
+        ++g_failed;
+        return {};
+    } catch (...) {
+        std::fprintf(stderr, "FAIL %s: threw unknown exception\n", name);
+        ++g_failed;
+        return {};
+    }
+}
+
+static void expect_defaults(const char *name, const std::string &animation) {
+    const auto parsed = parse_no_throw(name, animation);
+    if (!is_default(parsed)) {
+        std::fprintf(stderr,
+                     "FAIL %s: expected defaults, got type=%d timing=%d duration=%f damping=%f velocity=%f delay=%f "
+                     "repeat=%d key=%s\n",
+                     name, parsed.animationType, parsed.timingFuncType, static_cast<double>(parsed.duration),
+                     static_cast<double>(parsed.damping), static_cast<double>(parsed.velocity),
+                     static_cast<double>(parsed.delay), static_cast<int>(parsed.repeatForever),
+                     parsed.animationKey.c_str());
+        ++g_failed;
+        return;
+    }
+    std::printf("PASS %s (defaults, no throw)\n", name);
+}
+
+int main() {
+    // Document leftover abort polarity: bare stoi/stof throw on these tokens.
+    leftover_stoi_throws("leftover stoi(\"\")", "");
+    leftover_stoi_throws("leftover stoi(\"x\")", "x");
+    leftover_stof_throws("leftover stof(\"w\")", "w");
+
+    // Required leftover inputs: no throw and leave member defaults.
+    expect_defaults("empty", "");
+    expect_defaults("\"1 2\"", "1 2");
+    expect_defaults("\"0\"", "0");
+    expect_defaults("\"a b c\"", "a b c");
+
+    // Non-numeric 5-token leftover: no throw; skip bad fields (keep 0).
+    {
+        const char *name = "\"x y z q w\"";
+        const auto parsed = parse_no_throw(name, "x y z q w");
+        if (is_default(parsed)) {
+            std::printf("PASS %s (no throw, defaults)\n", name);
+        } else {
+            std::fprintf(stderr, "FAIL %s: expected defaults after bad tokens\n", name);
+            ++g_failed;
+        }
+    }
+
+    // Valid 5-token production string.
+    {
+        const char *name = "\"1 2 3 4 5\"";
+        const auto parsed = parse_no_throw(name, "1 2 3 4 5");
+        const bool ok = parsed.animationType == 1 && parsed.timingFuncType == 2 && parsed.duration == 3.f &&
+                        parsed.damping == 4.f && parsed.velocity == 5.f && parsed.delay == 0.f && !parsed.repeatForever &&
+                        parsed.animationKey.empty();
+        expect_true(name, ok);
+        if (ok) {
+            std::printf("  type=1 timing=2 duration=3 damping=4 velocity=5\n");
+        }
+    }
+
+    // Full 8-token string also sets delay / repeat / key.
+    {
+        const char *name = "\"1 2 3 4 5 6 1 mykey\"";
+        const auto parsed = parse_no_throw(name, "1 2 3 4 5 6 1 mykey");
+        const bool ok = parsed.animationType == 1 && parsed.timingFuncType == 2 && parsed.duration == 3.f &&
+                        parsed.damping == 4.f && parsed.velocity == 5.f && parsed.delay == 6.f && parsed.repeatForever &&
+                        parsed.animationKey == "mykey";
+        expect_true(name, ok);
+        if (ok) {
+            std::printf("  delay=6 repeatForever=true key=mykey\n");
+        }
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_node_animation_parse_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_node_animation_parse_test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Compile + run leftover KRNodeAnimation::parseAnimation host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_kr_node_animation_parse_test.sh          # g++ default
+#   ./run_kr_node_animation_parse_test.sh asan     # Address+UB sanitizers
+#
+# Parse helpers live in header-only KRNodeAnimationParse.h (no ArkUI).
+# Host g++/clang++ includes it directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ANIM_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/components/base/animation"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$ANIM_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_node_animation_parse_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_node_animation_parse_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_node_animation_parse_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`KRNodeAnimation::parseAnimation` indexed `[0]..[4]` and called bare `std::stoi`/`std::stof` with no size guard (only delay/repeat/key had `size()` checks). Short strings (`"1 2"`, `"0"`, `"a b c"`) OOB or throw.

Fix: require 5 tokens before touching `[0]..[4]`; try/catch each numeric token (keep default 0 on failure). Logic in `KRNodeAnimationParse.h` for host tests.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_node_animation_parse_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
