### PR TITLE
fix(ohos): leftover KRSnapshotManager dataUri pixelMap/malloc guards

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/manager/KRSnapshotManager.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/manager/KRSnapshotManager.cpp
@@ -21,6 +21,8 @@
 #include <arkui/native_node_napi.h>
 #include <multimedia/image_framework/image_packer_mdk.h>
 #include <multimedia/image_framework/image_pixel_map_mdk.h>
+#include <cstdint>
+#include <cstdlib>
 #include <unistd.h>
 
 #include "libohos_render/foundation/KRCommon.h"
@@ -107,19 +109,61 @@ bool KRSnapshotManager::SetCachedSnapshotToNode(ArkUI_NodeHandle node, const std
     return false;
 }
 
+// leftover: ProcessSnapshotResultWithDataType used `size = width * height * 4` then
+// malloc(size) with no overflow/zero/null check. Same saturate as host-test
+// KRSnapshotDataUriComputePackedSize (NDK cannot host-compile this cpp).
+static bool ComputeDataUriPackedSize(uint32_t width, uint32_t height, size_t *out_size) {
+    if (out_size == nullptr) {
+        return false;
+    }
+    if (width == 0 || height == 0) {
+        return false;
+    }
+    const size_t w = static_cast<size_t>(width);
+    const size_t h = static_cast<size_t>(height);
+    if (w > SIZE_MAX / h) {
+        return false;
+    }
+    const size_t pixels = w * h;
+    if (pixels > SIZE_MAX / 4) {
+        return false;
+    }
+    *out_size = pixels * 4;
+    return true;
+}
+
 struct KRSnapshotManager::ResultData KRSnapshotManager::ProcessSnapshotResultWithDataType(
     napi_env env, napi_value pixelMap, const std::string &path, const std::string &pathUri,
     ArkUI_DrawableDescriptor *drawableDescriptorPtr, std::weak_ptr<IKRRenderViewExport> weak_view) {
     struct ResultData resultData;
+    resultData.code = -1;
+
     NativePixelMap *nativePixelMap = OH_PixelMap_InitNativePixelMap(env, pixelMap);
+    if (nativePixelMap == nullptr) {
+        resultData.message = "InitNativePixelMap failed";
+        return resultData;
+    }
     OhosPixelMapInfos info;
-    OH_PixelMap_GetImageInfo(nativePixelMap, &info);
+    int infoErr = OH_PixelMap_GetImageInfo(nativePixelMap, &info);
+    if (infoErr != 0) {
+        resultData.message = "GetImageInfo failed";
+        return resultData;
+    }
+
+    size_t size = 0;
+    if (!ComputeDataUriPackedSize(info.width, info.height, &size)) {
+        resultData.message = "invalid pixel map size";
+        return resultData;
+    }
+    uint8_t *outData = reinterpret_cast<uint8_t *>(malloc(size));
+    if (outData == nullptr) {
+        resultData.message = "malloc failed";
+        return resultData;
+    }
+
     struct ImagePacker_Opts_ opts;
     opts.format = "image/png";
     opts.quality = 80;
-
-    size_t size = info.width * info.height * 4;
-    uint8_t *outData = reinterpret_cast<uint8_t *>(malloc(size));
 
     napi_value packer;
     OH_ImagePacker_Create(env, &packer);
@@ -259,8 +303,14 @@ void KRSnapshotManager::TakeSnapshot(const std::string &instance_id, const std::
                         if (auto root = strongView->GetRootView().lock()) {
                             auto snapshotManager = root->GetSnapshotManager();
                             if (type == "dataUri") {
-                                resultData = snapshotManager->ProcessSnapshotResultWithDataType(
-                                    env, pixelMap, "", "", drawableDescriptorPtr, weak_view);
+                                // leftover: drawableDescriptor was null-checked; pixelMap was not.
+                                if (arkTs.IsNull(pixelMap) || arkTs.IsUndefined(pixelMap)) {
+                                    resultData.code = -1;
+                                    resultData.message = "pixelMap is null or undefined";
+                                } else {
+                                    resultData = snapshotManager->ProcessSnapshotResultWithDataType(
+                                        env, pixelMap, "", "", drawableDescriptorPtr, weak_view);
+                                }
                             } else if (type == "cacheKey") {
                                 napi_value path = arkTs.GetObjectProperty(snapshotData, "path");
                                 pathStr = arkTs.GetString(path);

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/KRSnapshotDataUriGuards.h
+++ b/core-render-ohos/src/test/cpp/KRSnapshotDataUriGuards.h
@@ -1,0 +1,56 @@
+#ifndef CORE_RENDER_OHOS_TEST_KRSNAPSHOT_DATAURI_GUARDS_H
+#define CORE_RENDER_OHOS_TEST_KRSNAPSHOT_DATAURI_GUARDS_H
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+// Header-only leftover dataUri guards from KRSnapshotManager.cpp.
+// Production cpp cannot host-compile (ArkUI / Harmony NDK).
+//
+// Leftover ProcessSnapshotResultWithDataType:
+//   size = width * height * 4; malloc(size);
+//   no overflow / zero / null check. PackToData / GetImageInfo on bad input.
+// Leftover TakeSnapshot dataUri path:
+//   drawableDescriptor was null-checked; pixelMap was not.
+//
+// Same saturate as ComputeDataUriPackedSize in KRSnapshotManager.cpp.
+
+inline bool KRSnapshotDataUriComputePackedSize(uint32_t width, uint32_t height, size_t *out_size) {
+    if (out_size == nullptr) {
+        return false;
+    }
+    if (width == 0 || height == 0) {
+        return false;
+    }
+    const size_t w = static_cast<size_t>(width);
+    const size_t h = static_cast<size_t>(height);
+    if (w > SIZE_MAX / h) {
+        return false;
+    }
+    const size_t pixels = w * h;
+    if (pixels > SIZE_MAX / 4) {
+        return false;
+    }
+    *out_size = pixels * 4;
+    return true;
+}
+
+// dataUri path: reject null/undefined pixelMap before ProcessSnapshotResultWithDataType.
+inline bool KRSnapshotDataUriPixelMapRejected(bool is_null, bool is_undefined) {
+    return is_null || is_undefined;
+}
+
+struct KRSnapshotDataUriResult {
+    int code;
+    std::string message;
+};
+
+inline KRSnapshotDataUriResult KRSnapshotDataUriRejectNullPixelMap() {
+    KRSnapshotDataUriResult result;
+    result.code = -1;
+    result.message = "pixelMap is null or undefined";
+    return result;
+}
+
+#endif  // CORE_RENDER_OHOS_TEST_KRSNAPSHOT_DATAURI_GUARDS_H

--- a/core-render-ohos/src/test/cpp/kr_snapshot_datauri_pixelmap_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_snapshot_datauri_pixelmap_test.cpp
@@ -1,0 +1,98 @@
+// Host unit test for leftover KRSnapshotManager dataUri pixelMap / malloc guards.
+//
+// Leftover TakeSnapshot dataUri path:
+//   drawableDescriptor was null-checked; pixelMap was not.
+//   ProcessSnapshotResultWithDataType then InitNativePixelMap / GetImageInfo /
+//   PackToData on a null/undefined pixelMap.
+//
+// Leftover ProcessSnapshotResultWithDataType:
+//   size = width * height * 4; malloc(size);
+//   no overflow / zero / malloc-null check.
+//
+// Production cpp cannot host-compile without Harmony. Header-only
+// KRSnapshotDataUriGuards.h extracts the size / null guards.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_kr_snapshot_datauri_pixelmap_test.sh
+//   ./run_kr_snapshot_datauri_pixelmap_test.sh asan
+
+#include "KRSnapshotDataUriGuards.h"
+
+#include <cstdio>
+#include <cstdint>
+#include <limits>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void expect_eq(const char *name, int got, int want) {
+    if (got != want) {
+        std::fprintf(stderr, "FAIL %s: got %d want %d\n", name, got, want);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+int main() {
+    // leftover: width * height overflow must reject (no wrap into malloc).
+    {
+        size_t size = 0xdeadbeef;
+        bool ok = KRSnapshotDataUriComputePackedSize(std::numeric_limits<uint32_t>::max(),
+                                                     std::numeric_limits<uint32_t>::max(), &size);
+        expect_true("width*height overflow reject", !ok);
+        expect_true("overflow leaves out_size untouched", size == 0xdeadbeef);
+    }
+    {
+        size_t size = 0xdeadbeef;
+        // 2^31 * 2^31 = 2^62; 2^62 * 4 overflows size_t on 64-bit.
+        bool ok = KRSnapshotDataUriComputePackedSize(1u << 31, 1u << 31, &size);
+        expect_true("2^31 * 2^31 * 4 overflow reject", !ok);
+        expect_true("2^31 overflow leaves out_size untouched", size == 0xdeadbeef);
+    }
+
+    // leftover: size == 0 (zero width or height) must reject.
+    {
+        size_t size = 0xdeadbeef;
+        expect_true("width==0 reject", !KRSnapshotDataUriComputePackedSize(0, 10, &size));
+        expect_true("height==0 reject", !KRSnapshotDataUriComputePackedSize(10, 0, &size));
+        expect_true("0x0 reject", !KRSnapshotDataUriComputePackedSize(0, 0, &size));
+        expect_true("zero size leaves out_size untouched", size == 0xdeadbeef);
+    }
+
+    // leftover: null / undefined pixelMap → code = -1, never ProcessSnapshotResultWithDataType.
+    {
+        expect_true("null pixelMap rejected", KRSnapshotDataUriPixelMapRejected(true, false));
+        expect_true("undefined pixelMap rejected", KRSnapshotDataUriPixelMapRejected(false, true));
+        expect_true("null+undefined pixelMap rejected", KRSnapshotDataUriPixelMapRejected(true, true));
+        expect_true("present pixelMap not rejected", !KRSnapshotDataUriPixelMapRejected(false, false));
+
+        KRSnapshotDataUriResult null_result = KRSnapshotDataUriRejectNullPixelMap();
+        expect_eq("null-pixelMap code=-1", null_result.code, -1);
+        expect_true("null-pixelMap message set", !null_result.message.empty());
+    }
+
+    // leftover: valid size still computes width * height * 4 (success path unchanged).
+    {
+        size_t size = 0;
+        expect_true("1x1 packed size ok", KRSnapshotDataUriComputePackedSize(1, 1, &size));
+        expect_true("1x1 packed size == 4", size == 4);
+        expect_true("10x20 packed size ok", KRSnapshotDataUriComputePackedSize(10, 20, &size));
+        expect_true("10x20 packed size == 800", size == 800);
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all leftover snapshot dataUri pixelMap/malloc tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_snapshot_datauri_pixelmap_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_snapshot_datauri_pixelmap_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Compile + run leftover KRSnapshotManager dataUri pixelMap / malloc host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_kr_snapshot_datauri_pixelmap_test.sh          # g++ default
+#   ./run_kr_snapshot_datauri_pixelmap_test.sh asan     # Address+UB sanitizers
+#
+# KRSnapshotDataUriGuards.h is header-only (no ArkUI). Host g++ includes it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$SCRIPT_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_snapshot_datauri_pixelmap_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_snapshot_datauri_pixelmap_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_snapshot_datauri_pixelmap_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`TakeSnapshot` dataUri path null-checked `drawableDescriptor` then called `ProcessSnapshotResultWithDataType` with `pixelMap` unchecked. Null/undefined `pixelMap` reached `OH_PixelMap_InitNativePixelMap` / `GetImageInfo` / `PackToData`.

Inside that fn leftover `size = width * height * 4; malloc(size)` had no overflow, zero-size, InitNativePixelMap-null, GetImageInfo-fail, or malloc-null check.

Fix:
- dataUri path: reject null/undefined `pixelMap` (`code = -1` + message) before `ProcessSnapshotResultWithDataType`
- init `code = -1`
- null `InitNativePixelMap` → return
- `GetImageInfo` fail → return
- overflow / zero size → return
- malloc-null → return
- no `PackToData` / `GetImageInfo` on bad input
- success path unchanged

`KRSnapshotManager.cpp` cannot host-compile without Harmony. Header-only `KRSnapshotDataUriGuards.h` extracts the size / null guards.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_snapshot_datauri_pixelmap_test.sh
core-render-ohos/src/test/cpp/run_kr_snapshot_datauri_pixelmap_test.sh asan
```

Signed-off-by: Tony Coder <407243179@qq.com>
