### PR TITLE
fix(ohos): leftover APNG fcTL blend/dispose dstIdx OOB

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGBlendBounds.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGBlendBounds.h
@@ -1,0 +1,83 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_APNG_BLEND_BOUNDS_H
+#define CORE_RENDER_OHOS_APNG_BLEND_BOUNDS_H
+
+#include <cstddef>
+#include <cstdint>
+
+// Leftover APNG fcTL blend / BACKGROUND dispose helpers.
+//
+// ApngParser copies fcTL width/height/left/top with no check against IHDR.
+// HandleFrameBlendOp / HandlePostFrameDisposeOp then did
+//   dstIdx = ((y + top) * canvasW + (x + left)) * 4
+// and wrote drawingBuffer[dstIdx .. dstIdx+3] with no range check.
+// A fcTL with left+width > canvasW (or negative / overflowing int) is an
+// OOB write. APNG spec requires the frame rect to lie inside IHDR.
+//
+// Header-only so host g++ leftover tests compile without Harmony / ArkUI.
+
+inline bool ApngCanvasBufferBigEnough(int canvasW, int canvasH, size_t bufBytes) {
+    if (canvasW <= 0 || canvasH <= 0) {
+        return false;
+    }
+    const int64_t need = static_cast<int64_t>(canvasW) * static_cast<int64_t>(canvasH) * 4;
+    if (need <= 0) {
+        return false;
+    }
+    return static_cast<uint64_t>(need) <= bufBytes;
+}
+
+// True iff the fcTL rect is entirely inside the IHDR canvas (no int overflow).
+inline bool ApngFrameRectInCanvas(int left, int top, int fw, int fh, int canvasW, int canvasH) {
+    if (fw <= 0 || fh <= 0 || canvasW <= 0 || canvasH <= 0) {
+        return false;
+    }
+    if (left < 0 || top < 0) {
+        return false;
+    }
+    const int64_t right = static_cast<int64_t>(left) + fw;
+    const int64_t bottom = static_cast<int64_t>(top) + fh;
+    return right <= canvasW && bottom <= canvasH;
+}
+
+// leftover dstIdx formula, exposed so host tests can show OOB polarity.
+inline int64_t ApngLeftoverDstIdx(int x, int y, int left, int top, int canvasW) {
+    return (static_cast<int64_t>(y) + top) * canvasW + (static_cast<int64_t>(x) + left);
+}
+
+// leftover: the old formula wraps to the next scanline when col>=canvasW,
+// and is a true heap OOB when the linear index runs past width*height
+// (last rows, huge left/top, or a short buffer).
+inline bool ApngLeftoverDstWouldOOB(int x, int y, int left, int top, int fw, int fh, int canvasW, int canvasH,
+                                    size_t bufBytes) {
+    if (x < 0 || y < 0 || x >= fw || y >= fh) {
+        return true;
+    }
+    const int64_t col = static_cast<int64_t>(x) + left;
+    const int64_t row = static_cast<int64_t>(y) + top;
+    if (col < 0 || row < 0 || col >= canvasW || row >= canvasH) {
+        return true;
+    }
+    const int64_t pix = ApngLeftoverDstIdx(x, y, left, top, canvasW);
+    const int64_t byte = pix * 4;
+    if (byte < 0) {
+        return true;
+    }
+    return static_cast<uint64_t>(byte) + 3 >= bufBytes;
+}
+
+#endif  // CORE_RENDER_OHOS_APNG_BLEND_BOUNDS_H

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGStructs.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGStructs.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "libohos_render/expand/components/apng/APNGStructs.h"
+#include "libohos_render/expand/components/apng/APNGBlendBounds.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -168,6 +169,13 @@ void APNG::HandleFrameBlendOp(std::shared_ptr<Frame> frame, int index) {
     if (!frameDecodeSuccess) {
         return;
     }
+    // leftover: fcTL left/top/width/height are unvalidated. Skip blend when the
+    // frame rect is outside IHDR or the canvas/frame buffers are too small.
+    if (!ApngCanvasBufferBigEnough(width, height, drawingBuffer.size()) ||
+        !ApngCanvasBufferBigEnough(frame->width, frame->height, frameBuffer.size()) ||
+        !ApngFrameRectInCanvas(frame->left, frame->top, frame->width, frame->height, width, height)) {
+        return;
+    }
     for (int y = 0; y < frame->height; ++y) {
         for (int x = 0; x < frame->width; ++x) {
             int srcIdx = (y * frame->width + x) * 4;
@@ -224,6 +232,11 @@ void APNG::HandleFrameBlendOp(std::shared_ptr<Frame> frame, int index) {
 void APNG::HandlePostFrameDisposeOp(std::shared_ptr<Frame> frame) {
     if (frame->disposeOp == 1) {  // 清理当前区域
         auto &drawingBuffer = this->curBitmapBuffer;
+        // leftover: same unvalidated fcTL rect as HandleFrameBlendOp.
+        if (!ApngCanvasBufferBigEnough(width, height, drawingBuffer.size()) ||
+            !ApngFrameRectInCanvas(frame->left, frame->top, frame->width, frame->height, width, height)) {
+            return;
+        }
         // 清除当前帧区域
         for (int y = 0; y < frame->height; ++y) {
             for (int x = 0; x < frame->width; ++x) {

--- a/core-render-ohos/src/test/cpp/apng_blend_bounds_host_test.cpp
+++ b/core-render-ohos/src/test/cpp/apng_blend_bounds_host_test.cpp
@@ -1,0 +1,126 @@
+// Host unit test for leftover APNG fcTL blend / BACKGROUND dispose dstIdx OOB.
+//
+// leftover polarity: fcTL left/top/width/height are copied with no IHDR check.
+// HandleFrameBlendOp / HandlePostFrameDisposeOp indexed
+//   dstIdx = ((y + top) * canvasW + (x + left)) * 4
+// without a range check. Malformed fcTL (left+width > canvas) is an OOB write.
+//
+// This test injects ints into the helpers (no Harmony device, no PixelMap,
+// does not compile APNGStructs.cpp).
+//
+// Build + run (from this directory):
+//   ./run_apng_blend_bounds_host_test.sh
+//   ./run_apng_blend_bounds_host_test.sh asan
+
+#include "APNGBlendBounds.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+#include <vector>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool cond) {
+    if (!cond) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+int main() {
+    const int W = 10;
+    const int H = 10;
+    std::vector<uint8_t> canvas(static_cast<size_t>(W) * H * 4, 0);
+
+    // leftover: fcTL left=8 width=5 sits past canvasW=10. Old dstIdx OOB.
+    {
+        const int left = 8;
+        const int top = 0;
+        const int fw = 5;
+        const int fh = 1;
+        expect_true("leftover left+width past canvas is rejected",
+                    !ApngFrameRectInCanvas(left, top, fw, fh, W, H));
+        bool saw_oob = false;
+        for (int y = 0; y < fh; ++y) {
+            for (int x = 0; x < fw; ++x) {
+                if (ApngLeftoverDstWouldOOB(x, y, left, top, fw, fh, W, H, canvas.size())) {
+                    saw_oob = true;
+                }
+            }
+        }
+        expect_true("leftover dstIdx wrap/OOB on left=8 width=5 canvasW=10", saw_oob);
+    }
+
+    // leftover heap OOB: last scanline + left overflow runs past width*height.
+    {
+        const int left = 8;
+        const int top = 9;
+        const int fw = 5;
+        const int fh = 1;
+        expect_true("leftover last-row rect rejected", !ApngFrameRectInCanvas(left, top, fw, fh, W, H));
+        const int64_t pix = ApngLeftoverDstIdx(4, 0, left, top, W);  // (9)*10 + 12 = 102
+        expect_true("leftover last-row linear index past W*H", pix >= static_cast<int64_t>(W) * H);
+        expect_true("leftover last-row dstIdx heap OOB",
+                    ApngLeftoverDstWouldOOB(4, 0, left, top, fw, fh, W, H, canvas.size()));
+    }
+
+    // leftover: negative left (uint32 fcTL truncated into int).
+    {
+        expect_true("leftover negative left rejected", !ApngFrameRectInCanvas(-1, 0, 2, 2, W, H));
+        expect_true("leftover leftover dstIdx OOB on negative left",
+                    ApngLeftoverDstWouldOOB(0, 0, -1, 0, 2, 2, W, H, canvas.size()));
+    }
+
+    // leftover: top+height past canvasH.
+    {
+        expect_true("leftover top+height past canvas rejected", !ApngFrameRectInCanvas(0, 8, 1, 5, W, H));
+    }
+
+    // leftover: zero / negative frame size.
+    {
+        expect_true("leftover fw=0 rejected", !ApngFrameRectInCanvas(0, 0, 0, 1, W, H));
+        expect_true("leftover fh=-1 rejected", !ApngFrameRectInCanvas(0, 0, 1, -1, W, H));
+    }
+
+    // leftover: left+fw overflows int.
+    {
+        const int left = std::numeric_limits<int>::max() - 2;
+        expect_true("leftover left+fw int overflow rejected", !ApngFrameRectInCanvas(left, 0, 5, 1, W, H));
+    }
+
+    // in-bounds control: exact fit and interior rect.
+    {
+        expect_true("exact-fit rect accepted", ApngFrameRectInCanvas(5, 5, 5, 5, W, H));
+        expect_true("interior rect accepted", ApngFrameRectInCanvas(0, 0, 2, 2, W, H));
+        expect_true("full canvas accepted", ApngFrameRectInCanvas(0, 0, W, H, W, H));
+        expect_true("in-bounds pixel not OOB",
+                    !ApngLeftoverDstWouldOOB(0, 0, 0, 0, 2, 2, W, H, canvas.size()));
+        expect_true("in-bounds last pixel not OOB",
+                    !ApngLeftoverDstWouldOOB(1, 1, 0, 0, 2, 2, W, H, canvas.size()));
+    }
+
+    // leftover undersized canvas buffer (reserve-not-resize polarity).
+    {
+        std::vector<uint8_t> tiny(4, 0);
+        expect_true("leftover tiny buffer rejected", !ApngCanvasBufferBigEnough(W, H, tiny.size()));
+        expect_true("full canvas buffer accepted", ApngCanvasBufferBigEnough(W, H, canvas.size()));
+        expect_true("zero canvas rejected", !ApngCanvasBufferBigEnough(0, H, canvas.size()));
+    }
+
+    // leftover BACKGROUND dispose uses the same dstIdx; skip when rect invalid.
+    {
+        expect_true("dispose BACKGROUND invalid rect skipped",
+                    !ApngFrameRectInCanvas(8, 0, 5, 1, W, H));
+        expect_true("dispose BACKGROUND valid rect kept", ApngFrameRectInCanvas(1, 1, 2, 2, W, H));
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_apng_blend_bounds_host_test.sh
+++ b/core-render-ohos/src/test/cpp/run_apng_blend_bounds_host_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Compile + run leftover APNG fcTL blend dstIdx OOB host unit tests (no Harmony device).
+#
+# Usage:
+#   ./run_apng_blend_bounds_host_test.sh          # g++ default
+#   ./run_apng_blend_bounds_host_test.sh asan     # Address+UB sanitizers
+#
+# Does not compile APNGStructs.cpp or call OH PixelMap APIs.
+# Host g++/clang++ is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APNG_DIR="$SCRIPT_DIR/../../main/cpp/libohos_render/expand/components/apng"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$APNG_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/apng_blend_bounds_host_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/apng_blend_bounds_host_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/apng_blend_bounds_host_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`ApngParser` copies fcTL `width` / `height` / `left` / `top` with no check against IHDR. `HandleFrameBlendOp` and BACKGROUND `HandlePostFrameDisposeOp` then did

```
dstIdx = ((y + top) * canvasW + (x + left)) * 4
drawingBuffer[dstIdx .. dstIdx+3] = ...
```

with no range check.

- `left+width > canvasW` on an interior row wraps into the next scanline
- last-row overflow (`top=canvasH-1`, `left+width > canvasW`) is a true heap OOB (`linear index >= width*height`)
- negative / overflowing `left` (uint32 fcTL stored in `int`) is the same leftover

APNG spec requires the frame rect to lie inside IHDR. Skip blend / BACKGROUND dispose when the rect is outside or the canvas/frame buffer is too small. In-bounds fcTL is unchanged.

`#1660` (PixelmapToBitmapBuffer reserve vs resize), `#1665` (disposeOp PREVIOUS restore), and `#1676` (parser `subBuffer` / fdAT length) touch APNG but not this dstIdx math.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_apng_blend_bounds_host_test.sh
core-render-ohos/src/test/cpp/run_apng_blend_bounds_host_test.sh asan
```

Signed-off-by: Tony Coder <407243179@qq.com>