### PR TITLE
fix(ohos): leftover APNGAnimateView dtor null-deref on load failure

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGAnimateView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/apng/APNGAnimateView.cpp
@@ -59,9 +59,13 @@ void APNGAnimateView::Destroy() {
 
 APNGAnimateView::~APNGAnimateView() {
     Destroy();
-    KRGCDQueue::GetInstance().DispatchAsync([apng = apng_] {
-        apng->width;  // sub thread gc
-    });
+    if (apng_) {
+        KRGCDQueue::GetInstance().DispatchAsync([apng = apng_] {
+            if (apng) {
+                apng->width;  // sub thread gc
+            }
+        });
+    }
 }
 
 void APNGAnimateView::SetAutoPlay(bool auto_play) {

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/apng_animate_dtor_null_test.cpp
+++ b/core-render-ohos/src/test/cpp/apng_animate_dtor_null_test.cpp
@@ -1,0 +1,82 @@
+// Host unit test for leftover APNGAnimateView dtor null-deref.
+//
+// Leftover:
+//   APNGAnimateView::~APNGAnimateView() {
+//     Destroy();
+//     KRGCDQueue::GetInstance().DispatchAsync([apng = apng_] {
+//         apng->width;  // sub thread gc
+//     });
+//   }
+//
+// apng_ defaults nullptr (header). LoadFailure never assigns apng_.
+// KRApngView::OnDestroy does Destroy(); apng_view_ = nullptr which drops the
+// last shared_ptr and runs this dtor. Same on LoadFile replace before
+// FetchAPNG completes, or http(s) LoadFailure. Unconditional apng->width
+// is a null deref / crash.
+//
+// Production fix: only dispatch / only deref when apng_ is non-null.
+// Off-thread release extracted here so a null shared_ptr is a no-op.
+// Header-only helper — compiles without ArkUI / Harmony.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_apng_animate_dtor_null_test.sh
+//   ./run_apng_animate_dtor_null_test.sh asan
+
+#include "apng_animate_dtor_release.h"
+
+#include <cstdio>
+#include <memory>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_eq(const char *name, int got, int want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got %d want %d\n", name, got, want);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+struct DummyAPNG {
+    int width = 42;
+};
+
+int main() {
+    // leftover polarity: null shared_ptr (LoadFailure / destroy-before-load)
+    // used to deref apng->width → crash. Must be a no-op.
+    {
+        std::shared_ptr<DummyAPNG> apng;
+        expect_true("null shared_ptr is empty", !apng);
+        expect_eq("null shared_ptr is no-op", APNGAnimateDtorRelease(apng), 0);
+    }
+
+    {
+        std::shared_ptr<DummyAPNG> apng = nullptr;
+        expect_eq("explicit nullptr is no-op", APNGAnimateDtorRelease(apng), 0);
+    }
+
+    // leftover: non-null dummy with width field — deref ok (sub thread gc).
+    {
+        auto apng = std::make_shared<DummyAPNG>();
+        apng->width = 128;
+        expect_eq("non-null dummy width deref", APNGAnimateDtorRelease(apng), 128);
+        expect_true("non-null dummy still alive after touch", apng.use_count() == 1);
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all leftover apng animate dtor tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/apng_animate_dtor_release.h
+++ b/core-render-ohos/src/test/cpp/apng_animate_dtor_release.h
@@ -1,0 +1,24 @@
+#ifndef CORE_RENDER_OHOS_TEST_APNG_ANIMATE_DTOR_RELEASE_H
+#define CORE_RENDER_OHOS_TEST_APNG_ANIMATE_DTOR_RELEASE_H
+
+#include <memory>
+
+// Extracted leftover APNGAnimateView dtor off-thread release:
+//   KRGCDQueue::GetInstance().DispatchAsync([apng = apng_] { apng->width; });
+//
+// apng_ defaults nullptr. LoadFailure never assigns it. KRApngView::OnDestroy
+// does Destroy(); apng_view_ = nullptr which drops the last shared_ptr and
+// runs this dtor — same on LoadFile replace before FetchAPNG completes, or
+// http(s) LoadFailure. Unconditional apng->width is a null deref / crash.
+//
+// Header-only so host leftover tests compile without ArkUI / Harmony.
+
+template <typename T>
+inline int APNGAnimateDtorRelease(const std::shared_ptr<T> &apng) {
+    if (!apng) {
+        return 0;  // no-op
+    }
+    return apng->width;  // sub thread gc
+}
+
+#endif  // CORE_RENDER_OHOS_TEST_APNG_ANIMATE_DTOR_RELEASE_H

--- a/core-render-ohos/src/test/cpp/run_apng_animate_dtor_null_test.sh
+++ b/core-render-ohos/src/test/cpp/run_apng_animate_dtor_null_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Compile + run leftover APNGAnimateView dtor null-deref host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_apng_animate_dtor_null_test.sh          # g++ default
+#   ./run_apng_animate_dtor_null_test.sh asan     # Address+UB sanitizers
+#
+# apng_animate_dtor_release.h is header-only (no ArkUI). Host g++ includes it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$SCRIPT_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/apng_animate_dtor_null_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/apng_animate_dtor_null_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/apng_animate_dtor_null_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`APNGAnimateView::~APNGAnimateView` always dispatched `apng_->width` on a worker for "sub thread gc". `apng_` defaults `nullptr`. `LoadFailure` never assigns it. `KRApngView::OnDestroy` does `Destroy(); apng_view_ = nullptr` which drops the last `shared_ptr` and runs this dtor. Same on `LoadFile` replace before `FetchAPNG` completes, or http(s) `LoadFailure`. Unconditional `apng->width` is a null deref / crash.

Fix: only dispatch / only deref when `apng_` is non-null. `Destroy()` kept. Animation logic unchanged.

Host leftover tests extract the off-thread release (`apng_animate_dtor_release.h`) so a null `shared_ptr` is a no-op without ArkUI / Harmony.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_apng_animate_dtor_null_test.sh
core-render-ohos/src/test/cpp/run_apng_animate_dtor_null_test.sh asan
```

Signed-off-by: Tony Coder <407243179@qq.com>
