### PR TITLE
fix(ohos): leftover KREncodeURLComponent signed-char hex-index OOB

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/codec/KRCodec.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/codec/KRCodec.cpp
@@ -27,29 +27,13 @@ inline namespace model_util {
 const char HEX_DIGITS[] = "0123456789abcdef";
 // Maps integer in the range [0,16) to a hex digit.
 
-const char HEX_DIGITS_URI[] = "0123456789ABCDEF";
-// RFC 3986 section 2.1 says "For consistency, URI producers and normalizers should use uppercase
-// hexadecimal digits for all percent-encodings.
-
 const char base64_chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                             "abcdefghijklmnopqrstuvwxyz"
                             "0123456789+/";
 // Maps integer in the range [0,16) to a hex digit.
 
-std::string KREncodeURLComponent(const std::string &in) {
-    std::string out;
-    for (auto &b : in) {
-        if (('A' <= b && b <= 'Z') || ('a' <= b && b <= 'z') || ('0' <= b && b <= '9') || b == '-' || b == '_' ||
-            b == '.' || b == '!' || b == '~' || b == '*' || b == '\'' || b == '(' || b == ')') {
-            out.push_back(b);
-        } else {
-            out.push_back('%');
-            out.push_back(HEX_DIGITS_URI[b / 16]);
-            out.push_back(HEX_DIGITS_URI[b % 16]);
-        }
-    }
-    return out;
-}
+// leftover KREncodeURLComponent is header-only in KRCodecEncode.h so host
+// tests compile the leftover unsigned-char hex-index path without Harmony.
 
 std::string KRDecodeURLComponent(const std::string &in) {
     std::string res;

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/codec/KRCodec.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/codec/KRCodec.h
@@ -15,10 +15,10 @@
 #pragma once
 
 #include <string>
+#include "KRCodecEncode.h"
 
 namespace kuikly {
 inline namespace model_util {
-std::string KREncodeURLComponent(const std::string &str);
 
 std::string KRDecodeURLComponent(const std::string &str);
 

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/codec/KRCodecEncode.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/codec/KRCodecEncode.h
@@ -1,0 +1,46 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+namespace kuikly {
+inline namespace model_util {
+
+// RFC 3986 section 2.1: URI producers should use uppercase hex digits.
+inline constexpr char kHexDigitsUri[] = "0123456789ABCDEF";
+
+// leftover: KREncodeURLComponent iterated `auto &b : in` (signed char on
+// OHOS aarch64/x86_64). UTF-8 high bytes (e.g. 0xE4 in "你") became
+// HEX_DIGITS_URI[b / 16] with b/16 == -1 — OOB into a 16-entry table.
+// Sibling KRBase64Encode already iterates unsigned char.
+// Header-only so host leftover tests compile without Harmony / md5 / sha256.
+inline std::string KREncodeURLComponent(const std::string &in) {
+    std::string out;
+    for (unsigned char b : in) {
+        if (('A' <= b && b <= 'Z') || ('a' <= b && b <= 'z') || ('0' <= b && b <= '9') || b == '-' || b == '_' ||
+            b == '.' || b == '!' || b == '~' || b == '*' || b == '\'' || b == '(' || b == ')') {
+            out.push_back(static_cast<char>(b));
+        } else {
+            out.push_back('%');
+            out.push_back(kHexDigitsUri[b / 16]);
+            out.push_back(kHexDigitsUri[b % 16]);
+        }
+    }
+    return out;
+}
+
+}  //  namespace util
+}  //  namespace kuikly

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_encode_url_signed_char_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_encode_url_signed_char_test.cpp
@@ -1,0 +1,79 @@
+// Host unit test for leftover KREncodeURLComponent signed-char hex-index OOB.
+//
+// Leftover:
+//   for (auto &b : in) { ... HEX_DIGITS_URI[b / 16] ... }
+//
+// On OHOS aarch64/x86_64 char is signed. UTF-8 high bytes (0xE4 in "你")
+// make b/16 == -1 and b%16 == -12. UBSAN: index -1 out of bounds for
+// char[17]. Result is garbage ("%") instead of "%E4%BD%A0%E5%A5%BD".
+// Sibling KRBase64Encode already iterates unsigned char.
+//
+// Header-only KRCodecEncode.h so this compiles without Harmony / md5.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_kr_encode_url_signed_char_test.sh
+//   ./run_kr_encode_url_signed_char_test.sh asan
+
+#include "KRCodecEncode.h"
+
+#include <cstdio>
+#include <string>
+
+using kuikly::KREncodeURLComponent;
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_eq(const char *name, const std::string &got, const std::string &want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got \"%s\" want \"%s\"\n", name, got.c_str(), want.c_str());
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+// leftover polarity: signed char 0xE4 indexes HEX_DIGITS_URI[-1] / [-12].
+static void leftover_signed_index_polarity() {
+    char b = static_cast<char>(0xE4);
+    expect_true("host char is signed (leftover precondition)", b < 0);
+    expect_true("leftover 0xE4 b/16 is -1 (OOB)", (b / 16) == -1);
+    expect_true("leftover 0xE4 b%16 is -12 (OOB)", (b % 16) == -12);
+
+    unsigned char ub = static_cast<unsigned char>(0xE4);
+    expect_true("leftover unsigned 0xE4 b/16 is 14", (ub / 16) == 14);
+    expect_true("leftover unsigned 0xE4 b%16 is 4", (ub % 16) == 4);
+}
+
+int main() {
+    leftover_signed_index_polarity();
+
+    // leftover: ASCII unreserved stays unescaped.
+    expect_eq("hello", KREncodeURLComponent("hello"), "hello");
+    expect_eq("unreserved", KREncodeURLComponent("AZaz09-_.!~*'()"), "AZaz09-_.!~*'()");
+
+    // leftover: reserved / non-unreserved ASCII is percent-encoded (uppercase).
+    expect_eq("space", KREncodeURLComponent(" "), "%20");
+    expect_eq("hello world", KREncodeURLComponent("hello world"), "hello%20world");
+    expect_eq("slash", KREncodeURLComponent("a/b"), "a%2Fb");
+
+    // leftover: UTF-8 "你好" (E4 BD A0 E5 A5 BD) used to OOB on signed char.
+    expect_eq("nihao", KREncodeURLComponent("你好"), "%E4%BD%A0%E5%A5%BD");
+
+    expect_eq("empty", KREncodeURLComponent(""), "");
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all leftover encode tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_encode_url_signed_char_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_encode_url_signed_char_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Compile + run leftover KREncodeURLComponent host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_kr_encode_url_signed_char_test.sh          # g++ default
+#   ./run_kr_encode_url_signed_char_test.sh asan     # Address+UB sanitizers
+#
+# KRCodecEncode.h is header-only (no ArkUI / md5). Host g++ includes it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CODEC_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/modules/codec"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$CODEC_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_encode_url_signed_char_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_encode_url_signed_char_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_encode_url_signed_char_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`KREncodeURLComponent` iterated `auto &b : in` then indexed `HEX_DIGITS_URI[b / 16]` / `[b % 16]`. On OHOS aarch64/x86_64 `char` is signed. UTF-8 high bytes (e.g. `0xE4` in `"你"`) make `b/16 == -1` and `b%16 == -12`.

UBSAN: `index -1 out of bounds for type 'char [17]'`. Host leftover result for `"你好"` is garbage (`"%"`) instead of `"%E4%BD%A0%E5%A5%BD"`. Caller is `KRCodecModule::urlEncode`. Sibling `KRBase64Encode` already iterates `unsigned char`.

Fix: iterate `unsigned char`, same unreserved set / uppercase hex. Header-only `KRCodecEncode.h` so host leftover tests compile without Harmony / md5.

Does not touch leftover `KRDecodeURLComponent` ctype (`isxdigit` on raw `char`) — that is UB, not this table OOB.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_encode_url_signed_char_test.sh
core-render-ohos/src/test/cpp/run_kr_encode_url_signed_char_test.sh asan
```

Signed-off-by: Tony Coder <407243179@qq.com>