### PR TITLE
fix(ohos): leftover Date::Parse stoi/substr OOR

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRDate.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRDate.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "KRDate.h"
+#include "KRDateParse.h"
 
 #include <chrono>
 
@@ -115,53 +116,38 @@ std::int64_t Date::Now() {
 }
 
 void Date::Parse(std::string &dateStr, std::string &formatStr) {
-    auto pos = formatStr.find("yyyy");
-    if (pos != std::string::npos) {
-        // 已格式化的日期字符串不包含引号，要减去格式字符串中的引号数量，以便找到该字段正确位置。
-        pos -= quoteCount(formatStr.substr(0, pos));
-        int year = std::stoi(dateStr.substr(pos, 4));
+    // Token slices are bounds-checked in TryParseDateField. Short / non-numeric
+    // leftover input skips that field (keeps existing Date members) instead of
+    // throwing from substr / stoi.
+    int year = 0;
+    if (TryParseDateField(dateStr, formatStr, "yyyy", 4, year)) {
         this->SetYear(year);
     }
-    pos = formatStr.find("YYYY");
-    if (pos != std::string::npos) {
-        pos -= quoteCount(formatStr.substr(0, pos));
-        int year = std::stoi(dateStr.substr(pos, 4));
+    if (TryParseDateField(dateStr, formatStr, "YYYY", 4, year)) {
         this->SetYear(year);
     }
-    pos = formatStr.find("MM");
-    if (pos != std::string::npos) {
-        pos -= quoteCount(formatStr.substr(0, pos));
-        int month = std::stoi(dateStr.substr(pos, 2)) - 1;  // 解析时，要将正常月份计数调整为从0开始
-        this->SetMonth(month);
+    int month = 0;
+    if (TryParseDateField(dateStr, formatStr, "MM", 2, month)) {
+        this->SetMonth(month - 1);  // 解析时，要将正常月份计数调整为从0开始
     }
-    pos = formatStr.find("dd");
-    if (pos != std::string::npos) {
-        pos -= quoteCount(formatStr.substr(0, pos));
-        int date = std::stoi(dateStr.substr(pos, 2));
+    int date = 0;
+    if (TryParseDateField(dateStr, formatStr, "dd", 2, date)) {
         this->SetDate(date);
     }
-    pos = formatStr.find("HH");
-    if (pos != std::string::npos) {
-        pos -= quoteCount(formatStr.substr(0, pos));
-        int hour = std::stoi(dateStr.substr(pos, 2));
+    int hour = 0;
+    if (TryParseDateField(dateStr, formatStr, "HH", 2, hour)) {
         this->SetHours(hour);
     }
-    pos = formatStr.find("mm");
-    if (pos != std::string::npos) {
-        pos -= quoteCount(formatStr.substr(0, pos));
-        int minute = std::stoi(dateStr.substr(pos, 2));
+    int minute = 0;
+    if (TryParseDateField(dateStr, formatStr, "mm", 2, minute)) {
         this->SetMinutes(minute);
     }
-    pos = formatStr.find("ss");
-    if (pos != std::string::npos) {
-        pos -= quoteCount(formatStr.substr(0, pos));
-        int second = std::stoi(dateStr.substr(pos, 2));
+    int second = 0;
+    if (TryParseDateField(dateStr, formatStr, "ss", 2, second)) {
         this->SetSeconds(second);
     }
-    pos = formatStr.find("SSS");
-    if (pos != std::string::npos) {
-        pos -= quoteCount(formatStr.substr(0, pos));
-        int num = std::stoi(dateStr.substr(pos, 3));
+    int num = 0;
+    if (TryParseDateField(dateStr, formatStr, "SSS", 3, num)) {
         this->SetMilliseconds(num);
     }
 }
@@ -175,19 +161,7 @@ void Date::Parse(std::string &dateStr, std::string &formatStr) {
  * @return
  */
 std::string::size_type Date::quoteCount(std::string subString) {
-    std::string::size_type count = 0;
-    auto length = subString.length();
-    for (std::string::size_type i = 0; i < length; i++) {
-        if (subString.at(i) == '\'') {
-            if ((i + 1) < length && subString.at(i + 1) == '\'') {
-                count++;  //  双引号计数。'' is treated as a single quote regardless of being in a quoted section.
-                i++;
-                continue;
-            }
-            count++;  //  单引号计数
-        }
-    }
-    return count;
+    return DateParseQuoteCount(subString);
 }
 
 }  //  namespace util

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRDate.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRDate.h
@@ -14,6 +14,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <ctime>
 #include <string>
 

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRDateParse.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/calendar/KRDateParse.h
@@ -1,0 +1,74 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+namespace kuikly {
+namespace util {
+
+// Leftover Date::Parse helpers. Bare formatStr.find + quoteCount subtract +
+// std::stoi(dateStr.substr(pos, N)) has no pos/width check: a short date
+// ("1" vs "yyyy-MM-dd") throws std::out_of_range, and a non-numeric token
+// ("xxxx" vs "yyyy") throws std::invalid_argument. Header-only so host g++
+// leftover tests compile without Harmony / ArkUI.
+
+// Count "'" / "''" in the prefix before a format token (Android date-pattern
+// convention). Used to map format position onto the quote-stripped date string.
+inline std::string::size_type DateParseQuoteCount(const std::string &subString) {
+    std::string::size_type count = 0;
+    auto length = subString.length();
+    for (std::string::size_type i = 0; i < length; i++) {
+        if (subString.at(i) == '\'') {
+            if ((i + 1) < length && subString.at(i + 1) == '\'') {
+                count++;  //  双引号计数。'' is treated as a single quote regardless of being in a quoted section.
+                i++;
+                continue;
+            }
+            count++;  //  单引号计数
+        }
+    }
+    return count;
+}
+
+// Parse one format token (yyyy/YYYY/MM/dd/HH/mm/ss/SSS). Returns true and
+// writes `out` only when the token is present, the adjusted pos is in range,
+// and the slice is numeric. On any failure returns false without throwing
+// (caller leaves existing Date members).
+inline bool TryParseDateField(const std::string &dateStr, const std::string &formatStr, const char *token,
+                              std::string::size_type width, int &out) {
+    auto pos = formatStr.find(token);
+    if (pos == std::string::npos) {
+        return false;
+    }
+    const auto quotes = DateParseQuoteCount(formatStr.substr(0, pos));
+    // size_type is unsigned: quoteCount > pos would wrap to a huge index.
+    if (quotes > pos) {
+        return false;
+    }
+    pos -= quotes;
+    if (pos >= dateStr.size() || pos + width > dateStr.size()) {
+        return false;
+    }
+    try {
+        out = std::stoi(dateStr.substr(pos, width));
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+}  // namespace util
+}  // namespace kuikly

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/krdate_parse_host_test.cpp
+++ b/core-render-ohos/src/test/cpp/krdate_parse_host_test.cpp
@@ -1,0 +1,180 @@
+// Host unit test for leftover Date::Parse stoi / substr out-of-range.
+//
+// Leftover:
+//   pos = formatStr.find(token);
+//   pos -= quoteCount(formatStr.substr(0, pos));
+//   std::stoi(dateStr.substr(pos, N));
+//
+// No check that pos+N <= dateStr.size(); non-numeric tokens throw.
+// "xxxx" vs "yyyy" → std::invalid_argument
+// "1" vs "yyyy-MM-dd" → std::out_of_range
+//
+// KRDate.cpp / KRDateParse.h have no OHOS APIs, so this builds with host g++.
+//
+// Build + run (from this directory):
+//   ./run_krdate_parse_host_test.sh
+//   ./run_krdate_parse_host_test.sh asan
+
+#include "KRDate.h"
+#include "KRDateParse.h"
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+using kuikly::util::Date;
+using kuikly::util::TryParseDateField;
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_eq(const char *name, int got, int want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got %d want %d\n", name, got, want);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void leftover_stoi_throws(const char *name, const std::string &s) {
+    bool threw = false;
+    try {
+        (void)std::stoi(s);
+    } catch (const std::invalid_argument &) {
+        threw = true;
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: leftover stoi threw %s\n", name, e.what());
+        ++g_failed;
+        return;
+    }
+    expect_true(name, threw);
+}
+
+static void leftover_substr_throws(const char *name, const std::string &s, std::string::size_type pos,
+                                   std::string::size_type n) {
+    bool threw = false;
+    try {
+        (void)s.substr(pos, n);
+    } catch (const std::out_of_range &) {
+        threw = true;
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: leftover substr threw %s\n", name, e.what());
+        ++g_failed;
+        return;
+    }
+    expect_true(name, threw);
+}
+
+int main() {
+    leftover_stoi_throws("leftover stoi(\"xxxx\")", "xxxx");
+    leftover_substr_throws("leftover substr(\"1\", 5, 2) for MM in yyyy-MM-dd", "1", 5, 2);
+
+    // Date::Parse("xxxx","yyyy") does not throw; year field is skipped.
+    {
+        Date d;
+        d.SetFullYear(1999);
+        d.SetMonth(5);
+        d.SetDate(15);
+        std::string dateStr = "xxxx";
+        std::string formatStr = "yyyy";
+        bool threw = false;
+        try {
+            d.Parse(dateStr, formatStr);
+        } catch (const std::exception &e) {
+            std::fprintf(stderr, "FAIL Parse(\"xxxx\",\"yyyy\") threw: %s\n", e.what());
+            threw = true;
+            ++g_failed;
+        } catch (...) {
+            std::fprintf(stderr, "FAIL Parse(\"xxxx\",\"yyyy\") threw unknown\n");
+            threw = true;
+            ++g_failed;
+        }
+        expect_true("Date::Parse(\"xxxx\",\"yyyy\") does not throw", !threw);
+        expect_eq("Parse(\"xxxx\",\"yyyy\") year unchanged", d.GetFullYear(), 1999);
+        expect_eq("Parse(\"xxxx\",\"yyyy\") month unchanged", d.GetMonth(), 5);
+        expect_eq("Parse(\"xxxx\",\"yyyy\") date unchanged", d.GetDate(), 15);
+    }
+
+    // Parse("1","yyyy-MM-dd") does not throw; every token is short / OOR.
+    {
+        Date d;
+        d.SetFullYear(1999);
+        d.SetMonth(5);
+        d.SetDate(15);
+        std::string dateStr = "1";
+        std::string formatStr = "yyyy-MM-dd";
+        bool threw = false;
+        try {
+            d.Parse(dateStr, formatStr);
+        } catch (const std::exception &e) {
+            std::fprintf(stderr, "FAIL Parse(\"1\",\"yyyy-MM-dd\") threw: %s\n", e.what());
+            threw = true;
+            ++g_failed;
+        } catch (...) {
+            std::fprintf(stderr, "FAIL Parse(\"1\",\"yyyy-MM-dd\") threw unknown\n");
+            threw = true;
+            ++g_failed;
+        }
+        expect_true("Date::Parse(\"1\",\"yyyy-MM-dd\") does not throw", !threw);
+        expect_eq("Parse(\"1\",\"yyyy-MM-dd\") year unchanged", d.GetFullYear(), 1999);
+        expect_eq("Parse(\"1\",\"yyyy-MM-dd\") month unchanged", d.GetMonth(), 5);
+        expect_eq("Parse(\"1\",\"yyyy-MM-dd\") date unchanged", d.GetDate(), 15);
+    }
+
+    // Parse("2024-08-24","yyyy-MM-dd") sets year=2024 month=7 (0-based) date=24.
+    {
+        Date d;
+        std::string dateStr = "2024-08-24";
+        std::string formatStr = "yyyy-MM-dd";
+        bool threw = false;
+        try {
+            d.Parse(dateStr, formatStr);
+        } catch (const std::exception &e) {
+            std::fprintf(stderr, "FAIL Parse(\"2024-08-24\",\"yyyy-MM-dd\") threw: %s\n", e.what());
+            threw = true;
+            ++g_failed;
+        } catch (...) {
+            std::fprintf(stderr, "FAIL Parse(\"2024-08-24\",\"yyyy-MM-dd\") threw unknown\n");
+            threw = true;
+            ++g_failed;
+        }
+        expect_true("Date::Parse(\"2024-08-24\",\"yyyy-MM-dd\") does not throw", !threw);
+        expect_eq("Parse(\"2024-08-24\",\"yyyy-MM-dd\") year", d.GetFullYear(), 2024);
+        expect_eq("Parse(\"2024-08-24\",\"yyyy-MM-dd\") month (0-based)", d.GetMonth(), 7);
+        expect_eq("Parse(\"2024-08-24\",\"yyyy-MM-dd\") date", d.GetDate(), 24);
+    }
+
+    // Header helper: quoted prefix still maps onto the quote-stripped date.
+    {
+        int year = 0;
+        bool ok = TryParseDateField("at 2024", "'at' yyyy", "yyyy", 4, year);
+        expect_true("TryParseDateField quoted prefix", ok);
+        expect_eq("TryParseDateField quoted prefix year", year, 2024);
+    }
+
+    // Header helper: quoteCount > pos would wrap; skip the field.
+    // (Defensive — DateParseQuoteCount of a prefix cannot exceed its length.)
+    {
+        int out = 42;
+        // Empty date + token at pos 0 is the pos < size / pos+width path.
+        bool ok = TryParseDateField("", "yyyy", "yyyy", 4, out);
+        expect_true("TryParseDateField empty date skips", !ok);
+        expect_eq("TryParseDateField empty date leaves out", out, 42);
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_krdate_parse_host_test.sh
+++ b/core-render-ohos/src/test/cpp/run_krdate_parse_host_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Compile + run leftover Date::Parse stoi/substr OOR host unit tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_krdate_parse_host_test.sh          # g++ default
+#   ./run_krdate_parse_host_test.sh asan     # Address+UB sanitizers
+#
+# KRDate.cpp / KRDateParse.h have no OHOS APIs. Host g++/clang++ is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CALENDAR_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/modules/calendar"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -I"$CALENDAR_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/krdate_parse_host_test.cpp"
+    "$CALENDAR_DIR/KRDate.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/krdate_parse_host_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/krdate_parse_host_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`Date::Parse` found each format token then did `pos -= quoteCount` and `std::stoi(dateStr.substr(pos, N))` with no range check. Short dates (`"1"` vs `"yyyy-MM-dd"`) throw `out_of_range`; non-numeric tokens (`"xxxx"` vs `"yyyy"`) throw `invalid_argument`.

Distinct from #1649 (neg millis), #1655 (valuestring), #1668 (mktime yday/wday).

Fix: bounds-check `pos`/`width` (and quoteCount wrap); skip that field on parse failure. Helper in `KRDateParse.h` for host tests.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_krdate_parse_host_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
