### PR TITLE
fix(ohos): leftover ActivityIndicator MyUserData stop/new-free

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/ActivityIndicator/KRActivityIndicatorAnimationView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/ActivityIndicator/KRActivityIndicatorAnimationView.cpp
@@ -27,6 +27,51 @@ constexpr int kMinFrameRate = 10;
 constexpr int kMaxFrameRate = 120;
 constexpr int kExpectedFrameRate = 60;
 
+struct KRActivityIndicatorAnimationView::MyUserData {
+    ArkUI_ContextHandle handle = nullptr;
+    std::weak_ptr<IKRRenderViewExport> weak_view;
+    ArkUI_ContextCallback update{};
+    ArkUI_AnimateCompleteCallback complete_callback{};
+    ArkUI_AnimateOption *option = nullptr;
+    uint32_t index = 0;
+    bool stop = false;
+    bool armed = false;
+    MyUserData **owner = nullptr;
+};
+
+void KRActivityIndicatorAnimationView::DeleteMyUserData(MyUserData *user_data) {
+    if (user_data == nullptr) {
+        return;
+    }
+    if (user_data->owner != nullptr) {
+        *user_data->owner = nullptr;
+        user_data->owner = nullptr;
+    }
+    if (user_data->option != nullptr) {
+        OH_ArkUI_AnimateOption_Dispose(user_data->option);
+        user_data->option = nullptr;
+    }
+    user_data->weak_view.reset();
+    delete user_data;
+}
+
+void KRActivityIndicatorAnimationView::OnDestroy() {
+    IKRRenderViewExport::OnDestroy();
+    if (user_data_ == nullptr) {
+        return;
+    }
+    user_data_->stop = true;
+    // If animateTo never armed, complete will not fire — delete here.
+    // If armed, detach owner then drop the view slot so complete cannot
+    // write *owner into a destroyed view. Complete still deletes MyUserData.
+    if (!user_data_->armed) {
+        DeleteMyUserData(user_data_);
+    } else {
+        user_data_->owner = nullptr;
+        user_data_ = nullptr;
+    }
+}
+
 ArkUI_NodeHandle KRActivityIndicatorAnimationView::CreateNode() {
     return kuikly::util::GetNodeApi()->createNode(ARKUI_NODE_IMAGE);
 }
@@ -84,24 +129,23 @@ void KRActivityIndicatorAnimationView::FireOnImageCompleteEvent(ArkUI_NodeEvent 
 
     auto root_view = GetRootView().lock();
     if (!root_view) {
+        OH_ArkUI_AnimateOption_Dispose(option);
         return;
     }
     ArkUI_ContextHandle handle = root_view->GetUIContextHandle();
 
-    struct MyUserData {
-        ArkUI_ContextHandle handle;
-        std::weak_ptr<IKRRenderViewExport> weak_view;
-        ArkUI_ContextCallback update;
-        ArkUI_AnimateCompleteCallback complete_callback;
-        ArkUI_AnimateOption *option;
-        uint32_t index;
-        bool stop;
-    };
+    if (user_data_ != nullptr) {
+        DeleteMyUserData(user_data_);
+    }
+
     MyUserData *user_data = new MyUserData;
+    user_data->stop = false;
     user_data->weak_view = weak_from_this();
     user_data->handle = handle;
     user_data->option = option;
     user_data->index = 0;
+    user_data->owner = &user_data_;
+    user_data_ = user_data;
     user_data->update.userData = user_data;
     user_data->update.callback = [](void *userData) {
         struct MyUserData *user_data = (struct MyUserData *)userData;
@@ -122,8 +166,7 @@ void KRActivityIndicatorAnimationView::FireOnImageCompleteEvent(ArkUI_NodeEvent 
     user_data->complete_callback.callback = [](void *userData) {
         struct MyUserData *user_data = (struct MyUserData *)userData;
         if (user_data->stop) {
-            user_data->weak_view.reset();
-            free(userData);
+            DeleteMyUserData(user_data);
         } else {
             // start next iteration
             user_data->index = (user_data->index + 1) % kRotateTimesPerCycle;
@@ -137,11 +180,14 @@ void KRActivityIndicatorAnimationView::FireOnImageCompleteEvent(ArkUI_NodeEvent 
                 OH_ArkUI_AnimateOption_SetDuration(user_data->option, kDurations[user_data->index]);
                 ArkUI_NativeAnimateAPI_1 *animate_api = reinterpret_cast<ArkUI_NativeAnimateAPI_1 *>(
                     OH_ArkUI_QueryModuleInterfaceByName(ARKUI_NATIVE_ANIMATE, "ArkUI_NativeAnimateAPI_1"));
+                if (!animate_api) {
+                    DeleteMyUserData(user_data);
+                    return;
+                }
                 animate_api->animateTo(user_data->handle, user_data->option, &user_data->update,
                                        &user_data->complete_callback);
             } else {
-                user_data->weak_view.reset();
-                free(userData);
+                DeleteMyUserData(user_data);
             }
         }
     };
@@ -149,6 +195,9 @@ void KRActivityIndicatorAnimationView::FireOnImageCompleteEvent(ArkUI_NodeEvent 
     OH_ArkUI_AnimateOption_SetDuration(option, kDurations[user_data->index]);
     ArkUI_NativeAnimateAPI_1 *animate_api = reinterpret_cast<ArkUI_NativeAnimateAPI_1 *>(
         OH_ArkUI_QueryModuleInterfaceByName(ARKUI_NATIVE_ANIMATE, "ArkUI_NativeAnimateAPI_1"));
-
+    if (!animate_api) {
+        return;
+    }
+    user_data->armed = true;
     animate_api->animateTo(handle, option, &user_data->update, &user_data->complete_callback);
 }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/ActivityIndicator/KRActivityIndicatorAnimationView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/ActivityIndicator/KRActivityIndicatorAnimationView.h
@@ -26,10 +26,15 @@ class KRActivityIndicatorAnimationView : public IKRRenderViewExport {
                  const KRRenderCallback event_call_back = nullptr) override;
     void SetRenderViewFrame(const KRRect &frame) override;
     void OnEvent(ArkUI_NodeEvent *event, const ArkUI_NodeEventType &event_type) override;
+    void OnDestroy() override;
 
  private:
+    struct MyUserData;
+    static void DeleteMyUserData(MyUserData *user_data);
     void SetStyle(const std::string &style);
     void FireOnImageCompleteEvent(ArkUI_NodeEvent *event);
+
+    MyUserData *user_data_ = nullptr;
 };
 
 #endif  // CORE_RENDER_OHOS_KRACTIVITYINDICATORANIMATIONVIEW_H

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/activity_indicator_userdata_host.h
+++ b/core-render-ohos/src/test/cpp/activity_indicator_userdata_host.h
@@ -1,0 +1,115 @@
+#ifndef CORE_RENDER_OHOS_TEST_ACTIVITY_INDICATOR_USERDATA_HOST_H
+#define CORE_RENDER_OHOS_TEST_ACTIVITY_INDICATOR_USERDATA_HOST_H
+
+#include <memory>
+
+// Extracted leftover KRActivityIndicatorAnimationView MyUserData init/teardown.
+//
+// Production lifetime (no ArkUI in this helper):
+//   stop=false on create; armed=false until animateTo
+//   OnDestroy sets stop=true
+//   Unarmed: OnDestroy deletes
+//   Armed: OnDestroy detaches owner and drops the view slot; complete deletes
+//   the live MyUserData and must not write *owner (view already gone)
+//   delete not free; dispose option; null animate_api skip
+//
+// Header-only so host leftover tests compile without ArkUI / Harmony.
+
+struct ActivityIndicatorHostUserData {
+    std::weak_ptr<int> weak_view;
+    bool stop;
+    bool armed;
+    int *option;
+    bool *dtor_ran;
+    ActivityIndicatorHostUserData **owner;
+
+    ActivityIndicatorHostUserData()
+        : stop(false), armed(false), option(nullptr), dtor_ran(nullptr), owner(nullptr) {}
+
+    ~ActivityIndicatorHostUserData() {
+        if (dtor_ran != nullptr) {
+            *dtor_ran = true;
+        }
+    }
+};
+
+inline ActivityIndicatorHostUserData *InitMyUserData() {
+    ActivityIndicatorHostUserData *user_data = new ActivityIndicatorHostUserData();
+    user_data->stop = false;
+    user_data->armed = false;
+    return user_data;
+}
+
+inline void AttachOwner(ActivityIndicatorHostUserData *&slot) {
+    if (slot != nullptr) {
+        slot->owner = &slot;
+    }
+}
+
+template <typename DisposeFn>
+inline void DeleteMyUserData(ActivityIndicatorHostUserData *user_data, DisposeFn dispose_option) {
+    if (user_data == nullptr) {
+        return;
+    }
+    if (user_data->owner != nullptr) {
+        *user_data->owner = nullptr;
+        user_data->owner = nullptr;
+    }
+    dispose_option(user_data);
+    delete user_data;
+}
+
+template <typename DisposeFn>
+inline void TeardownMyUserData(ActivityIndicatorHostUserData *&slot, DisposeFn dispose_option) {
+    if (slot == nullptr) {
+        return;
+    }
+    ActivityIndicatorHostUserData *user_data = slot;
+    slot = nullptr;
+    user_data->owner = nullptr;
+    dispose_option(user_data);
+    delete user_data;
+}
+
+template <typename DisposeFn>
+inline void OnDestroyMyUserData(ActivityIndicatorHostUserData *&slot, DisposeFn dispose_option) {
+    if (slot == nullptr) {
+        return;
+    }
+    slot->stop = true;
+    if (!slot->armed) {
+        DeleteMyUserData(slot, dispose_option);
+        slot = nullptr;
+    } else {
+        slot->owner = nullptr;
+        slot = nullptr;
+    }
+}
+
+// complete holds the raw MyUserData pointer, not the view slot.
+// Must not write *owner if OnDestroy already detached it.
+template <typename DisposeFn>
+inline void CompleteDelete(ActivityIndicatorHostUserData *user_data, DisposeFn dispose_option) {
+    if (user_data == nullptr) {
+        return;
+    }
+    if (user_data->stop) {
+        DeleteMyUserData(user_data, dispose_option);
+    }
+}
+
+inline bool AnimateToIfPresent(void *animate_api) {
+    if (!animate_api) {
+        return false;
+    }
+    return true;
+}
+
+inline void ArmAnimateTo(ActivityIndicatorHostUserData *user_data, void *animate_api) {
+    if (!AnimateToIfPresent(animate_api) || user_data == nullptr) {
+        return;
+    }
+    user_data->armed = true;
+}
+
+#endif  // CORE_RENDER_OHOS_TEST_ACTIVITY_INDICATOR_USERDATA_HOST_H

--- a/core-render-ohos/src/test/cpp/activity_indicator_userdata_stop_test.cpp
+++ b/core-render-ohos/src/test/cpp/activity_indicator_userdata_stop_test.cpp
@@ -1,0 +1,99 @@
+// Host unit test for leftover ActivityIndicator MyUserData stop/new-free.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_activity_indicator_userdata_stop_test.sh
+//   ./run_activity_indicator_userdata_stop_test.sh asan
+
+#include "activity_indicator_userdata_host.h"
+
+#include <cstdio>
+#include <memory>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+static void dispose_option(ActivityIndicatorHostUserData *user_data) {
+    if (user_data != nullptr && user_data->option != nullptr) {
+        delete user_data->option;
+        user_data->option = nullptr;
+    }
+}
+
+int main() {
+    {
+        ActivityIndicatorHostUserData *slot = InitMyUserData();
+        expect_true("init stop defaults false", slot != nullptr && slot->stop == false);
+        TeardownMyUserData(slot, dispose_option);
+        expect_true("teardown nulls slot", slot == nullptr);
+    }
+
+    {
+        bool dtor_ran = false;
+        auto live = std::make_shared<int>(1);
+        ActivityIndicatorHostUserData *slot = InitMyUserData();
+        slot->dtor_ran = &dtor_ran;
+        slot->weak_view = live;
+        slot->option = new int(7);
+        expect_true("init stop false before teardown", slot->stop == false);
+        expect_true("weak_view attached", !slot->weak_view.expired());
+        TeardownMyUserData(slot, dispose_option);
+        expect_true("delete (not free) ran dtor", dtor_ran);
+        expect_true("slot nulled after delete", slot == nullptr);
+        expect_true("weak_ptr dtor released control block", live.use_count() == 1);
+        live.reset();
+    }
+
+    {
+        bool dtor_ran = false;
+        ActivityIndicatorHostUserData *slot = InitMyUserData();
+        slot->dtor_ran = &dtor_ran;
+        slot->option = new int(3);
+        expect_true("null animate_api is no-op", !AnimateToIfPresent(nullptr));
+        OnDestroyMyUserData(slot, dispose_option);
+        expect_true("unarmed OnDestroy sets stop and deletes", dtor_ran);
+        expect_true("unarmed OnDestroy nulls slot", slot == nullptr);
+    }
+
+    // Armed OnDestroy detaches owner and drops the view slot. Complete
+    // deletes the live MyUserData and must not write through a dangling owner
+    // (the leftover unmount-while-rotating write into a destroyed view).
+    {
+        bool dtor_ran = false;
+        ActivityIndicatorHostUserData *slot = InitMyUserData();
+        slot->dtor_ran = &dtor_ran;
+        slot->option = new int(5);
+        AttachOwner(slot);
+        int dummy_api = 1;
+        ArmAnimateTo(slot, &dummy_api);
+        expect_true("armed after animateTo", slot->armed);
+        expect_true("owner attached to view slot", slot->owner == &slot);
+        ActivityIndicatorHostUserData *raw = slot;
+        OnDestroyMyUserData(slot, dispose_option);
+        expect_true("armed OnDestroy does not delete", !dtor_ran);
+        expect_true("armed OnDestroy drops view slot", slot == nullptr);
+        expect_true("armed OnDestroy detaches owner", raw->owner == nullptr);
+        expect_true("armed OnDestroy left object live", raw->stop);
+        CompleteDelete(raw, dispose_option);
+        expect_true("complete after detach deletes live object", dtor_ran);
+    }
+
+    {
+        int dummy_api = 1;
+        expect_true("non-null animate_api is not skipped", AnimateToIfPresent(&dummy_api));
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all leftover activity indicator userdata tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_activity_indicator_userdata_stop_test.sh
+++ b/core-render-ohos/src/test/cpp/run_activity_indicator_userdata_stop_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Compile + run leftover ActivityIndicator MyUserData stop/new-free host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_activity_indicator_userdata_stop_test.sh          # g++ default
+#   ./run_activity_indicator_userdata_stop_test.sh asan     # Address+UB sanitizers
+#
+# activity_indicator_userdata_host.h is header-only (no ArkUI). Host g++ includes it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$SCRIPT_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/activity_indicator_userdata_stop_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/activity_indicator_userdata_stop_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/activity_indicator_userdata_stop_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`KRActivityIndicatorAnimationView::FireOnImageCompleteEvent` `new`s `MyUserData` (contains `std::weak_ptr`) and never writes `bool stop`. Complete reads `user_data->stop` (UB). `free()` on that object skips the dtor so the weak_ptr control block is not released. `stop` has no setter — destroy-stop was never wired (`OnDestroy` did not exist). `QueryModuleInterfaceByName` `animate_api` is used with no null check.

Fix (rotate math unchanged):
- `user_data->stop = false` on create; store `user_data` on the view
- `OnDestroy` sets `stop = true`
- `delete` not `free` in complete/teardown (weak_ptr dtor runs)
- `OH_ArkUI_AnimateOption_Dispose` on teardown (and root-view early return)
- `if (!animate_api) skip animateTo`
- If `OnDestroy` deletes, complete must not delete again (null the view pointer / `TeardownUserDataIfOwned`)
- If `animate_api` is null, `OnDestroy` still tears down (dispose + delete)

Host leftover tests extract MyUserData init/teardown (`activity_indicator_userdata_host.h`) so `stop` defaults false, teardown is delete-not-free, and null `animate_api` is a no-op — no ArkUI / Harmony.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_activity_indicator_userdata_stop_test.sh
core-render-ohos/src/test/cpp/run_activity_indicator_userdata_stop_test.sh asan
```

Signed-off-by: Tony Coder <407243179@qq.com>