### PR TITLE
fix(miniApp): remove negative zIndex from Tabs indicator

### DIFF
--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TabsView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TabsView.kt
@@ -165,7 +165,6 @@ class TabsView : ListView<TabsAttr, TabsEvent>(), IPagerLayoutEventObserver {
                 }
                 attr {
                     absolutePosition(top = 0f, left = 0f)
-                    zIndex(-1)
                     visibility(false)
                 }
                 creator.invoke(this)


### PR DESCRIPTION
# The PR
Related: #1683

The indicator of the Tabs component works normally on Android, iOS and HarmonyOS devices, but fails to display correctly when running in the WeChat Mini‑Program. After investigation and testing, the root cause was that the `zIndex` property of this component was not removed properly.

## Issue
While using KuiklyUI, I encountered an issue as shown in the screenshot:
<img width="1588" height="170" alt="image" src="https://github.com/user-attachments/assets/5cd5e16d-278d-4210-aaf1-04e4b0ecd30b" />

## Fix
As we can see, when the indicator is not empty, `zIndex` is set to `-1` by default to hide the indicator:
https://github.com/Tencent-TDS/KuiklyUI/blob/ab3abc769b2295789ffafcb4631418026e916461/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TabsView.kt#L161-L173

However, only the visibility state was updated when showing the indicator, while the `zIndex` value was left untouched.
Tests verified that removing this `zIndex` will not introduce abnormal behaviors for Tabs. Therefore, directly deleting the problematic `zIndex` assignment is the proper solution.

Related code lines:
https://github.com/Tencent-TDS/KuiklyUI/blob/ab3abc769b2295789ffafcb4631418026e916461/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TabsView.kt#L68-L78
https://github.com/Tencent-TDS/KuiklyUI/blob/ab3abc769b2295789ffafcb4631418026e916461/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TabsView.kt#L77
