### PR TITLE
fix(ohos): leftover APNG blend/dispose canvas dstIdx OOB

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGCanvasIndex.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGCanvasIndex.h
@@ -1,0 +1,131 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_APNG_CANVAS_INDEX_H
+#define CORE_RENDER_OHOS_APNG_CANVAS_INDEX_H
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+// Header-only leftover helpers for APNG blend / dispose-clear dstIdx.
+//
+// Parser fcTL left/top/width/height are not clamped to the canvas. The
+// leftover compositor used:
+//   dstIdx = ((y + frame->top) * width + (x + frame->left)) * 4
+// then wrote drawingBuffer[dstIdx..+3]. A frame with left=8, width=5 on
+// canvas W=10 walks past the RGBA buffer. Same math in dispose-clear.
+//
+// Host tests can include this file without Harmony / OH PixelMap.
+
+// True iff the fcTL rectangle is entirely inside the canvas:
+// left>=0 && top>=0 && left+frameWidth<=canvasWidth &&
+// top+frameHeight<=canvasHeight (and dimensions are non-negative).
+inline bool IsFrameRectInCanvas(int left, int top, int frameWidth, int frameHeight, int canvasWidth,
+                                int canvasHeight) {
+    if (left < 0 || top < 0 || frameWidth < 0 || frameHeight < 0) {
+        return false;
+    }
+    if (canvasWidth < 0 || canvasHeight < 0) {
+        return false;
+    }
+    if (static_cast<int64_t>(left) + static_cast<int64_t>(frameWidth) > canvasWidth) {
+        return false;
+    }
+    if (static_cast<int64_t>(top) + static_cast<int64_t>(frameHeight) > canvasHeight) {
+        return false;
+    }
+    return true;
+}
+
+// RGBA8888 dest index. Caller must have accepted the frame via
+// IsFrameRectInCanvas and must pass x in [0, frameWidth), y in [0, frameHeight).
+inline size_t CanvasDstIndex(int x, int y, int left, int top, int canvasWidth) {
+    const size_t px = static_cast<size_t>(x) + static_cast<size_t>(left);
+    const size_t py = static_cast<size_t>(y) + static_cast<size_t>(top);
+    return (py * static_cast<size_t>(canvasWidth) + px) * 4u;
+}
+
+// Per-pixel leftover clamp: false if (x+left, y+top) is outside the canvas
+// or dstIdx..+3 would exceed canvasBytes.
+inline bool TryCanvasDstIndex(int x, int y, int left, int top, int canvasWidth, int canvasHeight, size_t canvasBytes,
+                              size_t *outIdx) {
+    if (outIdx == nullptr || x < 0 || y < 0) {
+        return false;
+    }
+    const int64_t px = static_cast<int64_t>(x) + static_cast<int64_t>(left);
+    const int64_t py = static_cast<int64_t>(y) + static_cast<int64_t>(top);
+    if (px < 0 || py < 0 || px >= canvasWidth || py >= canvasHeight) {
+        return false;
+    }
+    const size_t idx =
+        (static_cast<size_t>(py) * static_cast<size_t>(canvasWidth) + static_cast<size_t>(px)) * 4u;
+    if (idx + 4u > canvasBytes) {
+        return false;
+    }
+    *outIdx = idx;
+    return true;
+}
+
+// SOURCE copy (blendOp==0) of a frame buffer onto a host vector canvas.
+// Returns false and leaves canvas unchanged if the frame rect is OOB.
+inline bool BlendSourceFrameOntoCanvas(std::vector<uint8_t> &canvas, int canvasWidth, int canvasHeight,
+                                       const std::vector<uint8_t> &frameBuffer, int left, int top, int frameWidth,
+                                       int frameHeight) {
+    if (!IsFrameRectInCanvas(left, top, frameWidth, frameHeight, canvasWidth, canvasHeight)) {
+        return false;
+    }
+    const size_t needSrc = static_cast<size_t>(frameWidth) * static_cast<size_t>(frameHeight) * 4u;
+    const size_t needDst = static_cast<size_t>(canvasWidth) * static_cast<size_t>(canvasHeight) * 4u;
+    if (frameBuffer.size() < needSrc || canvas.size() < needDst) {
+        return false;
+    }
+    for (int y = 0; y < frameHeight; ++y) {
+        for (int x = 0; x < frameWidth; ++x) {
+            const size_t srcIdx = (static_cast<size_t>(y) * static_cast<size_t>(frameWidth) + static_cast<size_t>(x)) * 4u;
+            const size_t dstIdx = CanvasDstIndex(x, y, left, top, canvasWidth);
+            canvas[dstIdx + 0] = frameBuffer[srcIdx + 0];
+            canvas[dstIdx + 1] = frameBuffer[srcIdx + 1];
+            canvas[dstIdx + 2] = frameBuffer[srcIdx + 2];
+            canvas[dstIdx + 3] = frameBuffer[srcIdx + 3];
+        }
+    }
+    return true;
+}
+
+// disposeOp BACKGROUND (1): clear the frame rectangle. Returns false and
+// leaves canvas unchanged if the frame rect is OOB.
+inline bool DisposeClearFrameOnCanvas(std::vector<uint8_t> &canvas, int canvasWidth, int canvasHeight, int left,
+                                      int top, int frameWidth, int frameHeight) {
+    if (!IsFrameRectInCanvas(left, top, frameWidth, frameHeight, canvasWidth, canvasHeight)) {
+        return false;
+    }
+    const size_t needDst = static_cast<size_t>(canvasWidth) * static_cast<size_t>(canvasHeight) * 4u;
+    if (canvas.size() < needDst) {
+        return false;
+    }
+    for (int y = 0; y < frameHeight; ++y) {
+        for (int x = 0; x < frameWidth; ++x) {
+            const size_t dstIdx = CanvasDstIndex(x, y, left, top, canvasWidth);
+            canvas[dstIdx + 0] = 0;
+            canvas[dstIdx + 1] = 0;
+            canvas[dstIdx + 2] = 0;
+            canvas[dstIdx + 3] = 0;
+        }
+    }
+    return true;
+}
+
+#endif  // CORE_RENDER_OHOS_APNG_CANVAS_INDEX_H

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGStructs.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGStructs.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "libohos_render/expand/components/apng/APNGStructs.h"
+#include "libohos_render/expand/components/apng/APNGCanvasIndex.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -160,6 +161,11 @@ bool APNG::DidAddFrame(std::shared_ptr<Frame> frame, int index) {
 
 void APNG::HandleFrameBlendOp(std::shared_ptr<Frame> frame, int index) {
     // 合成// 根据 blendOp 合成帧
+    // fcTL left/top/width/height are unclamped; reject frames that walk
+    // past the canvas before writing drawingBuffer[dstIdx..+3].
+    if (!IsFrameRectInCanvas(frame->left, frame->top, frame->width, frame->height, width, height)) {
+        return;
+    }
     auto &drawingBuffer = this->curBitmapBuffer;
     auto framePixelmap = CreatePixelMap(frame);
     auto frameBuffer = std::vector<uint8_t>();
@@ -171,7 +177,7 @@ void APNG::HandleFrameBlendOp(std::shared_ptr<Frame> frame, int index) {
     for (int y = 0; y < frame->height; ++y) {
         for (int x = 0; x < frame->width; ++x) {
             int srcIdx = (y * frame->width + x) * 4;
-            int dstIdx = ((y + frame->top) * width + (x + frame->left)) * 4;
+            const size_t dstIdx = CanvasDstIndex(x, y, frame->left, frame->top, width);
 
             if (frame->blendOp == 0) {  // 覆盖操作
                 drawingBuffer[dstIdx + 0] = frameBuffer[srcIdx + 0];
@@ -223,11 +229,15 @@ void APNG::HandleFrameBlendOp(std::shared_ptr<Frame> frame, int index) {
 
 void APNG::HandlePostFrameDisposeOp(std::shared_ptr<Frame> frame) {
     if (frame->disposeOp == 1) {  // 清理当前区域
+        // Same leftover dstIdx math as HandleFrameBlendOp; skip OOB fcTL.
+        if (!IsFrameRectInCanvas(frame->left, frame->top, frame->width, frame->height, width, height)) {
+            return;
+        }
         auto &drawingBuffer = this->curBitmapBuffer;
         // 清除当前帧区域
         for (int y = 0; y < frame->height; ++y) {
             for (int x = 0; x < frame->width; ++x) {
-                int dstIdx = ((y + frame->top) * width + (x + frame->left)) * 4;
+                const size_t dstIdx = CanvasDstIndex(x, y, frame->left, frame->top, width);
                 drawingBuffer[dstIdx + 0] = 0;
                 drawingBuffer[dstIdx + 1] = 0;
                 drawingBuffer[dstIdx + 2] = 0;

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host C++ test binaries
+build/

--- a/core-render-ohos/src/test/cpp/apng_canvas_dstidx_host_test.cpp
+++ b/core-render-ohos/src/test/cpp/apng_canvas_dstidx_host_test.cpp
@@ -59,9 +59,12 @@ static bool LeftoverWriteWalksPast(int left, int top, int frameWidth, int frameH
 
 int main() {
     // leftover example: left=8, width=5 on W=10 walks past the buffer.
+    // On a 1-row canvas the leftover dstIdx for x=4 is 12*4=48, past 40 bytes.
+    // On a taller canvas the same x wraps into the next row (wrong pixels)
+    // and only the last row walks off the end.
     {
         const int canvasW = 10;
-        const int canvasH = 4;
+        const int canvasH = 1;
         const int left = 8;
         const int top = 0;
         const int fw = 5;
@@ -85,6 +88,12 @@ int main() {
     {
         expect_true("OOB top=8 height=5 on H=10 detected", !IsFrameRectInCanvas(0, 8, 1, 5, 10, 10));
         expect_true("leftover top=8 height=5 walks past", LeftoverWriteWalksPast(0, 8, 1, 5, 10, 10));
+    }
+
+    // leftover last-row wrap: left=8,width=5 on W=10,H=4 writes past the last row.
+    {
+        expect_true("leftover last-row left=8 width=5 walks past", LeftoverWriteWalksPast(8, 3, 5, 1, 10, 4));
+        expect_true("OOB last-row left=8 width=5 detected", !IsFrameRectInCanvas(8, 3, 5, 1, 10, 4));
     }
 
     // leftover negative origin (uint32 overflow into signed int).

--- a/core-render-ohos/src/test/cpp/apng_canvas_dstidx_host_test.cpp
+++ b/core-render-ohos/src/test/cpp/apng_canvas_dstidx_host_test.cpp
@@ -1,0 +1,189 @@
+// Host unit test for leftover APNG blend/dispose canvas dstIdx OOB.
+//
+// leftover polarity: fcTL left/top/width/height are unclamped. The compositor
+// computed dstIdx = ((y + top) * width + (x + left)) * 4 and wrote
+// drawingBuffer[dstIdx..+3]. left=8, width=5 on canvas W=10 walks past the
+// RGBA buffer. Same math in dispose-clear.
+//
+// This test drives the header-only index/clamp helpers over a std::vector
+// canvas (no Harmony device, no OH PixelMap, does not compile APNGStructs.cpp).
+//
+// Build + run (from this directory):
+//   ./run_apng_canvas_dstidx_host_test.sh
+//   ./run_apng_canvas_dstidx_host_test.sh asan
+
+#include "APNGCanvasIndex.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool cond) {
+    if (!cond) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_eq_size(const char *name, size_t got, size_t want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got %zu want %zu\n", name, got, want);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+// leftover dstIdx formula from HandleFrameBlendOp / dispose-clear.
+static int LeftoverDstIdx(int x, int y, int left, int top, int canvasWidth) {
+    return ((y + top) * canvasWidth + (x + left)) * 4;
+}
+
+static bool LeftoverWriteWalksPast(int left, int top, int frameWidth, int frameHeight, int canvasWidth,
+                                   int canvasHeight) {
+    const int canvasBytes = canvasWidth * canvasHeight * 4;
+    for (int y = 0; y < frameHeight; ++y) {
+        for (int x = 0; x < frameWidth; ++x) {
+            const int dstIdx = LeftoverDstIdx(x, y, left, top, canvasWidth);
+            if (dstIdx < 0 || dstIdx + 3 >= canvasBytes) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+int main() {
+    // leftover example: left=8, width=5 on W=10 walks past the buffer.
+    {
+        const int canvasW = 10;
+        const int canvasH = 4;
+        const int left = 8;
+        const int top = 0;
+        const int fw = 5;
+        const int fh = 1;
+        expect_true("leftover left=8 width=5 on W=10 walks past",
+                    LeftoverWriteWalksPast(left, top, fw, fh, canvasW, canvasH));
+        expect_true("OOB left=8 width=5 detected", !IsFrameRectInCanvas(left, top, fw, fh, canvasW, canvasH));
+
+        std::vector<uint8_t> canvas(static_cast<size_t>(canvasW * canvasH * 4), 0xCC);
+        const std::vector<uint8_t> before = canvas;
+        std::vector<uint8_t> frame(static_cast<size_t>(fw * fh * 4), 0x11);
+        expect_true("OOB SOURCE blend rejected",
+                    !BlendSourceFrameOntoCanvas(canvas, canvasW, canvasH, frame, left, top, fw, fh));
+        expect_true("OOB SOURCE blend leaves canvas unchanged", canvas == before);
+        expect_true("OOB dispose-clear rejected",
+                    !DisposeClearFrameOnCanvas(canvas, canvasW, canvasH, left, top, fw, fh));
+        expect_true("OOB dispose-clear leaves canvas unchanged", canvas == before);
+    }
+
+    // leftover vertical OOB: top=8, height=5 on H=10.
+    {
+        expect_true("OOB top=8 height=5 on H=10 detected", !IsFrameRectInCanvas(0, 8, 1, 5, 10, 10));
+        expect_true("leftover top=8 height=5 walks past", LeftoverWriteWalksPast(0, 8, 1, 5, 10, 10));
+    }
+
+    // leftover negative origin (uint32 overflow into signed int).
+    {
+        expect_true("negative left rejected", !IsFrameRectInCanvas(-1, 0, 2, 2, 10, 10));
+        expect_true("negative top rejected", !IsFrameRectInCanvas(0, -1, 2, 2, 10, 10));
+        expect_true("negative frame width rejected", !IsFrameRectInCanvas(0, 0, -1, 2, 10, 10));
+    }
+
+    // leftover exact-fit and in-bounds frames are accepted.
+    {
+        expect_true("full-canvas frame in bounds", IsFrameRectInCanvas(0, 0, 10, 10, 10, 10));
+        expect_true("left+width == canvasW accepted", IsFrameRectInCanvas(5, 0, 5, 1, 10, 4));
+        expect_true("left+width > canvasW rejected", !IsFrameRectInCanvas(6, 0, 5, 1, 10, 4));
+        expect_true("zero-size at origin accepted", IsFrameRectInCanvas(0, 0, 0, 0, 10, 10));
+    }
+
+    // leftover in-bounds SOURCE write: left=2, width=3 on W=10.
+    {
+        const int canvasW = 10;
+        const int canvasH = 2;
+        const int left = 2;
+        const int top = 0;
+        const int fw = 3;
+        const int fh = 1;
+        expect_true("in-bounds left=2 width=3 accepted", IsFrameRectInCanvas(left, top, fw, fh, canvasW, canvasH));
+        expect_true("in-bounds leftover formula stays inside",
+                    !LeftoverWriteWalksPast(left, top, fw, fh, canvasW, canvasH));
+
+        std::vector<uint8_t> canvas(static_cast<size_t>(canvasW * canvasH * 4), 0xCC);
+        std::vector<uint8_t> frame(static_cast<size_t>(fw * fh * 4), 0);
+        // RGB pixels: (R,G,B,A) = (1,2,3,4), (5,6,7,8), (9,10,11,12)
+        for (int i = 0; i < fw; ++i) {
+            frame[static_cast<size_t>(i) * 4u + 0] = static_cast<uint8_t>(1 + i * 4);
+            frame[static_cast<size_t>(i) * 4u + 1] = static_cast<uint8_t>(2 + i * 4);
+            frame[static_cast<size_t>(i) * 4u + 2] = static_cast<uint8_t>(3 + i * 4);
+            frame[static_cast<size_t>(i) * 4u + 3] = static_cast<uint8_t>(4 + i * 4);
+        }
+        expect_true("in-bounds SOURCE blend writes",
+                    BlendSourceFrameOntoCanvas(canvas, canvasW, canvasH, frame, left, top, fw, fh));
+
+        for (int i = 0; i < fw; ++i) {
+            const size_t dstIdx = CanvasDstIndex(i, 0, left, top, canvasW);
+            expect_eq_size("in-bounds dstIdx matches leftover formula", dstIdx,
+                           static_cast<size_t>(LeftoverDstIdx(i, 0, left, top, canvasW)));
+            expect_true("in-bounds pixel written", canvas[dstIdx + 0] == static_cast<uint8_t>(1 + i * 4) &&
+                                                       canvas[dstIdx + 1] == static_cast<uint8_t>(2 + i * 4) &&
+                                                       canvas[dstIdx + 2] == static_cast<uint8_t>(3 + i * 4) &&
+                                                       canvas[dstIdx + 3] == static_cast<uint8_t>(4 + i * 4));
+        }
+        // Pixel immediately left of the frame stays 0xCC.
+        expect_true("pixel left of frame untouched", canvas[CanvasDstIndex(0, 0, 1, 0, canvasW)] == 0xCC);
+        // Pixel immediately right of the frame stays 0xCC (x=5).
+        expect_true("pixel right of frame untouched", canvas[CanvasDstIndex(0, 0, 5, 0, canvasW)] == 0xCC);
+        // Second row untouched.
+        expect_true("second row untouched", canvas[CanvasDstIndex(0, 0, left, 1, canvasW)] == 0xCC);
+    }
+
+    // leftover in-bounds dispose-clear zeros only the frame rect.
+    {
+        const int canvasW = 6;
+        const int canvasH = 3;
+        const int left = 1;
+        const int top = 1;
+        const int fw = 2;
+        const int fh = 1;
+        std::vector<uint8_t> canvas(static_cast<size_t>(canvasW * canvasH * 4), 0xAB);
+        expect_true("in-bounds dispose-clear accepted",
+                    DisposeClearFrameOnCanvas(canvas, canvasW, canvasH, left, top, fw, fh));
+        for (int x = 0; x < fw; ++x) {
+            const size_t dstIdx = CanvasDstIndex(x, 0, left, top, canvasW);
+            expect_true("dispose-clear zeroed frame pixel", canvas[dstIdx + 0] == 0 && canvas[dstIdx + 1] == 0 &&
+                                                               canvas[dstIdx + 2] == 0 && canvas[dstIdx + 3] == 0);
+        }
+        expect_true("dispose-clear left neighbor untouched", canvas[CanvasDstIndex(0, 0, 0, 1, canvasW)] == 0xAB);
+        expect_true("dispose-clear row 0 untouched", canvas[0] == 0xAB);
+    }
+
+    // leftover TryCanvasDstIndex clips per-pixel (alternative to reject).
+    {
+        size_t idx = 999;
+        const size_t canvasBytes = static_cast<size_t>(10 * 2 * 4);
+        expect_true("TryCanvasDstIndex in-bounds", TryCanvasDstIndex(0, 0, 2, 0, 10, 2, canvasBytes, &idx));
+        expect_eq_size("TryCanvasDstIndex idx", idx, 2u * 4u);
+        expect_true("TryCanvasDstIndex OOB left=8 width walk",
+                    !TryCanvasDstIndex(4, 0, 8, 0, 10, 2, canvasBytes, &idx));
+        expect_true("TryCanvasDstIndex null out rejected",
+                    !TryCanvasDstIndex(0, 0, 0, 0, 10, 2, canvasBytes, nullptr));
+    }
+
+    // leftover int overflow: huge left+width must not wrap and accept.
+    {
+        expect_true("INT_MAX left + width rejected", !IsFrameRectInCanvas(2147483647, 0, 2, 1, 10, 10));
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_apng_canvas_dstidx_host_test.sh
+++ b/core-render-ohos/src/test/cpp/run_apng_canvas_dstidx_host_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Compile + run leftover APNG blend/dispose canvas dstIdx host unit tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_apng_canvas_dstidx_host_test.sh          # g++ default
+#   ./run_apng_canvas_dstidx_host_test.sh asan     # Address+UB sanitizers
+#
+# Does not compile APNGStructs.cpp or call OH PixelMap APIs.
+# Host g++/clang++ is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APNG_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/components/apng"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -I"$APNG_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/apng_canvas_dstidx_host_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/apng_canvas_dstidx_host_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/apng_canvas_dstidx_host_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

APNG compositor used `dstIdx = ((y + top) * width + (x + left)) * 4` with no clamp of fcTL `left/top/width/height` to the canvas. A frame with `left=8, width=5` on `W=10` walks past `drawingBuffer`. Same math in dispose-clear.

Distinct from #1660 (reserve→resize) and #1665 (dispose PREVIOUS restore).

Fix: reject out-of-canvas frames before blend/dispose loops. Helper in `APNGCanvasIndex.h` for host tests.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_apng_canvas_dstidx_host_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
