### PR TITLE
fix(ohos): leftover KRSnapshotModule FILE toFile missing catch

### DIFF
--- a/core-render-ohos/src/main/ets/modules/internal/KRSnapshotModule.ets
+++ b/core-render-ohos/src/main/ets/modules/internal/KRSnapshotModule.ets
@@ -80,6 +80,9 @@ export class KRSnapshotModule extends KuiklyRenderBaseModule {
           if (type == 'file') {
             KRPixelMapUtil.toFile(resultParam.path, data).then((file) => {
               callback([resultParam, new ArrayBuffer(1)]);
+            }).catch((err: Error) => {
+              resultParam.message = (err instanceof Error ? err.message : JSON.stringify(err)) ?? '';
+              callback([resultParam, new ArrayBuffer(1)]);
             });
             return;
           }
@@ -89,7 +92,9 @@ export class KRSnapshotModule extends KuiklyRenderBaseModule {
             resultParam.drawableDescriptor = drawableDesciptor;
             resultParam.pixelMap = data;
             callback([resultParam, new ArrayBuffer(1)]);
-            KRPixelMapUtil.toFile(resultParam.path, data);
+            KRPixelMapUtil.toFile(resultParam.path, data).catch((err: Error) => {
+              KRRenderLog.i('KRSnapshotModule', `complete error message: ${(err instanceof Error ? err.message : JSON.stringify(err)) ?? ''}`);
+            });
             return;
           }
         }

--- a/core-render-ohos/src/test/ets/kr_snapshot_module_tofile_catch_test.js
+++ b/core-render-ohos/src/test/ets/kr_snapshot_module_tofile_catch_test.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+'use strict';
+
+/*
+ * Host leftover extract of KRSnapshotModule.toImage FILE / cacheKey toFile
+ * catch contract. Harmony / ArkTS kits are not on host; this mirrors the
+ * then/catch pairing in KRSnapshotModule.ets:
+ *   FILE:     toFile reject -> callback with resultParam.message set
+ *   cacheKey: callback already fired; catch logs only (no second callback,
+ *             no unhandled rejection)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+function extractMessage(err) {
+  return (err instanceof Error ? err.message : JSON.stringify(err)) ?? '';
+}
+
+function handleFileToFile(toFilePromise, resultParam, callback) {
+  return toFilePromise.then((file) => {
+    callback([resultParam]);
+  }).catch(err => {
+    resultParam.message = extractMessage(err);
+    callback([resultParam]);
+  });
+}
+
+function handleCacheKeyToFile(toFilePromise, resultParam, callback, log) {
+  callback([resultParam]);
+  return toFilePromise.catch(err => {
+    log(`complete error message: ${extractMessage(err)}`);
+  });
+}
+
+function waitUnhandledTick() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function testFileRejectInvokesCallbackWithMessage() {
+  const resultParam = { message: '' };
+  const calls = [];
+  await handleFileToFile(
+    Promise.reject(new Error('pack failed')),
+    resultParam,
+    (args) => calls.push(args),
+  );
+  assert.strictEqual(calls.length, 1, 'FILE reject must invoke callback once');
+  assert.strictEqual(resultParam.message, 'pack failed');
+  assert.strictEqual(calls[0][0], resultParam);
+}
+
+async function testFileRejectNonErrorStringifies() {
+  const resultParam = { message: '' };
+  const calls = [];
+  await handleFileToFile(
+    Promise.reject({ code: 1, reason: 'open fail' }),
+    resultParam,
+    (args) => calls.push(args),
+  );
+  assert.strictEqual(calls.length, 1);
+  assert.strictEqual(resultParam.message, JSON.stringify({ code: 1, reason: 'open fail' }));
+}
+
+async function testFileSuccessKeepsThenCallback() {
+  const resultParam = { message: '' };
+  const calls = [];
+  await handleFileToFile(Promise.resolve('ok'), resultParam, (args) => calls.push(args));
+  assert.strictEqual(calls.length, 1, 'FILE success must keep then(callback)');
+  assert.strictEqual(resultParam.message, '', 'FILE success must not set message');
+}
+
+async function testCacheKeyRejectDoesNotDoubleCallbackOrUnhandled() {
+  const resultParam = { message: '' };
+  const calls = [];
+  const logs = [];
+  const unhandled = [];
+  const onUnhandled = (reason) => { unhandled.push(reason); };
+  process.on('unhandledRejection', onUnhandled);
+  try {
+    await handleCacheKeyToFile(
+      Promise.reject(new Error('rename failed')),
+      resultParam,
+      (args) => calls.push(args),
+      (m) => logs.push(m),
+    );
+    await waitUnhandledTick();
+  } finally {
+    process.off('unhandledRejection', onUnhandled);
+  }
+  assert.strictEqual(calls.length, 1, 'cacheKey reject must not call callback twice');
+  assert.strictEqual(unhandled.length, 0, `cacheKey reject leaked unhandled: ${unhandled}`);
+  assert.strictEqual(logs.length, 1, 'cacheKey reject must log');
+  assert.ok(logs[0].includes('rename failed'));
+  assert.strictEqual(resultParam.message, '', 'cacheKey reject must not overwrite message');
+}
+
+async function testCacheKeySuccessCallbackOnce() {
+  const resultParam = { message: '' };
+  const calls = [];
+  await handleCacheKeyToFile(
+    Promise.resolve('ok'),
+    resultParam,
+    (args) => calls.push(args),
+    () => { throw new Error('cacheKey success must not log'); },
+  );
+  assert.strictEqual(calls.length, 1);
+}
+
+function testProductionSourceHasCatchContract() {
+  const srcPath = path.join(
+    __dirname,
+    '../../main/ets/modules/internal/KRSnapshotModule.ets',
+  );
+  const src = fs.readFileSync(srcPath, 'utf8');
+  const fileBlock = src.slice(src.indexOf("if (type == 'file')"), src.indexOf("if (type == 'cacheKey')"));
+  const cacheBlock = src.slice(src.indexOf("if (type == 'cacheKey')"), src.indexOf('waitUntilRenderFinished'));
+  assert.ok(fileBlock.includes('.then((file)'), 'FILE must keep then(success)');
+  assert.ok(fileBlock.includes('.catch'), 'FILE must attach .catch');
+  assert.ok(fileBlock.includes('resultParam.message'), 'FILE catch must set message');
+  assert.ok(fileBlock.includes('callback(['), 'FILE catch must invoke callback');
+  const cbIdx = cacheBlock.indexOf('callback([');
+  const toFileIdx = cacheBlock.indexOf('KRPixelMapUtil.toFile');
+  const catchIdx = cacheBlock.indexOf('.catch');
+  assert.ok(cbIdx >= 0 && toFileIdx > cbIdx, 'cacheKey must callback before toFile');
+  assert.ok(catchIdx > toFileIdx, 'cacheKey toFile must attach .catch');
+  const catchBody = cacheBlock.slice(catchIdx);
+  assert.ok(!catchBody.includes('callback('), 'cacheKey catch must not call callback again');
+  assert.ok(catchBody.includes('KRRenderLog'), 'cacheKey catch must log only');
+}
+
+async function main() {
+  const tests = [
+    ['FILE reject invokes callback with message', testFileRejectInvokesCallbackWithMessage],
+    ['FILE reject non-Error uses JSON.stringify', testFileRejectNonErrorStringifies],
+    ['FILE success keeps then(callback)', testFileSuccessKeepsThenCallback],
+    ['cacheKey reject no double-callback / no unhandled', testCacheKeyRejectDoesNotDoubleCallbackOrUnhandled],
+    ['cacheKey success callback once', testCacheKeySuccessCallbackOnce],
+    ['production source FILE/cacheKey catch contract', testProductionSourceHasCatchContract],
+  ];
+  let failed = 0;
+  for (const [name, fn] of tests) {
+    try {
+      await fn();
+      console.log(`PASS  ${name}`);
+    } catch (e) {
+      failed += 1;
+      console.log(`FAIL  ${name}`);
+      console.log(e && e.stack ? e.stack : e);
+    }
+  }
+  console.log(failed ? `${failed} failed` : `${tests.length} passed`);
+  process.exit(failed ? 1 : 0);
+}
+
+main();

--- a/core-render-ohos/src/test/ets/run_kr_snapshot_module_tofile_catch_test.sh
+++ b/core-render-ohos/src/test/ets/run_kr_snapshot_module_tofile_catch_test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Host leftover: KRSnapshotModule FILE/cacheKey toFile catch contract.
+# No Harmony device. Requires node.
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec node "${DIR}/kr_snapshot_module_tofile_catch_test.js"


### PR DESCRIPTION
## leftover

`KRSnapshotModule.toImage` FILE path waits on `KRPixelMapUtil.toFile(...).then(callback)` with no `.catch()`. Pack/open/rename fail is an unhandled rejection; C++ `toImageCb` never fires and hangs.

`cacheKey` already invoked callback (L92) then fires `toFile` with no catch — reject is leak/unhandled-reject only. Catch/log; do not double-callback.

`get()` errors already callback (L55–61). openspec contract is `code=-1` + `message`.

Fix:
- FILE: keep `then(success)` callback; `.catch` sets `resultParam.message` (same extract as L56) and invokes callback
- cacheKey: keep callback-before-toFile order; `.catch` logs only

Does not touch leftover `KRSnapshotManager.cpp` FILE path (still keys off path, not message) — that is K3.

Host test (no Harmony device):

```
core-render-ohos/src/test/ets/run_kr_snapshot_module_tofile_catch_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
