### PR TITLE
fix(ohos): leftover KRPAGView setProgress uncaught JSON.parse

### DIFF
--- a/core-render-ohos/src/main/ets/components/KRPAGView.ets
+++ b/core-render-ohos/src/main/ets/components/KRPAGView.ets
@@ -130,10 +130,14 @@ export class KRPAGView extends KuiklyRenderBaseView implements IKRPAGViewListene
       }
     } else if (method == KRPAGView.PROP_METHOD_SET_PROGRESS) {
       if (typeof params === 'string') {
-        const json: Record<string, Object> = JSON.parse(params as string) as Record<string, Object>;
-        const value = json['value'] as number;
-        if (value !== undefined) {
-          this.controller?.setProgress(value);
+        try {
+          const json: Record<string, Object> = JSON.parse(params as string) as Record<string, Object>;
+          const value = json['value'] as number;
+          if (typeof value === 'number' && Number.isFinite(value)) {
+            this.controller?.setProgress(value);
+          }
+        } catch (e) {
+          console.log(`KRPAGView setProgress error ${e}`);
         }
       }
     } else {


### PR DESCRIPTION
## leftover

`KRPAGView.call("setProgress", params)` does `JSON.parse(params as string)` with no try/catch. Sibling leftover `KRRouterModule.openPage` already wraps parse in try/catch and logs.

Malformed / non-JSON / truncated JSON throws out of `call()` and aborts ArkTS dispatch.

Fix: try/catch like Router. Ignore/log bad payload. Only call `controller.setProgress` when `value` is a finite number.

Does not change play/stop/src.

There is no ArkTS host harness. Required test plan:

- setProgress("not-json") does not throw
- setProgress("{\"value\":") does not throw
- setProgress("{\"value\":0.5}") calls setProgress(0.5)

Signed-off-by: Tony Coder <407243179@qq.com>