### PR TITLE
fix(ohos): leftover custom-font OpenRawFile null/len guards

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRParagraph.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRParagraph.cpp
@@ -90,12 +90,18 @@ class KRFontCollectionManager final {
                     if (isRawFilePath(std::string(fontSrc))) {
                         auto newRawPath = fontStrString.substr(strlen(kRawFilePrefix));
                         RawFile *rawFile = OH_ResourceManager_OpenRawFile(resMgr, newRawPath.c_str());
-                        long len = OH_ResourceManager_GetRawFileSize(rawFile);
-                        std::unique_ptr<uint8_t[]> data = std::make_unique<uint8_t[]>(len);
-                        int res = OH_ResourceManager_ReadRawFile(rawFile, data.get(), len);
-                        OH_ResourceManager_CloseRawFile(rawFile);
+                        if (rawFile) {
+                            long len = OH_ResourceManager_GetRawFileSize(rawFile);
+                            if (len > 0) {
+                                std::unique_ptr<uint8_t[]> data = std::make_unique<uint8_t[]>(len);
+                                int res = OH_ResourceManager_ReadRawFile(rawFile, data.get(), len);
+                                OH_ResourceManager_CloseRawFile(rawFile);
 
-                        error = OH_Drawing_RegisterFontBuffer(collection_, fontFamily.c_str(), data.get(), len);
+                                error = OH_Drawing_RegisterFontBuffer(collection_, fontFamily.c_str(), data.get(), len);
+                            } else {
+                                OH_ResourceManager_CloseRawFile(rawFile);
+                            }
+                        }
                     } else {
                         error = OH_Drawing_RegisterFont(collection_, fontFamily.c_str(), fontSrc);
                     }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
@@ -254,6 +254,9 @@ void KRFontCollectionWrapper::MarkFontRegistered(const std::string& fontFamily) 
 
 void KRFontCollectionWrapper::RegisterCustomFont(NativeResourceManager *resMgr,
                                                   const std::string &fontFamily) {
+    if (fontFamily.empty() || resMgr == nullptr) {
+        return;
+    }
     auto fontAdapters = KRFontAdapterManager::GetInstance()->AllAdapters();
     auto adapter = fontAdapters.find(fontFamily);
     if (adapter != fontAdapters.end() && !IsFontRegistered(fontFamily)) {
@@ -267,11 +270,17 @@ void KRFontCollectionWrapper::RegisterCustomFont(NativeResourceManager *resMgr,
             if (isRawFilePath(std::string(fontSrc))) {
                 auto newRawPath = fontStrString.substr(strlen(kRawFilePrefix));
                 RawFile *rawFile = OH_ResourceManager_OpenRawFile(resMgr, newRawPath.c_str());
-                long len = OH_ResourceManager_GetRawFileSize(rawFile);
-                std::unique_ptr<uint8_t[]> data = std::make_unique<uint8_t[]>(len);
-                int res = OH_ResourceManager_ReadRawFile(rawFile, data.get(), len);
-                OH_ResourceManager_CloseRawFile(rawFile);
-                error = OH_Drawing_RegisterFontBuffer(fontCollection_, fontFamily.c_str(), data.get(), len);
+                if (rawFile) {
+                    long len = OH_ResourceManager_GetRawFileSize(rawFile);
+                    if (len > 0) {
+                        std::unique_ptr<uint8_t[]> data = std::make_unique<uint8_t[]>(len);
+                        int res = OH_ResourceManager_ReadRawFile(rawFile, data.get(), len);
+                        OH_ResourceManager_CloseRawFile(rawFile);
+                        error = OH_Drawing_RegisterFontBuffer(fontCollection_, fontFamily.c_str(), data.get(), len);
+                    } else {
+                        OH_ResourceManager_CloseRawFile(rawFile);
+                    }
+                }
             } else {
                 error = OH_Drawing_RegisterFont(fontCollection_, fontFamily.c_str(), fontSrc);
             }
@@ -554,8 +563,10 @@ OH_Drawing_Typography *KRRichTextShadow::BuildTextTypography(double constraint_w
             OH_Drawing_SetTextStyleFontFamilies(txtStyle, 1, fontFamilies);
             auto rootView = GetRootView();
             auto rootViewLock = rootView.lock();
-            auto nativeResMgr = rootViewLock->GetNativeResourceManager();
-            KRFontCollectionWrapper::GetInstance().RegisterCustomFont(nativeResMgr, fontFamily);
+            if (rootViewLock) {
+                auto nativeResMgr = rootViewLock->GetNativeResourceManager();
+                KRFontCollectionWrapper::GetInstance().RegisterCustomFont(nativeResMgr, fontFamily);
+            }
         }
 
         // 需要在fontFamily设置后设置

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_custom_font_rawfile_guard.h
+++ b/core-render-ohos/src/test/cpp/kr_custom_font_rawfile_guard.h
@@ -1,0 +1,85 @@
+// Host leftover helper: custom-font OpenRawFile null / GetRawFileSize <= 0.
+//
+// Production KRParagraph.cpp LoadCustomFont and KRRichTextShadow.cpp
+// RegisterCustomFont pull Harmony NDK (rawfile / drawing) and cannot
+// host-compile. This header mirrors the FIXED rawfile load decision:
+//   if (!rawFile) skip — do not GetRawFileSize / Read / Close, no alloc
+//   if (len <= 0) skip — CloseRawFile if opened; do not allocate
+//   leftover: GetRawFileSize -1 → unique_ptr<uint8_t[]>(size_t max) bad_alloc
+//
+// RegisterCustomFont also rejects null resMgr at start (KRParagraph L77).
+// Caller still sets font families when !rootViewLock; skips RegisterCustomFont.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace kuikly {
+namespace leftover_custom_font {
+
+enum class RawFileAction {
+    SkipNullRawFile,  // OpenRawFile returned NULL
+    SkipNonPositive,  // opened, GetRawFileSize <= 0
+    Load,             // opened, len > 0 — allocate + read + close
+};
+
+struct RawFileLoadPlan {
+    RawFileAction action;
+    std::size_t planned_bytes;
+    bool would_get_size;
+    bool would_read;
+    bool would_close;
+    bool would_allocate;
+};
+
+// leftover polarity: make_unique<uint8_t[]>(len) with len == -1 is size_t max.
+inline bool leftoverLenConvertsToSizeTMax(long len) {
+    return static_cast<std::size_t>(len) == std::numeric_limits<std::size_t>::max();
+}
+
+// Mirror of the FIXED OpenRawFile / GetRawFileSize / allocate path.
+// rawFile == nullptr means OpenRawFile failed (missing file or null resMgr).
+// len is the GetRawFileSize result when a file was opened (ignored if null).
+inline RawFileLoadPlan PlanRawFileLoad(const void *rawFile, long len) {
+    RawFileLoadPlan p{};
+    p.planned_bytes = 0;
+    p.would_get_size = false;
+    p.would_read = false;
+    p.would_close = false;
+    p.would_allocate = false;
+    if (rawFile == nullptr) {
+        p.action = RawFileAction::SkipNullRawFile;
+        return p;
+    }
+    p.would_get_size = true;
+    if (len <= 0) {
+        p.action = RawFileAction::SkipNonPositive;
+        p.would_close = true;
+        return p;
+    }
+    p.action = RawFileAction::Load;
+    p.planned_bytes = static_cast<std::size_t>(len);
+    p.would_read = true;
+    p.would_close = true;
+    p.would_allocate = true;
+    return p;
+}
+
+// RegisterCustomFont: reject null resMgr / empty family (KRParagraph L77).
+inline bool ShouldRegisterCustomFont(const void *resMgr, bool fontFamilyEmpty) {
+    return resMgr != nullptr && !fontFamilyEmpty;
+}
+
+// Caller: skip RegisterCustomFont if !rootViewLock; still set font families.
+inline bool ShouldSetFontFamilies(bool fontFamilyEmpty) {
+    return !fontFamilyEmpty;
+}
+
+inline bool ShouldCallRegisterCustomFont(const void *rootViewLock) {
+    return rootViewLock != nullptr;
+}
+
+}  // namespace leftover_custom_font
+}  // namespace kuikly

--- a/core-render-ohos/src/test/cpp/kr_custom_font_rawfile_null_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_custom_font_rawfile_null_test.cpp
@@ -1,0 +1,128 @@
+// Host unit test for leftover custom-font OpenRawFile null / len<=0.
+//
+// Leftover (KRParagraph LoadCustomFont + KRRichTextShadow RegisterCustomFont):
+//   RawFile *rawFile = OH_ResourceManager_OpenRawFile(resMgr, path);
+//   long len = OH_ResourceManager_GetRawFileSize(rawFile);
+//   std::unique_ptr<uint8_t[]> data = std::make_unique<uint8_t[]>(len);
+//
+// OpenRawFile returns NULL on missing rawfile / null resMgr. GetRawFileSize
+// on that pointer is -1. make_unique<uint8_t[]>(-1) is size_t max → bad_alloc
+// (or asan abort). First Text/RichText layout with fontFamily adapter
+// returning rawfile:fonts/Missing.ttf kills the process.
+//
+// Fix:
+//   if (!rawFile) skip (no size/read/close, no alloc)
+//   if (len <= 0) skip (CloseRawFile if opened; do not allocate)
+//   RegisterCustomFont: reject null resMgr at start (like KRParagraph L77)
+//   caller: skip RegisterCustomFont if !rootViewLock; still set font families
+//
+// KRParagraph.cpp / KRRichTextShadow.cpp cannot host-compile without NDK.
+// Helper kr_custom_font_rawfile_guard.h mirrors the FIXED decision.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_kr_custom_font_rawfile_null_test.sh
+//   ./run_kr_custom_font_rawfile_null_test.sh asan
+
+#include "kr_custom_font_rawfile_guard.h"
+
+#include <cstdio>
+#include <limits>
+
+using kuikly::leftover_custom_font::leftoverLenConvertsToSizeTMax;
+using kuikly::leftover_custom_font::PlanRawFileLoad;
+using kuikly::leftover_custom_font::RawFileAction;
+using kuikly::leftover_custom_font::ShouldCallRegisterCustomFont;
+using kuikly::leftover_custom_font::ShouldRegisterCustomFont;
+using kuikly::leftover_custom_font::ShouldSetFontFamilies;
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+// leftover polarity: GetRawFileSize -1 → unique_ptr<uint8_t[]>(size_t max).
+static void leftover_len_minus_one_is_size_t_max() {
+    expect_true("leftover len==-1 converts to size_t max", leftoverLenConvertsToSizeTMax(-1));
+    expect_true("leftover len==0 is not size_t max", !leftoverLenConvertsToSizeTMax(0));
+    expect_true("leftover len==16 is not size_t max", !leftoverLenConvertsToSizeTMax(16));
+}
+
+int main() {
+    leftover_len_minus_one_is_size_t_max();
+
+    // leftover: null rawFile → skip (no size/read/close, no alloc).
+    {
+        auto p = PlanRawFileLoad(nullptr, -1);
+        expect_true("null rawFile action SkipNullRawFile", p.action == RawFileAction::SkipNullRawFile);
+        expect_true("null rawFile no get size", !p.would_get_size);
+        expect_true("null rawFile no read", !p.would_read);
+        expect_true("null rawFile no close", !p.would_close);
+        expect_true("null rawFile no alloc", !p.would_allocate);
+        expect_true("null rawFile planned_bytes 0", p.planned_bytes == 0);
+    }
+
+    // leftover: len<=0 → skip, CloseRawFile if opened, no alloc.
+    {
+        const char opened = 1;
+        auto p0 = PlanRawFileLoad(&opened, 0);
+        expect_true("len==0 action SkipNonPositive", p0.action == RawFileAction::SkipNonPositive);
+        expect_true("len==0 get size", p0.would_get_size);
+        expect_true("len==0 no read", !p0.would_read);
+        expect_true("len==0 close", p0.would_close);
+        expect_true("len==0 no alloc", !p0.would_allocate);
+        expect_true("len==0 planned_bytes 0", p0.planned_bytes == 0);
+
+        auto pneg = PlanRawFileLoad(&opened, -1);
+        expect_true("len==-1 action SkipNonPositive", pneg.action == RawFileAction::SkipNonPositive);
+        expect_true("len==-1 no alloc (not size_t max)", !pneg.would_allocate);
+        expect_true("len==-1 planned_bytes 0 (not size_t max)", pneg.planned_bytes == 0);
+        expect_true("len==-1 planned_bytes != size_t max",
+                    pneg.planned_bytes != std::numeric_limits<std::size_t>::max());
+        expect_true("len==-1 close", pneg.would_close);
+        expect_true("len==-1 no read", !pneg.would_read);
+    }
+
+    // leftover: len>0 → would allocate that many bytes (no size_t max).
+    {
+        const char opened = 1;
+        auto p = PlanRawFileLoad(&opened, 16);
+        expect_true("len>0 action Load", p.action == RawFileAction::Load);
+        expect_true("len>0 get size", p.would_get_size);
+        expect_true("len>0 read", p.would_read);
+        expect_true("len>0 close", p.would_close);
+        expect_true("len>0 allocate", p.would_allocate);
+        expect_true("len>0 planned_bytes 16", p.planned_bytes == 16);
+        expect_true("len>0 planned_bytes != size_t max",
+                    p.planned_bytes != std::numeric_limits<std::size_t>::max());
+    }
+
+    // leftover: RegisterCustomFont rejects null resMgr / empty family.
+    expect_true("null resMgr skip register", !ShouldRegisterCustomFont(nullptr, false));
+    {
+        const char mgr = 1;
+        expect_true("empty family skip register", !ShouldRegisterCustomFont(&mgr, true));
+        expect_true("resMgr + family register", ShouldRegisterCustomFont(&mgr, false));
+    }
+
+    // leftover: caller skip RegisterCustomFont if !rootViewLock; still set families.
+    expect_true("empty family no SetFontFamilies", !ShouldSetFontFamilies(true));
+    expect_true("non-empty family SetFontFamilies", ShouldSetFontFamilies(false));
+    expect_true("null rootViewLock skip RegisterCustomFont", !ShouldCallRegisterCustomFont(nullptr));
+    {
+        const char lock = 1;
+        expect_true("rootViewLock calls RegisterCustomFont", ShouldCallRegisterCustomFont(&lock));
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all leftover custom-font rawfile null tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_custom_font_rawfile_null_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_custom_font_rawfile_null_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Compile + run leftover custom-font OpenRawFile null/len host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_kr_custom_font_rawfile_null_test.sh          # g++ default
+#   ./run_kr_custom_font_rawfile_null_test.sh asan     # Address+UB sanitizers
+#
+# KRParagraph.cpp / KRRichTextShadow.cpp cannot host-compile without NDK.
+# Helper kr_custom_font_rawfile_guard.h is header-only.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$SCRIPT_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_custom_font_rawfile_null_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_custom_font_rawfile_null_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_custom_font_rawfile_null_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`LoadCustomFont` (KRParagraph.cpp) and `RegisterCustomFont` (KRRichTextShadow.cpp) call `OH_ResourceManager_OpenRawFile` then immediately `GetRawFileSize` / `ReadRawFile` / `CloseRawFile` on that pointer.

`OpenRawFile` returns NULL on a missing rawfile or a null `resMgr`. `GetRawFileSize` on NULL is -1. `std::make_unique<uint8_t[]>(len)` then allocates `size_t` max and `bad_alloc`s. First Text/RichText layout whose fontFamily adapter returns `rawfile:fonts/Missing.ttf` kills the process.

`KRParagraph` already rejects a null `resMgr` at L77; `RegisterCustomFont` does not. The RichText caller also does `rootViewLock->GetNativeResourceManager()` with no lock-null check.

Fix: if (!rawFile) skip (no GetRawFileSize/Read/Close). if (len <= 0) skip (CloseRawFile if opened; do not allocate). `RegisterCustomFont` rejects null resMgr at start (like KRParagraph L77). Caller skips RegisterCustomFont if !rootViewLock; still sets font families as today.

Keep deallocator paths. Does not rewrite font registration beyond these guards.

Header-only `kr_custom_font_rawfile_guard.h` so host leftover tests compile without Harmony NDK.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_custom_font_rawfile_null_test.sh
core-render-ohos/src/test/cpp/run_kr_custom_font_rawfile_null_test.sh asan
```

Signed-off-by: Tony Coder <407243179@qq.com>