### PR TITLE
fix(ohos): leftover KRBasePropsHandler kFrame memcpy length

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/core/KRRenderCore.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/core/KRRenderCore.cpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include "libohos_render/foundation/KRRect.h"
 #include "libohos_render/layer/KRRenderLayerHandler.h"
+#include "libohos_render/utils/KRFrameMemcpy.h"
 #include "libohos_render/manager/KRArkTSManager.h"
 #include "libohos_render/scheduler/KRContextScheduler.h"
 #include "libohos_render/utils/KRRenderLoger.h"
@@ -304,7 +305,9 @@ KRAnyValue KRRenderCore::PerformNativeCallback(const KuiklyRenderNativeMethod &m
         const float right = alignEdgeToPixel(arg2->toFloat() + arg4->toFloat());
         const float bottom = alignEdgeToPixel(arg3->toFloat() + arg5->toFloat());
         auto rect = KRRect(left, top, right - left, bottom - top);
-        std::string rectData((const char *)&rect, sizeof(KRRect));
+        // Wire only the 4 floats. sizeof(KRRect) includes isDefault_ and would
+        // be rejected by TryCopyFrameFloats (exactly kKRFrameFloatBytes).
+        std::string rectData(reinterpret_cast<const char *>(&rect.x), kuikly::util::kKRFrameFloatBytes);
         auto value = KRRenderValue::Make(rectData);
         renderLayerHandler_->SetProp(arg1->toInt(), "frame", value);
         break;

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/base/KRBasePropsHandler.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/base/KRBasePropsHandler.cpp
@@ -20,6 +20,7 @@
 #include "libohos_render/foundation/KRConfig.h"
 #include "libohos_render/foundation/KRRect.h"
 #include "libohos_render/utils/KREventUtil.h"
+#include "libohos_render/utils/KRFrameMemcpy.h"
 #include "libohos_render/utils/KRRenderLoger.h"
 #include "libohos_render/utils/KRViewUtil.h"
 #include "libohos_render/export/IKRRenderViewExport.h"
@@ -90,8 +91,11 @@ bool KRBasePropsHandler::SetPropWithoutAnimation(const std::string &prop_key, co
     if (strcmp(prop_key.c_str(), kFrame) == 0) {
         if (prop_value->isString()) {
             KRRect frame;
-            const std::string &s = prop_value->toString();
-            memcpy(&frame, s.data(), s.size());
+            // leftover: memcpy(&frame, s.data(), s.size()) smashed the stack
+            // when s.size() > sizeof(KRRect), and also wrote into isDefault_.
+            if (!kuikly::util::TryCopyFrameFloats(prop_value->toString(), frame)) {
+                return false;
+            }
             ResetTransformIfNeed();
             kuikly::util::UpdateNodeFrame(node_, frame);
             frame_ = frame;

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/forward/KRForwardArkTSViewV2.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/forward/KRForwardArkTSViewV2.cpp
@@ -16,6 +16,7 @@
 #include "libohos_render/expand/components/forward/KRForwardArkTSViewV2.h"
 
 #include "libohos_render/manager/KRArkTSManager.h"
+#include "libohos_render/utils/KRFrameMemcpy.h"
 
 std::shared_ptr<KRBaseEventHandler>  KRForwardArkTSViewV2::CreateBaseEventHandler(std::shared_ptr<IKRRenderView> rootView) {
     if(rootView){
@@ -78,8 +79,10 @@ bool KRForwardArkTSViewV2::SetProp(const std::string &prop_key, const KRAnyValue
         // 设置属性
         if(prop_key == "frame"){
             KRRect frame;
-            const std::string &s = prop_value->toString();
-            memcpy(&frame, s.data(), s.size());
+            // leftover: memcpy(&frame, s.data(), s.size()) smashed KRRect.
+            if (!kuikly::util::TryCopyFrameFloats(prop_value->toString(), frame)) {
+                return false;
+            }
             std::string serialized(64,0);
             snprintf(serialized.data(), serialized.size() - 1, "%.3f %.3f %.3f %.3f %d", frame.x, frame.y, frame.width, frame.height, frame.isDefaultZero());
             KRArkTSManager::GetInstance().CallArkTSMethod(this->GetInstanceId(), KRNativeCallArkTSMethod::SetViewProp,

--- a/core-render-ohos/src/main/cpp/libohos_render/export/IKRRenderViewExport.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/export/IKRRenderViewExport.cpp
@@ -20,6 +20,7 @@
 #include "libohos_render/foundation/KRConfig.h"
 #include "libohos_render/manager/KRSnapshotManager.h"
 #include "libohos_render/manager/KRWeakObjectManager.h"
+#include "libohos_render/utils/KRFrameMemcpy.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -204,9 +205,11 @@ void IKRRenderViewExport::ToSetProp(const std::string &prop_key, const KRAnyValu
             didHanded = ToSetBaseProp(prop_key, prop_value, event_call_back);  // 基础属性设置分发处理
         }
         if (isFrameProp) {
-            const std::string &s = prop_value->toString();
-            memcpy(&frame_, s.data(), s.size());
-            SetRenderViewFrame(frame_);
+            // leftover: memcpy(&frame_, s.data(), s.size()) smashed KRRect
+            // when the payload was not exactly 4 floats.
+            if (kuikly::util::TryCopyFrameFloats(prop_value->toString(), frame_)) {
+                SetRenderViewFrame(frame_);
+            }
         }
     }
     if (!didHanded && base_event_handler_ != nullptr) {

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRFrameMemcpy.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRFrameMemcpy.h
@@ -1,0 +1,50 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_KRFRAMEMEMCPY_H
+#define CORE_RENDER_OHOS_KRFRAMEMEMCPY_H
+
+#include <cstring>
+#include <string_view>
+
+namespace kuikly {
+namespace util {
+
+// Wire size of a kFrame binary payload: x, y, width, height. KRRect also has
+// a trailing isDefault_ flag, so sizeof(KRRect) is larger than this.
+inline constexpr std::size_t kKRFrameFloatBytes = sizeof(float) * 4;
+
+// leftover: KRBasePropsHandler kFrame (and sibling memcpy sites) copied
+// caller-controlled s.size() into a stack KRRect. Size != 16 is reject
+// (empty / text / oversized smash). On accept, copy only the 4 floats so
+// isDefault_ is not clobbered. Header-only so host tests compile without ArkUI.
+template <typename RectT>
+inline bool TryCopyFrameFloats(std::string_view payload, RectT &out) {
+    if (payload.size() != kKRFrameFloatBytes) {
+        return false;
+    }
+    float xywh[4];
+    memcpy(xywh, payload.data(), kKRFrameFloatBytes);
+    out.x = xywh[0];
+    out.y = xywh[1];
+    out.width = xywh[2];
+    out.height = xywh[3];
+    return true;
+}
+
+}  // namespace util
+}  // namespace kuikly
+
+#endif  // CORE_RENDER_OHOS_KRFRAMEMEMCPY_H

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_frame_memcpy_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_frame_memcpy_test.cpp
@@ -1,0 +1,117 @@
+// Host unit test for leftover KRBasePropsHandler kFrame memcpy length.
+//
+// The kFrame branch used to:
+//   memcpy(&frame, s.data(), s.size());
+// into a stack KRRect (4 floats + trailing isDefault_). Caller-controlled
+// s.size() > sizeof(frame) is a stack smash; a text frame string writes
+// garbage. Helper accepts only exactly 4 floats and copies into x/y/width/
+// height so isDefault_ is not clobbered. Header-only KRFrameMemcpy.h so this
+// compiles without ArkUI / Harmony.
+//
+// Build + run (from this directory):
+//   ./run_kr_frame_memcpy_test.sh
+//   ./run_kr_frame_memcpy_test.sh asan
+
+#include "libohos_render/utils/KRFrameMemcpy.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+using kuikly::util::kKRFrameFloatBytes;
+using kuikly::util::TryCopyFrameFloats;
+
+static int g_failed = 0;
+
+// KRRect-like: 4 floats plus the trailing flag the leftover memcpy used to
+// overwrite when s.size() >= sizeof(KRRect).
+struct FrameLike {
+    float x = 9.0f;
+    float y = 9.0f;
+    float width = 9.0f;
+    float height = 9.0f;
+    bool isDefault_ = true;
+    unsigned char canary[8] = {'C', 'A', 'N', 'A', 'R', 'Y', '!', 0};
+};
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static bool floats_eq(const FrameLike &got, float x, float y, float w, float h) {
+    return got.x == x && got.y == y && got.width == w && got.height == h;
+}
+
+static bool canary_intact(const FrameLike &got) {
+    return std::memcmp(got.canary, "CANARY!", 8) == 0;
+}
+
+static std::string pack4(float x, float y, float w, float h) {
+    float xywh[4] = {x, y, w, h};
+    return std::string(reinterpret_cast<const char *>(xywh), sizeof(xywh));
+}
+
+int main() {
+    expect_true("kKRFrameFloatBytes == 16", kKRFrameFloatBytes == 16);
+    expect_true("FrameLike larger than 4 floats", sizeof(FrameLike) > kKRFrameFloatBytes);
+
+    // leftover: size 0 must reject and not write the dest.
+    {
+        FrameLike frame;
+        expect_true("size 0 reject", !TryCopyFrameFloats(std::string_view(), frame));
+        expect_true("size 0 dest unchanged", floats_eq(frame, 9, 9, 9, 9));
+        expect_true("size 0 isDefault_ intact", frame.isDefault_);
+        expect_true("size 0 canary intact", canary_intact(frame));
+    }
+
+    // leftover: size 15 (one byte short) must reject / no overflow.
+    {
+        FrameLike frame;
+        std::string buf(15, '\x7f');
+        expect_true("size 15 reject", !TryCopyFrameFloats(buf, frame));
+        expect_true("size 15 dest unchanged", floats_eq(frame, 9, 9, 9, 9));
+        expect_true("size 15 isDefault_ intact", frame.isDefault_);
+        expect_true("size 15 canary intact", canary_intact(frame));
+    }
+
+    // leftover: size 64 used to smash past the stack KRRect. Reject, no overflow.
+    {
+        FrameLike frame;
+        std::string buf(64, '\xff');
+        expect_true("size 64 reject", !TryCopyFrameFloats(buf, frame));
+        expect_true("size 64 dest unchanged", floats_eq(frame, 9, 9, 9, 9));
+        expect_true("size 64 isDefault_ intact", frame.isDefault_);
+        expect_true("size 64 canary intact", canary_intact(frame));
+    }
+
+    // leftover: text frame string is not a 16-byte float payload.
+    {
+        FrameLike frame;
+        expect_true("text frame reject", !TryCopyFrameFloats(std::string_view("10 20 30 40"), frame));
+        expect_true("text frame dest unchanged", floats_eq(frame, 9, 9, 9, 9));
+    }
+
+    // size == 16 copies the 4 floats and must not clobber isDefault_ / canary.
+    {
+        FrameLike frame;
+        const std::string payload = pack4(1.5f, 2.5f, 3.5f, 4.5f);
+        expect_true("size 16 payload", payload.size() == 16);
+        expect_true("size 16 accept", TryCopyFrameFloats(payload, frame));
+        expect_true("size 16 floats", floats_eq(frame, 1.5f, 2.5f, 3.5f, 4.5f));
+        expect_true("size 16 isDefault_ intact", frame.isDefault_);
+        expect_true("size 16 canary intact", canary_intact(frame));
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_frame_memcpy_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_frame_memcpy_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Compile + run leftover KRBasePropsHandler kFrame memcpy host unit tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_kr_frame_memcpy_test.sh          # g++ default
+#   ./run_kr_frame_memcpy_test.sh asan     # Address+UB sanitizers
+#
+# KRFrameMemcpy.h is header-only std C++. Host g++/clang++ is enough — no ArkUI.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CPP_ROOT="$SCRIPT_DIR/../../main/cpp"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$CPP_ROOT"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_frame_memcpy_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_frame_memcpy_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_frame_memcpy_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`KRBasePropsHandler` `kFrame` (and sibling sites) did `memcpy(&frame, s.data(), s.size())` into a stack `KRRect`. Caller-controlled length > `sizeof(KRRect)` smashes the stack; a 16-byte write also clobbered `isDefault_`.

Fix: accept only exactly `sizeof(float)*4`, copy into `x/y/width/height` only. Same helper applied at other `memcpy` frame sites (`IKRRenderViewExport`, `KRForwardArkTSViewV2`) and the producer in `KRRenderCore` now wires 16 bytes.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_frame_memcpy_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
