### PR TITLE
fix(ohos): leftover KRScrollerView SetContentOffset split OOB

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRContentOffsetParse.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRContentOffsetParse.h
@@ -1,0 +1,102 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_KRCONTENTOFFSETPARSE_H
+#define CORE_RENDER_OHOS_KRCONTENTOFFSETPARSE_H
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace kuikly {
+namespace util {
+
+// Leftover KRScrollerView::SetContentOffset helpers.
+// SplitString(value, ' ') then indexed [0]/[1]/[2] with no size check.
+// iOS css_contentOffsetWithParams uses:
+//   animated = count > 2 ? points[2] : NO
+//   firstObject / points[1] for x/y
+// so "10 20" (no animate token) is valid on iOS and crashes on OHOS.
+// #1663 guarded inset / border / shadow short props, not this method.
+// Header-only so host g++ can compile without Harmony / ArkUI.
+
+inline std::vector<std::string> SplitContentOffsetTokens(const std::string &str) {
+    std::vector<std::string> tokens;
+    std::string token;
+    std::istringstream tokenStream(str);
+    while (std::getline(tokenStream, token, ' ')) {
+        tokens.push_back(token);
+    }
+    return tokens;
+}
+
+inline float ParseContentOffsetFloat(const std::string &token) {
+    try {
+        return std::stof(token);
+    } catch (...) {
+        return 0.f;
+    }
+}
+
+inline int ParseContentOffsetInt(const std::string &token) {
+    try {
+        return std::stoi(token);
+    } catch (...) {
+        return 0;
+    }
+}
+
+inline bool ParseContentOffsetBool(const std::string &token) {
+    if (token.empty() || token == "0" || token == "false") {
+        return false;
+    }
+    try {
+        return std::stof(token) != 0.f;
+    } catch (...) {
+        return true;
+    }
+}
+
+struct KRContentOffsetArgs {
+    float offset_x = 0.f;
+    float offset_y = 0.f;
+    bool animate = false;
+    int duration = 0;
+    float damping = 0.f;
+    int curve = 0;
+};
+
+// Policy:
+//   size < 2 → return false (do not write outs; cannot form a point)
+//   size == 2 → x, y, animate=false (iOS sibling)
+//   size >= 3 → x, y, animate, plus existing optional duration/damping/curve
+inline bool ParseContentOffset(const std::string &value, KRContentOffsetArgs &out) {
+    const std::vector<std::string> tokens = SplitContentOffsetTokens(value);
+    if (tokens.size() < 2) {
+        return false;
+    }
+    out.offset_x = ParseContentOffsetFloat(tokens[0]);
+    out.offset_y = ParseContentOffsetFloat(tokens[1]);
+    out.animate = tokens.size() > 2 ? ParseContentOffsetBool(tokens[2]) : false;
+    out.duration = tokens.size() > 3 ? ParseContentOffsetInt(tokens[3]) : 0;
+    out.damping = tokens.size() > 4 ? ParseContentOffsetFloat(tokens[4]) : 0.f;
+    out.curve = tokens.size() > 6 ? ParseContentOffsetInt(tokens[6]) : 0;
+    return true;
+}
+
+}  // namespace util
+}  // namespace kuikly
+
+#endif  // CORE_RENDER_OHOS_KRCONTENTOFFSETPARSE_H

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/scroller/KRScrollerView.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 
 #include "libohos_render/expand/components/scroller/KRScrollerView.h"
+#include "libohos_render/expand/components/scroller/KRContentOffsetParse.h"
 
 #include <cfloat>
 #include <cmath>
@@ -428,13 +429,19 @@ bool KRScrollerView::RegisterWillDragEndEvent(const KRRenderCallback event_callb
  * @param value
  */
 void KRScrollerView::SetContentOffset(const KRAnyValue &value) {
-    auto content_offset_splits = kuikly::util::SplitString(value->toString(), ' ');
-    auto offset_x = content_offset_splits[0]->toFloat();
-    auto offset_y = content_offset_splits[1]->toFloat();
-    auto animate = content_offset_splits[2]->toBool();
-    auto duration = content_offset_splits.size() > 3 ? content_offset_splits[3]->toInt() : 0;
-    auto damping = content_offset_splits.size() > 4 ? content_offset_splits[4]->toFloat() : 0;
-    auto curve = content_offset_splits.size() > 6 ? content_offset_splits[6]->toInt() : 0;
+    // Leftover: [0]/[1]/[2] were unguarded after SplitString. iOS uses
+    // count > 2 for animate, so "10 20" is valid there and OOB here.
+    // #1663 covered inset/border/shadow, not this method.
+    kuikly::util::KRContentOffsetArgs args;
+    if (!kuikly::util::ParseContentOffset(value->toString(), args)) {
+        return;
+    }
+    auto offset_x = args.offset_x;
+    auto offset_y = args.offset_y;
+    auto animate = args.animate;
+    auto duration = args.duration;
+    auto damping = args.damping;
+    auto curve = args.curve;
 
     if (!is_set_frame_) {
         first_offset_x_ = offset_x;

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_content_offset_parse_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_content_offset_parse_test.cpp
@@ -1,0 +1,121 @@
+// Host unit test for leftover KRScrollerView::SetContentOffset split OOB.
+//
+// Leftover:
+//   auto splits = SplitString(value->toString(), ' ');
+//   offset_x = splits[0]->toFloat();
+//   offset_y = splits[1]->toFloat();
+//   animate  = splits[2]->toBool();   // no size check
+//
+// iOS css_contentOffsetWithParams:
+//   animated = [points count] > 2 ? [points[2] boolValue] : NO;
+// so "10 20" is valid on iOS and operator[] OOB on OHOS.
+// #1663 guarded inset / border / shadow, not this method.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_kr_content_offset_parse_test.sh
+//   ./run_kr_content_offset_parse_test.sh asan
+
+#include "KRContentOffsetParse.h"
+
+#include <cmath>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+static int g_failed = 0;
+
+static bool floats_eq(float a, float b) {
+    return std::fabs(a - b) <= 0.0001f;
+}
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void leftover_index_oob(const char *name, const std::string &s) {
+    const std::vector<std::string> tokens = kuikly::util::SplitContentOffsetTokens(s);
+    bool threw = false;
+    try {
+        (void)tokens.at(0);
+        (void)tokens.at(1);
+        (void)tokens.at(2);
+    } catch (const std::out_of_range &) {
+        threw = true;
+    }
+    expect_true(name, threw);
+}
+
+static void expect_parse(const char *name, const std::string &value, bool want_applied, float x, float y, bool animate,
+                         int duration, float damping, int curve) {
+    kuikly::util::KRContentOffsetArgs args;
+    args.offset_x = -1.f;
+    args.offset_y = -1.f;
+    args.animate = true;
+    args.duration = -1;
+    args.damping = -1.f;
+    args.curve = -1;
+    bool applied = false;
+    try {
+        applied = kuikly::util::ParseContentOffset(value, args);
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: threw std::exception: %s\n", name, e.what());
+        ++g_failed;
+        return;
+    } catch (...) {
+        std::fprintf(stderr, "FAIL %s: threw unknown exception\n", name);
+        ++g_failed;
+        return;
+    }
+    if (applied != want_applied) {
+        std::fprintf(stderr, "FAIL %s: applied=%d want %d\n", name, static_cast<int>(applied),
+                     static_cast<int>(want_applied));
+        ++g_failed;
+        return;
+    }
+    if (!want_applied) {
+        if (!floats_eq(args.offset_x, -1.f) || !floats_eq(args.offset_y, -1.f) || args.animate != true ||
+            args.duration != -1 || !floats_eq(args.damping, -1.f) || args.curve != -1) {
+            std::fprintf(stderr, "FAIL %s: size<2 wrote outs\n", name);
+            ++g_failed;
+            return;
+        }
+        std::printf("PASS %s (skip apply, no throw)\n", name);
+        return;
+    }
+    if (!floats_eq(args.offset_x, x) || !floats_eq(args.offset_y, y) || args.animate != animate ||
+        args.duration != duration || !floats_eq(args.damping, damping) || args.curve != curve) {
+        std::fprintf(stderr,
+                     "FAIL %s: got (%.4f %.4f a=%d d=%d damp=%.4f c=%d) want (%.4f %.4f a=%d d=%d damp=%.4f c=%d)\n",
+                     name, args.offset_x, args.offset_y, static_cast<int>(args.animate), args.duration, args.damping,
+                     args.curve, x, y, static_cast<int>(animate), duration, damping, curve);
+        ++g_failed;
+        return;
+    }
+    std::printf("PASS %s (%.4g %.4g a=%d, no throw)\n", name, args.offset_x, args.offset_y,
+                static_cast<int>(args.animate));
+}
+
+int main() {
+    leftover_index_oob("leftover \"\" [0] OOB", "");
+    leftover_index_oob("leftover \"10\" [1] OOB", "10");
+    leftover_index_oob("leftover \"10 20\" [2] OOB (iOS-valid)", "10 20");
+
+    expect_parse("\"\" (size<2)", "", false, 0.f, 0.f, false, 0, 0.f, 0);
+    expect_parse("\"10\" (size<2)", "10", false, 0.f, 0.f, false, 0, 0.f, 0);
+    expect_parse("\"10 20\" iOS 2-token", "10 20", true, 10.f, 20.f, false, 0, 0.f, 0);
+    expect_parse("\"10 20 1\"", "10 20 1", true, 10.f, 20.f, true, 0, 0.f, 0);
+    expect_parse("\"10 20 0 200 0.5 0 2\"", "10 20 0 200 0.5 0 2", true, 10.f, 20.f, false, 200, 0.5f, 2);
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_content_offset_parse_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_content_offset_parse_test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Compile + run leftover KRScrollerView::SetContentOffset host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_kr_content_offset_parse_test.sh          # g++ default
+#   ./run_kr_content_offset_parse_test.sh asan     # Address+UB sanitizers
+#
+# Parse helpers live in header-only KRContentOffsetParse.h (no ArkUI).
+# Host g++/clang++ includes it directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCROLLER_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/components/scroller"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$SCROLLER_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_content_offset_parse_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_content_offset_parse_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_content_offset_parse_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`KRScrollerView::SetContentOffset` split on space then indexed `[0]` / `[1]` / `[2]` with no size check. Duration / damping / curve already used `size() > N`. iOS `css_contentOffsetWithParams` uses `count > 2` for animate, so `"10 20"` (no animate token) is valid there and `operator[]` OOB here.

- `""` / `"10"` → skip apply (cannot form a point)
- `"10 20"` → x/y, animate=false (iOS sibling)
- `"10 20 1"` and longer → existing optional duration / damping / curve

`#1663` guarded inset / border / shadow short props (`KRScrollerContentInset.h`, `KRConvertUtil`, `KRViewUtil`). It did not touch `KRScrollerView.cpp` / `SetContentOffset`.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_content_offset_parse_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>