### PR TITLE
fix(ohos): leftover KRRenderValue toMap array-JSON nullptr crash

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/foundation/type/KRRenderValue.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/foundation/type/KRRenderValue.h
@@ -508,8 +508,15 @@ class KRRenderValue : public std::enable_shared_from_this<KRRenderValue> {
             if(cjson == nullptr){
                 return Map();
             }
+            if (!cJSON_IsObject(cjson)) {
+                cJSON_Delete(cjson);
+                return Map();
+            }
             Map map;
             for (cJSON *item = cjson->child; item != NULL; item = item->next) {
+                if (item->string == nullptr) {
+                    continue;
+                }
                 map[item->string] = fromJsonValue(item);
             }
             cJSON_Delete(cjson);

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/KRRenderValueToMapHost.h
+++ b/core-render-ohos/src/test/cpp/KRRenderValueToMapHost.h
@@ -1,0 +1,49 @@
+// Host leftover helper: KRRenderValue::toMap() string path without Harmony.
+//
+// Production KRRenderValue.h pulls ark_runtime / NAPI / JSVM and cannot
+// host-compile. This header mirrors the FIXED string path using real cJSON:
+//   cJSON_Parse
+//   empty only if parse-null
+//   if (!cJSON_IsObject(cjson)) { cJSON_Delete(cjson); return Map(); }
+//   skip children with item->string == nullptr
+//   map[item->string] = ...
+//
+// Leftover: array JSON children have item->string == nullptr.
+// Map is unordered_map<std::string, ...> so map[item->string] is
+// std::string(nullptr) UB; libstdc++ throws; uncaught in render process.
+
+#pragma once
+
+#include "cJSON.h"
+
+#include <string>
+#include <unordered_map>
+
+namespace kuikly {
+namespace leftover_tomap {
+
+using Map = std::unordered_map<std::string, bool>;
+
+// Mirror of KRRenderValue::toMap() string path after the leftover fix.
+inline Map toMapFromJsonString(const std::string &str) {
+    cJSON *cjson = cJSON_Parse(str.c_str());
+    if (cjson == nullptr) {
+        return Map();
+    }
+    if (!cJSON_IsObject(cjson)) {
+        cJSON_Delete(cjson);
+        return Map();
+    }
+    Map map;
+    for (cJSON *item = cjson->child; item != NULL; item = item->next) {
+        if (item->string == nullptr) {
+            continue;
+        }
+        map[item->string] = true;
+    }
+    cJSON_Delete(cjson);
+    return map;
+}
+
+}  // namespace leftover_tomap
+}  // namespace kuikly

--- a/core-render-ohos/src/test/cpp/kr_render_value_tomap_array_json_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_render_value_tomap_array_json_test.cpp
@@ -1,0 +1,105 @@
+// Host unit test for leftover KRRenderValue::toMap() array-JSON nullptr crash.
+//
+// Leftover (string path):
+//   cJSON_Parse, return empty only if parse-null. Never cJSON_IsObject.
+//   Array children have item->string == nullptr.
+//   Map is unordered_map<std::string, ...> so map[item->string] is
+//   std::string(nullptr) UB. libstdc++ throws; uncaught in render process.
+//
+// Fix:
+//   after successful parse, if (!cJSON_IsObject) { Delete; return Map(); }
+//   in the child loop, skip item->string == nullptr
+//
+// KRRenderValue.h cannot host-compile without Harmony. Helper
+// KRRenderValueToMapHost.h mirrors the FIXED string path using real cJSON.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_kr_render_value_tomap_array_json_test.sh
+//   ./run_kr_render_value_tomap_array_json_test.sh asan
+
+#include "KRRenderValueToMapHost.h"
+
+#include "cJSON.h"
+
+#include <cstdio>
+#include <string>
+
+using kuikly::leftover_tomap::toMapFromJsonString;
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+// leftover polarity: array JSON children have item->string == nullptr.
+// map[item->string] would be std::string(nullptr) UB.
+static void leftover_array_json_null_key_polarity() {
+    cJSON *arr = cJSON_Parse("[1,2,3]");
+    expect_true("leftover [1,2,3] parses", arr != nullptr);
+    expect_true("leftover [1,2,3] is not object", arr != nullptr && !cJSON_IsObject(arr));
+    expect_true("leftover array child string is nullptr",
+                arr != nullptr && arr->child != nullptr && arr->child->string == nullptr);
+    if (arr != nullptr) {
+        cJSON_Delete(arr);
+    }
+
+    cJSON *obj_arr = cJSON_Parse("[{}]");
+    expect_true("leftover [{}] parses", obj_arr != nullptr);
+    expect_true("leftover [{}] is not object", obj_arr != nullptr && !cJSON_IsObject(obj_arr));
+    expect_true("leftover [{}] child string is nullptr",
+                obj_arr != nullptr && obj_arr->child != nullptr && obj_arr->child->string == nullptr);
+    if (obj_arr != nullptr) {
+        cJSON_Delete(obj_arr);
+    }
+
+    cJSON *empty_arr = cJSON_Parse("[]");
+    expect_true("leftover [] parses", empty_arr != nullptr);
+    expect_true("leftover [] is not object", empty_arr != nullptr && !cJSON_IsObject(empty_arr));
+    if (empty_arr != nullptr) {
+        cJSON_Delete(empty_arr);
+    }
+}
+
+int main() {
+    leftover_array_json_null_key_polarity();
+
+    // leftover: array JSON must not throw; result is empty map.
+    {
+        auto m = toMapFromJsonString("[]");
+        expect_true("[] -> empty map", m.empty());
+    }
+    {
+        auto m = toMapFromJsonString("[{}]");
+        expect_true("[{}] -> empty map", m.empty());
+    }
+    {
+        auto m = toMapFromJsonString("[1,2,3]");
+        expect_true("[1,2,3] -> empty map", m.empty());
+    }
+
+    // leftover: parse-null still empty (unchanged).
+    {
+        auto m = toMapFromJsonString("not-json");
+        expect_true("not-json -> empty map", m.empty());
+    }
+
+    // leftover: object JSON still yields keys.
+    {
+        auto m = toMapFromJsonString("{\"a\":1}");
+        expect_true("{\"a\":1} -> key a present", m.find("a") != m.end());
+        expect_true("{\"a\":1} -> size 1", m.size() == 1);
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all leftover toMap array-JSON tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_render_value_tomap_array_json_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_render_value_tomap_array_json_test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Compile + run leftover KRRenderValue::toMap array-JSON host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_kr_render_value_tomap_array_json_test.sh          # g++ default
+#   ./run_kr_render_value_tomap_array_json_test.sh asan     # Address+UB sanitizers
+#
+# KRRenderValue.h cannot host-compile without Harmony. Helper
+# KRRenderValueToMapHost.h + vendored cJSON.c / cJSON.h.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CJSON_DIR="$SCRIPT_DIR/../../main/cpp/thirdparty/cJSON"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+CC="${CC:-gcc}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$SCRIPT_DIR"
+    -I"$CJSON_DIR"
+)
+
+CJSON_SRC="$CJSON_DIR/cJSON.c"
+TEST_SRC="$SCRIPT_DIR/kr_render_value_tomap_array_json_test.cpp"
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_render_value_tomap_array_json_test"
+        CJSON_OBJ="$OUT_DIR/cJSON.o"
+        echo ">>> [$CC] compile $CJSON_OBJ"
+        "$CC" -std=c11 -O2 -I"$CJSON_DIR" -c "$CJSON_SRC" -o "$CJSON_OBJ"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "$TEST_SRC" "$CJSON_OBJ" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_render_value_tomap_array_json_test_asan"
+        CJSON_OBJ="$OUT_DIR/cJSON_asan.o"
+        echo ">>> [$CC] ASan/UBSan compile $CJSON_OBJ"
+        "$CC" -std=c11 -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined -I"$CJSON_DIR" -c "$CJSON_SRC" -o "$CJSON_OBJ"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "$TEST_SRC" "$CJSON_OBJ" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`KRRenderValue::toMap()` string path `cJSON_Parse`s then walks `cjson->child` into `Map` (`unordered_map<std::string, …>`). It returns empty only if parse-null. It never calls `cJSON_IsObject`.

Array JSON (`[]`, `[{}]`, `[1,2,3]`) parses successfully. Array children have `item->string == nullptr`. `map[item->string]` constructs `std::string(nullptr)` — UB. libstdc++ throws `std::logic_error`; uncaught in the render process.

Fix (string path only):
- after successful parse, `if (!cJSON_IsObject(cjson)) { cJSON_Delete(cjson); return Map(); }`
- in the child loop, skip `item->string == nullptr`

Does not touch leftover `toArray()` (same missing `cJSON_Is*` check — not this crash).

`KRRenderValue.h` cannot host-compile without Harmony. Header-only `KRRenderValueToMapHost.h` mirrors the FIXED string path using real `cJSON`.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_render_value_tomap_array_json_test.sh
core-render-ohos/src/test/cpp/run_kr_render_value_tomap_array_json_test.sh asan
```

Signed-off-by: Tony Coder <407243179@qq.com>