### PR TITLE
fix(ohos): leftover KRMemoryCacheModule SetObject/CacheImage map[] deref

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/modules/cache/KRMemoryCacheModule.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/modules/cache/KRMemoryCacheModule.cpp
@@ -90,8 +90,16 @@ KRAnyValue KRMemoryCacheModule::CallMethod(bool sync, const std::string &method,
 
 KRAnyValue KRMemoryCacheModule::SetObject(const KRAnyValue &params) {
     auto map = params->toMap();
-    auto key = map[kParamNameKey]->toString();
-    auto value = map[kParamNameValue];
+    auto key_it = map.find(kParamNameKey);
+    if (key_it == map.end() || !key_it->second) {
+        return KREmptyValue();
+    }
+    auto value_it = map.find(kParamNameValue);
+    if (value_it == map.end() || !value_it->second) {
+        return KREmptyValue();
+    }
+    auto key = key_it->second->toString();
+    auto value = value_it->second;
     cache_map_[key] = value;
 
     bool found = false;
@@ -140,7 +148,15 @@ OH_PixelmapNative *KRMemoryCacheModule::LoadPixelmapFromLocal(std::string &src) 
 
 KRAnyValue KRMemoryCacheModule::CacheImage(const KRAnyValue &params, const KRRenderCallback &callback) {
     auto map = params->toMap();
-    auto src = map[kParamNameSrc]->toString();
+    auto src_it = map.find(kParamNameSrc);
+    if (src_it == map.end() || !src_it->second) {
+        KRRenderValueMap result = GenerateError(-1, "missing src");
+        if (callback) {
+            callback(NewKRRenderValue(result));
+        }
+        return NewKRRenderValue(std::move(result));
+    }
+    auto src = src_it->second->toString();
     auto cache_key = GenerateCacheKey(src);
 
     OH_PixelmapNative *pixelmap = GetImage(cache_key);

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_memory_cache_map_find.h
+++ b/core-render-ohos/src/test/cpp/kr_memory_cache_map_find.h
@@ -1,0 +1,102 @@
+#ifndef CORE_RENDER_OHOS_TEST_KR_MEMORY_CACHE_MAP_FIND_H
+#define CORE_RENDER_OHOS_TEST_KR_MEMORY_CACHE_MAP_FIND_H
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+// Host leftover helper for KRMemoryCacheModule SetObject / CacheImage.
+//
+// Production leftover:
+//   auto map = params->toMap();
+//   auto key = map[kParamNameKey]->toString();   // SetObject
+//   auto value = map[kParamNameValue];
+//   auto src = map[kParamNameSrc]->toString();   // CacheImage
+//
+// Map is unordered_map<string, shared_ptr<...>>. operator[] default-inserts
+// a nullptr shared_ptr when the key is missing; ->toString() is a null deref.
+// Get() already uses find (no operator[]).
+//
+// Production cannot host-compile (Harmony image APIs). This header mirrors
+// the FIXED lookup: find + null-check. Missing key/src/value → empty / error,
+// no deref. Valid {key,value} / {src} still work.
+//
+// Header-only so leftover host tests compile without Harmony.
+
+namespace leftover_memory_cache {
+
+constexpr char kParamNameKey[] = "key";
+constexpr char kParamNameValue[] = "value";
+constexpr char kParamNameSrc[] = "src";
+
+struct HostValue {
+    std::string str;
+    std::string toString() const { return str; }
+};
+
+using HostAny = std::shared_ptr<HostValue>;
+using HostMap = std::unordered_map<std::string, HostAny>;
+
+inline HostAny MakeHostValue(const std::string &s) {
+    return std::make_shared<HostValue>(HostValue{s});
+}
+
+// find + null-check, same shape as Get() plus a shared_ptr guard.
+template <typename Map>
+inline typename Map::mapped_type FindMapValue(const Map &map, const char *key) {
+    auto it = map.find(key);
+    if (it == map.end() || !it->second) {
+        return typename Map::mapped_type{};
+    }
+    return it->second;
+}
+
+struct SetObjectResult {
+    bool empty_return = true;
+    bool stored = false;
+    std::string key;
+    std::string value;
+};
+
+// SetObject({}): missing key or value → empty, no deref, nothing stored.
+// Valid {key,value} still stores.
+inline SetObjectResult SetObject(const HostMap &map) {
+    auto key_v = FindMapValue(map, kParamNameKey);
+    auto value_v = FindMapValue(map, kParamNameValue);
+    if (!key_v || !value_v) {
+        return SetObjectResult{};
+    }
+    SetObjectResult r;
+    r.empty_return = true;  // production success also returns KREmptyValue()
+    r.stored = true;
+    r.key = key_v->toString();
+    r.value = value_v->toString();
+    return r;
+}
+
+struct CacheImageResult {
+    bool is_error = false;
+    int error_code = 0;
+    std::string error_msg;
+    std::string src;
+};
+
+// CacheImage({}): missing / null src → GenerateError, no deref.
+// Valid {src} still extracts src (Harmony load is not host-compiled).
+inline CacheImageResult CacheImage(const HostMap &map) {
+    auto src_v = FindMapValue(map, kParamNameSrc);
+    if (!src_v) {
+        CacheImageResult r;
+        r.is_error = true;
+        r.error_code = -1;
+        r.error_msg = "missing src";
+        return r;
+    }
+    CacheImageResult r;
+    r.src = src_v->toString();
+    return r;
+}
+
+}  // namespace leftover_memory_cache
+
+#endif  // CORE_RENDER_OHOS_TEST_KR_MEMORY_CACHE_MAP_FIND_H

--- a/core-render-ohos/src/test/cpp/kr_memory_cache_map_find_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_memory_cache_map_find_test.cpp
@@ -1,0 +1,143 @@
+// Host unit test for leftover KRMemoryCacheModule SetObject/CacheImage map[].
+//
+// Leftover:
+//   auto map = params->toMap();
+//   auto key = map[kParamNameKey]->toString();
+//   auto value = map[kParamNameValue];
+//   auto src = map[kParamNameSrc]->toString();
+//
+// operator[] default-inserts nullptr shared_ptr when key/src/value is
+// missing. ->toString() is a null deref / crash. Get() already uses find.
+//
+// Fix: find + null-check like Get(); missing key/src/value → empty / error,
+// no deref. Valid {key,value} / {src} still work.
+//
+// Harmony image APIs block host compile of KRMemoryCacheModule.cpp.
+// Header-only helper kr_memory_cache_map_find.h mirrors the FIXED lookup.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_kr_memory_cache_map_find_test.sh
+//   ./run_kr_memory_cache_map_find_test.sh asan
+
+#include "kr_memory_cache_map_find.h"
+
+#include <cstdio>
+#include <string>
+
+using leftover_memory_cache::CacheImage;
+using leftover_memory_cache::HostMap;
+using leftover_memory_cache::MakeHostValue;
+using leftover_memory_cache::SetObject;
+using leftover_memory_cache::kParamNameKey;
+using leftover_memory_cache::kParamNameSrc;
+using leftover_memory_cache::kParamNameValue;
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void leftover_operator_index_inserts_nullptr() {
+    HostMap map;
+    auto inserted = map[kParamNameKey];
+    expect_true("leftover map[] missing key inserts default shared_ptr", !inserted);
+    expect_true("leftover map[] grew the map", map.find(kParamNameKey) != map.end());
+    expect_true("leftover map[] stored nullptr", map.find(kParamNameKey)->second == nullptr);
+}
+
+int main() {
+    leftover_operator_index_inserts_nullptr();
+
+    // SetObject({}) must not crash; return empty; nothing stored.
+    {
+        auto r = SetObject(HostMap{});
+        expect_true("SetObject({}) empty return", r.empty_return);
+        expect_true("SetObject({}) not stored", !r.stored);
+        expect_true("SetObject({}) key empty", r.key.empty());
+    }
+
+    // CacheImage({}) must not crash; return error.
+    {
+        auto r = CacheImage(HostMap{});
+        expect_true("CacheImage({}) is error", r.is_error);
+        expect_true("CacheImage({}) errorCode -1", r.error_code == -1);
+        expect_true("CacheImage({}) errorMsg missing src", r.error_msg == "missing src");
+        expect_true("CacheImage({}) src empty", r.src.empty());
+    }
+
+    // missing value only
+    {
+        HostMap map;
+        map[kParamNameKey] = MakeHostValue("k");
+        auto r = SetObject(map);
+        expect_true("SetObject({key}) empty return", r.empty_return);
+        expect_true("SetObject({key}) not stored", !r.stored);
+    }
+
+    // missing key only
+    {
+        HostMap map;
+        map[kParamNameValue] = MakeHostValue("v");
+        auto r = SetObject(map);
+        expect_true("SetObject({value}) empty return", r.empty_return);
+        expect_true("SetObject({value}) not stored", !r.stored);
+    }
+
+    // explicit nullptr shared_ptr at key / src (operator[] leftover payload)
+    {
+        HostMap map;
+        map[kParamNameKey] = nullptr;
+        map[kParamNameValue] = MakeHostValue("v");
+        auto r = SetObject(map);
+        expect_true("SetObject(null key) not stored", !r.stored);
+    }
+    {
+        HostMap map;
+        map[kParamNameSrc] = nullptr;
+        auto r = CacheImage(map);
+        expect_true("CacheImage(null src) is error", r.is_error);
+    }
+
+    // valid {key,value} still works
+    {
+        HostMap map;
+        map[kParamNameKey] = MakeHostValue("cache-a");
+        map[kParamNameValue] = MakeHostValue("payload");
+        auto r = SetObject(map);
+        expect_true("SetObject({key,value}) stored", r.stored);
+        expect_true("SetObject({key,value}) key", r.key == "cache-a");
+        expect_true("SetObject({key,value}) value", r.value == "payload");
+    }
+
+    // valid {src} still works
+    {
+        HostMap map;
+        map[kParamNameSrc] = MakeHostValue("https://example.com/a.png");
+        auto r = CacheImage(map);
+        expect_true("CacheImage({src}) not error", !r.is_error);
+        expect_true("CacheImage({src}) src", r.src == "https://example.com/a.png");
+        expect_true("CacheImage({src}) errorCode 0", r.error_code == 0);
+    }
+
+    // empty-string src is present (valid {src}), not missing
+    {
+        HostMap map;
+        map[kParamNameSrc] = MakeHostValue("");
+        auto r = CacheImage(map);
+        expect_true("CacheImage({src:\"\"}) not error", !r.is_error);
+        expect_true("CacheImage({src:\"\"}) src empty string", r.src.empty());
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all leftover memory-cache map-find tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_memory_cache_map_find_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_memory_cache_map_find_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Compile + run leftover KRMemoryCacheModule SetObject/CacheImage map[]
+# host tests (no Harmony device).
+#
+# Usage:
+#   ./run_kr_memory_cache_map_find_test.sh          # g++ default
+#   ./run_kr_memory_cache_map_find_test.sh asan     # Address+UB sanitizers
+#
+# kr_memory_cache_map_find.h is header-only (no Harmony image APIs).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$SCRIPT_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_memory_cache_map_find_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_memory_cache_map_find_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_memory_cache_map_find_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`KRMemoryCacheModule::SetObject` / `CacheImage` do `params->toMap()` then:

- `map[kParamNameKey]->toString()` and `map[kParamNameValue]`
- `map[kParamNameSrc]->toString()`

Map is `unordered_map<string, shared_ptr<KRRenderValue>>`. `operator[]` default-inserts a nullptr `shared_ptr` when the key is missing. `->toString()` is a null deref / crash. `Get()` already uses `find`.

Fix (those lookups only):

- `find` + null-check like `Get()`
- missing key / value → `KREmptyValue()`, nothing stored
- missing src → `GenerateError(-1, "missing src")`
- valid `{key,value}` / `{src}` still work

Does not edit `KRRenderValue.h`. Does not touch `toMap()` array-JSON leftover.

`KRMemoryCacheModule.cpp` cannot host-compile without Harmony image APIs. Header-only `kr_memory_cache_map_find.h` mirrors the FIXED find + null-check.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_memory_cache_map_find_test.sh
core-render-ohos/src/test/cpp/run_kr_memory_cache_map_find_test.sh asan
```

Signed-off-by: Tony Coder <407243179@qq.com>