### PR TITLE
fix(ohos): leftover KRNetworkModule httpRequestBinary array guard

### DIFF
--- a/core-render-ohos/src/main/ets/modules/KRNetworkModule.ets
+++ b/core-render-ohos/src/main/ets/modules/KRNetworkModule.ets
@@ -53,6 +53,18 @@ export class KRNetworkModule extends KuiklyRenderBaseModule {
       case KRNetworkModule.METHOD_HTTP_REQUEST:
         return this.httpRequest(params, null, callback);
       case KRNetworkModule.METHOD_HTTP_REQUEST_BINARY:
+        if (!Array.isArray(params) || (params as Array<KRAny>).length < 1) {
+          if (callback) {
+            const errmsg = `invalid httpRequestBinary params: ${params}`;
+            KRRenderLog.e("NetworkModule", errmsg);
+            let resultObject: Record<string, string> = {};
+            resultObject['errorMsg'] = errmsg;
+            resultObject['success'] = "0";
+            resultObject['statusCode'] = '-1000';
+            callback(resultObject);
+          }
+          return null;
+        }
         const args = params as Array<KRAny>;
         return this.httpRequest(args[0], args[1] as Int8Array, callback);
       default:


### PR DESCRIPTION
## leftover

`KRNetworkModule.call('httpRequestBinary')` does `const args = params as Array<KRAny>` then indexes `args[0]` / `args[1]` with no `Array.isArray` / length guard. `null` or a non-array (`{}`) throws on that index **before** `httpRequest`'s try/catch and aborts `call()`.

Empty array: `args[0]` is undefined; `JSON.parse` inside `httpRequest` is already caught. String `httpRequest` is already inside try/catch (L68–132).

Fix: if `!Array.isArray(params) || params.length < 1`, return error via callback (`success=0`) and do not index. Valid `[json, Int8Array]` still goes through the existing `httpRequest` try.

Does not rewrite `createURLAndOptions` / GET/POST body logic.

There is no ArkTS host harness. Required test plan:

- httpRequestBinary(null) and ({}) do not throw; callback success=0
- Valid [json, Int8Array] still works

Signed-off-by: Tony Coder <407243179@qq.com>