### PR TITLE
fix(ohos): leftover ApngParser subBuffer/fdAT length underflow

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/ApngParser.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/ApngParser.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 #include "libohos_render/expand/components/apng/APNGStructs.h"
+#include "libohos_render/expand/components/apng/ApngParserBuffer.h"
 
 class DataView {
  public:
@@ -107,23 +108,11 @@ static uint32_t crc32(const std::vector<uint8_t> &bytes, size_t start = 0, size_
     return ~crc;
 }
 
-static std::string readString(const std::vector<uint8_t> &bytes, size_t off, size_t length) {
-    std::string result;
-    for (size_t i = 0; i < length; ++i) {
-        result.push_back(static_cast<char>(bytes[off + i]));
-    }
-    return result;
-}
-
 static std::vector<uint8_t> makeStringArray(const std::string &str) {
     std::vector<uint8_t> result(str.begin(), str.end());
     return result;
 }
 
-static std::vector<uint8_t> subBuffer(const std::vector<uint8_t> &bytes, size_t start, size_t length) {
-    std::vector<uint8_t> result(bytes.begin() + start, bytes.begin() + start + length);
-    return result;
-}
 static std::vector<uint8_t> makeChunkBytes(const std::string &type, const std::vector<uint8_t> &dataBytes) {
     std::size_t crcLen = type.length() + dataBytes.size();
     std::vector<uint8_t> bytes(crcLen + 8);
@@ -146,21 +135,6 @@ static std::vector<uint8_t> makeChunkBytes(const std::string &type, const std::v
 static std::vector<uint8_t> makeDWordArray(uint32_t x) {
     return std::vector<uint8_t>{static_cast<uint8_t>((x >> 24) & 0xFF), static_cast<uint8_t>((x >> 16) & 0xFF),
                                 static_cast<uint8_t>((x >> 8) & 0xFF), static_cast<uint8_t>(x & 0xFF)};
-}
-
-static void eachChunk(std::vector<uint8_t> &bytes,
-                      std::function<bool(const std::string &, std::vector<uint8_t> &, size_t, size_t)> callback) {
-    size_t off = 8;
-    std::string type;
-    size_t length = 0;
-    bool res = false;
-    auto dv = DataView(bytes);
-    do {
-        length = dv.getUint32(off);
-        type = readString(bytes, off + 4, 4);
-        res = callback(type, bytes, off, length);
-        off += (12 + length);
-    } while (res != false && type != "IEND" && off < bytes.size());
 }
 
 static void parseAPNG(std::vector<uint8_t> &buffer, std::function<void(std::shared_ptr<APNG>)> completion) {
@@ -230,7 +204,10 @@ static void parseAPNG(std::vector<uint8_t> &buffer, std::function<void(std::shar
                 frame->disposeOp = 1;
             }
         } else if (type == "fdAT") {
-            frame->dataParts.push_back(subBuffer(bytes, off + 8 + 4, static_cast<size_t>(length - 4)));
+            std::vector<uint8_t> payload;
+            if (tryFdATPayload(bytes, off, length, payload)) {
+                frame->dataParts.push_back(std::move(payload));
+            }
         } else if (type == "IDAT") {
             frame->dataParts.push_back(subBuffer(bytes, off + 8, length));
         } else if (type == "IEND") {

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/ApngParserBuffer.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/ApngParserBuffer.h
@@ -1,0 +1,102 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_APNGPARSERBUFFER_H
+#define CORE_RENDER_OHOS_APNGPARSERBUFFER_H
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+// Leftover APNG buffer helpers. subBuffer/readString indexed with no range
+// check; fdAT did size_t(length - 4) (underflow when length < 4 → huge copy);
+// eachChunk advanced off += 12+length without ensuring the chunk fits.
+// Header-only so host g++ leftover tests compile without Harmony / ArkUI.
+
+inline bool SubBufferInRange(size_t size, size_t start, size_t length) {
+    return start <= size && length <= size - start;
+}
+
+inline std::vector<uint8_t> subBuffer(const std::vector<uint8_t> &bytes, size_t start, size_t length) {
+    if (!SubBufferInRange(bytes.size(), start, length)) {
+        throw std::out_of_range("subBuffer out of range");
+    }
+    return std::vector<uint8_t>(bytes.begin() + static_cast<std::ptrdiff_t>(start),
+                                bytes.begin() + static_cast<std::ptrdiff_t>(start + length));
+}
+
+inline std::string readString(const std::vector<uint8_t> &bytes, size_t off, size_t length) {
+    if (!SubBufferInRange(bytes.size(), off, length)) {
+        throw std::out_of_range("readString out of range");
+    }
+    std::string result;
+    result.reserve(length);
+    for (size_t i = 0; i < length; ++i) {
+        result.push_back(static_cast<char>(bytes[off + i]));
+    }
+    return result;
+}
+
+// fdAT payload is chunk data minus the 4-byte sequence number.
+// length < 4 must reject: size_t(length - 4) underflows to a huge copy / crash.
+inline bool tryFdATPayload(const std::vector<uint8_t> &bytes, size_t off, size_t length, std::vector<uint8_t> &out) {
+    out.clear();
+    if (length < 4) {
+        return false;
+    }
+    // start = off + 8 (chunk data) + 4 (sequence number)
+    if (off > bytes.size() || bytes.size() - off < 12) {
+        return false;
+    }
+    const size_t start = off + 12;
+    const size_t payload_len = length - 4;
+    if (!SubBufferInRange(bytes.size(), start, payload_len)) {
+        return false;
+    }
+    out = subBuffer(bytes, start, payload_len);
+    return true;
+}
+
+inline uint32_t ReadChunkLengthBE(const std::vector<uint8_t> &bytes, size_t off) {
+    return (static_cast<uint32_t>(bytes[off]) << 24) | (static_cast<uint32_t>(bytes[off + 1]) << 16) |
+           (static_cast<uint32_t>(bytes[off + 2]) << 8) | static_cast<uint32_t>(bytes[off + 3]);
+}
+
+// PNG chunk: 4-byte length + 4-byte type + `length` data + 4-byte CRC.
+// Stop if the 8-byte header is missing or 12+length would run past size
+// (also guards size_t overflow of 12+length).
+inline void eachChunk(std::vector<uint8_t> &bytes,
+                      std::function<bool(const std::string &, std::vector<uint8_t> &, size_t, size_t)> callback) {
+    size_t off = 8;
+    while (off <= bytes.size() && bytes.size() - off >= 8) {
+        const size_t length = ReadChunkLengthBE(bytes, off);
+        // 12+length must not wrap size_t or run past the buffer.
+        if (length > static_cast<size_t>(-1) - 12 || bytes.size() - off < 12 ||
+            length > bytes.size() - off - 12) {
+            break;
+        }
+        const std::string type = readString(bytes, off + 4, 4);
+        const bool res = callback(type, bytes, off, length);
+        if (!res || type == "IEND") {
+            break;
+        }
+        off += 12 + length;
+    }
+}
+
+#endif  // CORE_RENDER_OHOS_APNGPARSERBUFFER_H

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/apng_parser_buffer_test.cpp
+++ b/core-render-ohos/src/test/cpp/apng_parser_buffer_test.cpp
@@ -1,0 +1,150 @@
+// Host unit test for leftover ApngParser subBuffer / fdAT / eachChunk bounds.
+//
+// subBuffer did vector(begin+start, begin+start+length) with no range check.
+// fdAT did size_t(length - 4): length 0/2 underflows to a huge copy / crash.
+// eachChunk advanced off += 12+length without ensuring the chunk fits.
+//
+// Helpers live in header-only ApngParserBuffer.h so this compiles without
+// Harmony / ArkUI. Build + run (from this directory):
+//   ./run_apng_parser_buffer_test.sh
+//   ./run_apng_parser_buffer_test.sh asan
+
+#include "ApngParserBuffer.h"
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static bool subBufferThrows(const std::vector<uint8_t> &bytes, size_t start, size_t length) {
+    try {
+        (void)subBuffer(bytes, start, length);
+        return false;
+    } catch (const std::out_of_range &) {
+        return true;
+    }
+}
+
+static std::vector<uint8_t> MakeBeU32(uint32_t value) {
+    return {static_cast<uint8_t>((value >> 24) & 0xFF), static_cast<uint8_t>((value >> 16) & 0xFF),
+            static_cast<uint8_t>((value >> 8) & 0xFF), static_cast<uint8_t>(value & 0xFF)};
+}
+
+static std::vector<uint8_t> MakePngPrefix() {
+    return {0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a};
+}
+
+int main() {
+    const std::vector<uint8_t> bytes = {0, 1, 2, 3, 4};
+
+    // leftover: in-range slice still copies
+    {
+        auto got = subBuffer(bytes, 1, 3);
+        expect_true("subBuffer(1,3) size", got.size() == 3 && got[0] == 1 && got[2] == 3);
+        expect_true("SubBufferInRange(1,3)", SubBufferInRange(bytes.size(), 1, 3));
+    }
+
+    // leftover: start > size / length > size-start must reject (no OOB iterator)
+    {
+        expect_true("subBuffer start > size throws", subBufferThrows(bytes, 6, 1));
+        expect_true("subBuffer start == size+1 throws", subBufferThrows(bytes, bytes.size() + 1, 0));
+        expect_true("subBuffer length > size-start throws", subBufferThrows(bytes, 3, 3));
+        expect_true("SubBufferInRange start > size", !SubBufferInRange(bytes.size(), 6, 1));
+        expect_true("SubBufferInRange length OOB", !SubBufferInRange(bytes.size(), 3, 3));
+    }
+
+    // leftover: readString off+i was unchecked
+    {
+        bool threw = false;
+        try {
+            (void)readString(bytes, 4, 4);
+        } catch (const std::out_of_range &) {
+            threw = true;
+        }
+        expect_true("readString OOB throws", threw);
+        expect_true("readString in-range", readString(bytes, 1, 3) == "\x01\x02\x03");
+    }
+
+    // leftover: fdAT length=0 / length=2 must reject without size_t underflow
+    {
+        // off=0, need at least 12 bytes of chunk header+seq so start=12 is defined.
+        std::vector<uint8_t> chunk(16, 0xAB);
+        std::vector<uint8_t> out = {0xFF};
+
+        expect_true("tryFdATPayload length=0 rejects", !tryFdATPayload(chunk, 0, 0, out) && out.empty());
+        out = {0xFF};
+        expect_true("tryFdATPayload length=2 rejects", !tryFdATPayload(chunk, 0, 2, out) && out.empty());
+
+        // length=4 → empty payload after dropping the sequence number
+        expect_true("tryFdATPayload length=4 empty payload",
+                    tryFdATPayload(chunk, 0, 4, out) && out.empty());
+
+        // length=6 → two payload bytes at off+12
+        chunk[12] = 0x11;
+        chunk[13] = 0x22;
+        expect_true("tryFdATPayload length=6 payload",
+                    tryFdATPayload(chunk, 0, 6, out) && out.size() == 2 && out[0] == 0x11 && out[1] == 0x22);
+    }
+
+    // leftover: eachChunk must stop when off+8 > size (truncated after signature)
+    {
+        auto short_png = MakePngPrefix();
+        short_png.insert(short_png.end(), {0x00, 0x00});  // only 2 of 8 header bytes
+        int calls = 0;
+        eachChunk(short_png, [&](const std::string &, std::vector<uint8_t> &, size_t, size_t) {
+            ++calls;
+            return true;
+        });
+        expect_true("eachChunk off+8 > size stops", calls == 0);
+    }
+
+    // leftover: eachChunk must stop when 12+length would overflow past size
+    {
+        auto truncated = MakePngPrefix();
+        auto len = MakeBeU32(8);  // claims 8 data bytes
+        truncated.insert(truncated.end(), len.begin(), len.end());
+        truncated.insert(truncated.end(), {'I', 'D', 'A', 'T'});
+        truncated.insert(truncated.end(), {0x01, 0x02});  // only 2 of 8+4
+        int calls = 0;
+        eachChunk(truncated, [&](const std::string &, std::vector<uint8_t> &, size_t, size_t) {
+            ++calls;
+            return true;
+        });
+        expect_true("eachChunk 12+length past size stops", calls == 0);
+    }
+
+    // leftover: a complete empty IEND chunk is still visited
+    {
+        auto iend = MakePngPrefix();
+        auto len = MakeBeU32(0);
+        iend.insert(iend.end(), len.begin(), len.end());
+        iend.insert(iend.end(), {'I', 'E', 'N', 'D'});
+        iend.insert(iend.end(), {0, 0, 0, 0});  // crc
+        int calls = 0;
+        std::string seen;
+        eachChunk(iend, [&](const std::string &type, std::vector<uint8_t> &, size_t, size_t length) {
+            ++calls;
+            seen = type;
+            return length == 0;
+        });
+        expect_true("eachChunk complete IEND", calls == 1 && seen == "IEND");
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_apng_parser_buffer_test.sh
+++ b/core-render-ohos/src/test/cpp/run_apng_parser_buffer_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Compile + run leftover ApngParser subBuffer/fdAT host unit tests (no Harmony device).
+#
+# Usage:
+#   ./run_apng_parser_buffer_test.sh          # g++ default
+#   ./run_apng_parser_buffer_test.sh asan     # Address+UB sanitizers
+#
+# ApngParser.h pulls APNGStructs.h (ArkUI). Helpers live in header-only
+# ApngParserBuffer.h, so host g++/clang++ is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APNG_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/components/apng"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$APNG_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/apng_parser_buffer_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/apng_parser_buffer_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/apng_parser_buffer_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`ApngParser.h` `subBuffer` copied `[start, start+length)` with no range check. `fdAT` did `size_t(length - 4)` — `length < 4` underflows to a huge copy/crash. `eachChunk` advanced `off += 12+length` without ensuring the chunk fits.

Distinct from #1660 (reserve→resize) and #1665 (dispose PREVIOUS).

Fix: bounds-checked helpers in `ApngParserBuffer.h`; `tryFdATPayload` rejects `length < 4`; `eachChunk` stops on overflow.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_apng_parser_buffer_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
