### PR TITLE
fix(ohos): leftover KRNativeRenderController windowClass force-unwrap

### DIFF
--- a/core-render-ohos/src/main/ets/KRNativeRenderController.ets
+++ b/core-render-ohos/src/main/ets/KRNativeRenderController.ets
@@ -201,8 +201,11 @@ export class KRNativeRenderController {
     }
     this.updateSafeInsetsHandler = setTimeout(() => {
       this.updateSafeInsetsHandler = 0;
+      if (!this.windowClass) {
+        return;
+      }
       try {
-        this.onSafeAreaInsetsChanged(this.getSafeAreaRect(this.windowClass!));
+        this.onSafeAreaInsetsChanged(this.getSafeAreaRect(this.windowClass));
       } catch (e) {
         KRRenderLog.e('Window', `Error obtaining safearea, code:${e.code}`);
       }
@@ -268,13 +271,15 @@ export class KRNativeRenderController {
     }
 
     if (!imeMode) {
-      const winRect = this.windowClass!.getWindowProperties().windowRect;
-      this.windowRect = new KRRect(0,0, px2vp(winRect.width), px2vp(winRect.height));
-      this.windowId = this.windowClass!.getWindowProperties().id + "";
-      KRNativeManager.getInstance().onLastWindow(this.windowClass!);
-      this.onSafeAreaInsetsChanged(this.getSafeAreaRect(this.windowClass!));
-      this.windowClass!.on('avoidAreaChange', this.avoidAreaListener);
-      this.windowClass!.on('windowSizeChange', this.onWindowSizeChanged);
+      if (this.windowClass) {
+        const winRect = this.windowClass.getWindowProperties().windowRect;
+        this.windowRect = new KRRect(0,0, px2vp(winRect.width), px2vp(winRect.height));
+        this.windowId = this.windowClass.getWindowProperties().id + "";
+        KRNativeManager.getInstance().onLastWindow(this.windowClass);
+        this.onSafeAreaInsetsChanged(this.getSafeAreaRect(this.windowClass));
+        this.windowClass.on('avoidAreaChange', this.avoidAreaListener);
+        this.windowClass.on('windowSizeChange', this.onWindowSizeChanged);
+      }
     }
   }
 


### PR DESCRIPTION
## leftover

`windowClass` is `Window | null`. `findWindow` is try/catch (failure expected). `getWindowActiveDensity` and `onAboutToDisappear` already null-check. Non-IME `init` still does `this.windowClass!.getWindowProperties()` / `onLastWindow` / listeners.

Sibling leftover same file: `doUpdateSafeArea` `this.windowClass!`.

When `findWindow` throws, `windowClass` stays null. Non-IME `init` then force-unwraps and throws after `createNativeInstance` already ran.

Fix: on `!imeMode` path, if `!this.windowClass` skip the window-bind block only. Do not abort the rest of `init` — `createNativeInstance` already ran and must stay as-is. Same null-check in `doUpdateSafeArea`: do not call `getSafeAreaRect(this.windowClass!)` when null. Guard inside the timeout before using `windowClass`. Replace `!` force-unwraps with safe access.

Does not rewrite density/safe-area logic. `onAboutToDisappear` already null-checked.

There is no ArkTS host harness. Required test plan:

- findWindow throws → windowClass stays null → init(imeMode=false) does not throw
- window listeners not registered when windowClass is null
- onAboutToDisappear still safe (already null-checked)
- doUpdateSafeArea with null windowClass does not throw

Signed-off-by: Tony Coder <407243179@qq.com>