### PR TITLE
fix(ohos): leftover KRViewContext constructor bare stoi

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewContext.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRViewContext.h
@@ -17,6 +17,19 @@
 #define CORE_RENDER_OHOS_KRVIEWCONTEXT_H
 #include <string>
 
+// Leftover: KRViewContext(instance_id, tag) used bare std::stoi.
+// Empty / non-numeric / out-of-range ids throw std::invalid_argument
+// or std::out_of_range (uncaught → crash). Sibling KRRenderView uses
+// atoi (no throw). No prior leftover PR covers this constructor.
+// Header-only so host g++ can compile without Harmony / ArkUI.
+inline int ParseInstanceId(const std::string &instance_id) {
+    try {
+        return std::stoi(instance_id);
+    } catch (...) {
+        return 0;
+    }
+}
+
 struct KRViewContext final{
 private:
     union Boxing{
@@ -29,7 +42,7 @@ private:
     };
 public:
     KRViewContext(const std::string& instance_id, int tag){
-        box_.instance = std::stoi(instance_id);
+        box_.instance = ParseInstanceId(instance_id);
         box_.tag = tag;
     }
     constexpr KRViewContext(const void *context){

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_view_context_stoi_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_view_context_stoi_test.cpp
@@ -1,0 +1,99 @@
+// Host unit test for leftover KRViewContext constructor bare std::stoi.
+//
+// Leftover:
+//   KRViewContext(const std::string& instance_id, int tag){
+//       box_.instance = std::stoi(instance_id);
+//   }
+//
+// Empty / "abc" throw std::invalid_argument; oversized digits throw
+// std::out_of_range. Uncaught → process abort. Sibling KRRenderView
+// uses atoi (no throw). No prior leftover PR covers this constructor.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_kr_view_context_stoi_test.sh
+//   ./run_kr_view_context_stoi_test.sh asan
+
+#include "KRViewContext.h"
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void leftover_stoi_throws(const char *name, const std::string &s) {
+    bool threw = false;
+    try {
+        (void)std::stoi(s);
+    } catch (const std::invalid_argument &) {
+        threw = true;
+    } catch (const std::out_of_range &) {
+        threw = true;
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: leftover stoi threw %s\n", name, e.what());
+        ++g_failed;
+        return;
+    }
+    expect_true(name, threw);
+}
+
+static void expect_parse(const char *name, const std::string &id, int want) {
+    int got = -12345;
+    try {
+        got = ParseInstanceId(id);
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: threw std::exception: %s\n", name, e.what());
+        ++g_failed;
+        return;
+    } catch (...) {
+        std::fprintf(stderr, "FAIL %s: threw unknown exception\n", name);
+        ++g_failed;
+        return;
+    }
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got %d want %d\n", name, got, want);
+        ++g_failed;
+        return;
+    }
+    try {
+        KRViewContext ctx(id, 7);
+        if (ctx.Instance() != want || ctx.Tag() != 7) {
+            std::fprintf(stderr, "FAIL %s: ctor Instance=%d Tag=%d\n", name, ctx.Instance(), ctx.Tag());
+            ++g_failed;
+            return;
+        }
+    } catch (const std::exception &e) {
+        std::fprintf(stderr, "FAIL %s: KRViewContext ctor threw: %s\n", name, e.what());
+        ++g_failed;
+        return;
+    }
+    std::printf("PASS %s (instance=%d, no throw)\n", name, got);
+}
+
+int main() {
+    leftover_stoi_throws("leftover stoi(\"\")", "");
+    leftover_stoi_throws("leftover stoi(\"abc\")", "abc");
+    leftover_stoi_throws("leftover stoi(overflow)", "9999999999999999999");
+
+    expect_parse("\"\"", "", 0);
+    expect_parse("\"abc\"", "abc", 0);
+    expect_parse("overflow", "9999999999999999999", 0);
+    expect_parse("\"42\"", "42", 42);
+    expect_parse("\"12x\"", "12x", 12);
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_view_context_stoi_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_view_context_stoi_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Compile + run leftover KRViewContext constructor host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_kr_view_context_stoi_test.sh          # g++ default
+#   ./run_kr_view_context_stoi_test.sh asan     # Address+UB sanitizers
+#
+# KRViewContext.h is already header-only (no ArkUI). Host g++ includes it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UTIL_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/utils"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$UTIL_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_view_context_stoi_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_view_context_stoi_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_view_context_stoi_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`KRViewContext(const std::string& instance_id, int tag)` used bare `std::stoi(instance_id)`. Empty / non-numeric ids throw `std::invalid_argument`; oversized digits throw `std::out_of_range`. Uncaught → crash on image adapter / view-context boxing (`KRImageView::SetImageSrc`).

Sibling `KRRenderView` already uses `std::atoi` (no throw). No prior leftover PR covers this constructor (`#1674` is `Date::Parse`, `#1666` canvas `SetFont`, `#1672` animation parse).

Fix: `ParseInstanceId` try/catch, default 0 on failure. Union boxing / `InstanceString` unchanged.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_view_context_stoi_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>