### PR TITLE
fix(ohos): leftover KRNotifyModule uncaught JSON.parse

### DIFF
--- a/core-render-ohos/src/main/ets/modules/KRNotifyModule.ets
+++ b/core-render-ohos/src/main/ets/modules/KRNotifyModule.ets
@@ -74,9 +74,12 @@ export class KRNotifyModule extends KuiklyRenderBaseModule {
   }
 
   onDestroy(): void {
-    Object.keys(this.subscribersMap).forEach((key) => {
-      emitter.off(key, this.globalCallback!);
-    });
+    const cb = this.globalCallback;
+    if (cb) {
+      Object.keys(this.subscribersMap).forEach((key) => {
+        emitter.off(key, cb);
+      });
+    }
     this.subscribersMap = {};
     this.globalCallback = null;
   }
@@ -86,7 +89,13 @@ export class KRNotifyModule extends KuiklyRenderBaseModule {
       return;
     }
 
-    let paramsObj: KRAddNotifyParams = JSON.parse(params);
+    let paramsObj: KRAddNotifyParams;
+    try {
+      paramsObj = JSON.parse(params);
+    } catch (e) {
+      console.info(`NotifyModule: addNotify error ${e}`);
+      return;
+    }
 
     const callbackWrappers = this.subscribersMap[paramsObj.eventName];
     if (callbackWrappers) {
@@ -119,7 +128,13 @@ export class KRNotifyModule extends KuiklyRenderBaseModule {
     if (params == null) {
       return;
     }
-    let paramsObj: KRRemoveNotifyParams = JSON.parse(params);
+    let paramsObj: KRRemoveNotifyParams;
+    try {
+      paramsObj = JSON.parse(params);
+    } catch (e) {
+      console.info(`NotifyModule: removeNotify error ${e}`);
+      return;
+    }
     let callbackWrappers = this.subscribersMap[paramsObj.eventName];
     if (callbackWrappers) {
       const index = callbackWrappers.findIndex((value) => {
@@ -128,7 +143,9 @@ export class KRNotifyModule extends KuiklyRenderBaseModule {
       if (index > -1) {
         callbackWrappers.splice(index, 1);
         if (callbackWrappers.length === 0) {
-          emitter.off(paramsObj.eventName, this.globalCallback!);
+          if (this.globalCallback) {
+            emitter.off(paramsObj.eventName, this.globalCallback);
+          }
           this.subscribersMap[paramsObj.eventName] = null;
         }
       }
@@ -140,7 +157,13 @@ export class KRNotifyModule extends KuiklyRenderBaseModule {
       return;
     }
 
-    let paramsObj: KRPostNotifyParams = JSON.parse(params);
+    let paramsObj: KRPostNotifyParams;
+    try {
+      paramsObj = JSON.parse(params);
+    } catch (e) {
+      console.info(`NotifyModule: postNotify error ${e}`);
+      return;
+    }
 
     emitter.emit(paramsObj.eventName, {
       data: {


### PR DESCRIPTION
## leftover

`KRNotifyModule.addNotify` / `removeNotify` / `postNotify` null-check `params` then `JSON.parse` with no try/catch. Sibling leftover `KRRouterModule.openPage` already wraps parse in try/catch and logs.

Malformed / non-JSON / truncated JSON throws out of `call()` and aborts ArkTS dispatch.

Same-file leftover: `onDestroy` force-unwraps `this.globalCallback!` when the subscribers map is non-empty. `removeNotify` last-subscriber `emitter.off` does the same `globalCallback!`.

Fix: try/catch like Router. Ignore/log bad payload. Do not subscribe / unsubscribe / emit on bad JSON. If `!this.globalCallback`, skip `emitter.off` in `onDestroy` and last-subscriber `removeNotify`.

Does not rewrite emitter subscribe logic.

There is no ArkTS host harness. Required test plan:

- addNotify/removeNotify/postNotify("not-json") do not throw
- addNotify/removeNotify/postNotify("{\"eventName\": ") do not throw
- valid {"eventName":"e","id":"1"} still works

Signed-off-by: Tony Coder <407243179@qq.com>