### PR TITLE
fix(ohos): leftover KRView superTouch disable-after-latch null deref

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/view/KRView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/view/KRView.cpp
@@ -127,6 +127,8 @@ bool KRView::SetProp(const std::string &prop_key, const KRAnyValue &prop_value,
             if (super_touch_handler_) {
                 super_touch_handler_ = nullptr;
             }
+            super_touch_type_ = UNKNOWN;
+            parent_super_touch_handler_.reset();
         }
         didHand = true;
     } else if (kuikly::util::isEqual(prop_key, kPropNameHitTestModeOhos)) {
@@ -412,6 +414,8 @@ bool KRView::ResetProp(const std::string &prop_key) {
         didHande = true;
     } else if (kuikly::util::isEqual(prop_key, kPropNameSuperTouch)) {
         super_touch_handler_ = nullptr;
+        super_touch_type_ = UNKNOWN;
+        parent_super_touch_handler_.reset();
         didHande = true;
     } else if (kuikly::util::isEqual(prop_key, kPropNameHitTestModeOhos)) {
         target_hit_test_mode = ARKUI_HIT_TEST_MODE_DEFAULT;
@@ -464,7 +468,7 @@ void KRView::ProcessTouchEvent(ArkUI_NodeEvent *event) {
     }
     if (super_touch_type_ == SELF) {
         bool should_stop = handled;
-        if (super_touch_handler_->GetStopPropagation(action)) {
+        if (super_touch_handler_ && super_touch_handler_->GetStopPropagation(action)) {
             should_stop = true;
             super_touch_handler_->SetStopPropagation(action, false);
         }

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/kr_view_supertouch_disable_host.h
+++ b/core-render-ohos/src/test/cpp/kr_view_supertouch_disable_host.h
@@ -1,0 +1,60 @@
+#ifndef CORE_RENDER_OHOS_TEST_KR_VIEW_SUPERTOUCH_DISABLE_HOST_H
+#define CORE_RENDER_OHOS_TEST_KR_VIEW_SUPERTOUCH_DISABLE_HOST_H
+
+// Extracted leftover KRView superTouch disable-after-latch.
+//
+// Leftover:
+//   SetProp/ResetProp superTouch false nulls handler only; type_ stays SELF
+//   after EnsureSuperTouchType latched it. ProcessTouchEvent SELF branch
+//   does super_touch_handler_->GetStopPropagation with no null check.
+//
+// Production fix:
+//   disable also sets type = UNKNOWN and clears parent weak handler
+//   Process SELF null-checks handler before ->
+//
+// Header-only so host leftover tests compile without ArkUI / Harmony.
+
+enum SuperTouchHostType { kUnknown, kNone, kSelf, kParent };
+
+struct SuperTouchHostState {
+    void *handler;
+    SuperTouchHostType type;
+    bool parent_reset;
+
+    SuperTouchHostState() : handler(nullptr), type(kUnknown), parent_reset(false) {}
+};
+
+inline void LatchSelf(SuperTouchHostState &s, void *live_handler) {
+    s.handler = live_handler;
+    s.type = kSelf;
+}
+
+// leftover disable: null handler only (type stays SELF) — used to prove
+// Process must not deref null even if type is still SELF.
+inline void ClearHandlerOnly(SuperTouchHostState &s) {
+    s.handler = nullptr;
+}
+
+// production disable (SetProp/ResetProp superTouch false)
+inline void DisableSuperTouch(SuperTouchHostState &s) {
+    s.handler = nullptr;
+    s.type = kUnknown;
+    s.parent_reset = true;
+}
+
+// ProcessTouchEvent SELF branch after the null-check fix.
+// Returns true if it would have called GetStopPropagation.
+// Sets would_deref_null if the leftover unguarded -> would have fired.
+inline bool ProcessSelfStopPropagation(const SuperTouchHostState &s, bool &would_deref_null) {
+    would_deref_null = false;
+    if (s.type != kSelf) {
+        return false;
+    }
+    if (!s.handler) {
+        would_deref_null = true;  // leftover would have deref'd here
+        return false;             // fixed: skip
+    }
+    return true;
+}
+
+#endif  // CORE_RENDER_OHOS_TEST_KR_VIEW_SUPERTOUCH_DISABLE_HOST_H

--- a/core-render-ohos/src/test/cpp/kr_view_supertouch_disable_test.cpp
+++ b/core-render-ohos/src/test/cpp/kr_view_supertouch_disable_test.cpp
@@ -1,0 +1,67 @@
+// Host unit test for leftover KRView superTouch disable-after-latch null deref.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_kr_view_supertouch_disable_test.sh
+//   ./run_kr_view_supertouch_disable_test.sh asan
+
+#include "kr_view_supertouch_disable_host.h"
+
+#include <cstdio>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+int main() {
+    int live = 1;
+
+    // leftover polarity: latch SELF with live handler, then clear handler
+    // without resetting type. Next Process SELF must not deref null.
+    {
+        SuperTouchHostState s;
+        LatchSelf(s, &live);
+        expect_true("latched SELF with handler", s.type == kSelf && s.handler != nullptr);
+        ClearHandlerOnly(s);
+        expect_true("leftover disable leaves type SELF", s.type == kSelf && s.handler == nullptr);
+        bool would_deref_null = false;
+        bool called = ProcessSelfStopPropagation(s, would_deref_null);
+        expect_true("leftover SELF+null would have deref'd", would_deref_null);
+        expect_true("fixed Process does not call through null", !called);
+    }
+
+    // After reset-type fix: disable-then-next-touch stays UNKNOWN and skips SELF.
+    {
+        SuperTouchHostState s;
+        LatchSelf(s, &live);
+        DisableSuperTouch(s);
+        expect_true("disable resets type UNKNOWN", s.type == kUnknown);
+        expect_true("disable nulls handler", s.handler == nullptr);
+        expect_true("disable resets parent handler", s.parent_reset);
+        bool would_deref_null = false;
+        bool called = ProcessSelfStopPropagation(s, would_deref_null);
+        expect_true("UNKNOWN skips SELF deref", !called && !would_deref_null);
+    }
+
+    // Live SELF still calls through.
+    {
+        SuperTouchHostState s;
+        LatchSelf(s, &live);
+        bool would_deref_null = false;
+        bool called = ProcessSelfStopPropagation(s, would_deref_null);
+        expect_true("live SELF still calls handler", called && !would_deref_null);
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all leftover superTouch disable tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_kr_view_supertouch_disable_test.sh
+++ b/core-render-ohos/src/test/cpp/run_kr_view_supertouch_disable_test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Compile + run leftover KRView superTouch disable-after-latch host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_kr_view_supertouch_disable_test.sh          # g++ default
+#   ./run_kr_view_supertouch_disable_test.sh asan     # Address+UB sanitizers
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$SCRIPT_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/kr_view_supertouch_disable_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/kr_view_supertouch_disable_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/kr_view_supertouch_disable_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## leftover

`SetProp` / `ResetProp` `superTouch` false nulls `super_touch_handler_` only. `EnsureSuperTouchType` latches `SELF` on first touch with a handler and then returns forever. `ProcessTouchEvent` SELF branch calls `super_touch_handler_->GetStopPropagation` with no null check (`TryFireSuperTouchCancelEvent` already checks). Live disable after latch is a render-process null deref. `WillRemoveFromParentView` already resets type (reuse OK).

Fix:
- `SetProp` / `ResetProp` `superTouch` false also set `super_touch_type_ = UNKNOWN` and `parent_super_touch_handler_.reset()`
- `ProcessTouchEvent` SELF branch null-checks `super_touch_handler_` before `->` (same as cancel path)

Does not change `EnsureSuperTouchType` latch, `WillRemoveFromParentView`, other props, selection, or hit-test.

Host test (no Harmony device):

```
core-render-ohos/src/test/cpp/run_kr_view_supertouch_disable_test.sh
core-render-ohos/src/test/cpp/run_kr_view_supertouch_disable_test.sh asan
```

Signed-off-by: Tony Coder <407243179@qq.com>