### PR TITLE
fix(ohos): leftover KRTapGestureEventHandler 250ms raw-this UAF

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/events/gesture/KRGestureEventHandler.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/events/gesture/KRGestureEventHandler.cpp
@@ -167,12 +167,19 @@ void KRTapGestureEventHandler::OnGestureEvent(ArkUI_GestureEvent *event) {
             current_tap_count_++;
             if (current_tap_count_ == 1) {
                 last_tap_down_time_stamp_ = CurrentTimeStamp();
+                auto weak_self = std::weak_ptr<KRTapGestureEventHandler>(
+                    std::static_pointer_cast<KRTapGestureEventHandler>(shared_from_this()));
                 KRMainThread::RunOnMainThread(
-                    [this, event] {
-                        if (current_tap_count_ == 1) {
-                            gesture_callback_(node_, tap_event_data_, KRGestureEventType::kClick);
+                    [weak_self] {
+                        auto self = weak_self.lock();
+                        if (!self) {
+                            return;
                         }
-                        Reset();
+                        if (self->current_tap_count_ == 1) {
+                            self->gesture_callback_(self->node_, self->tap_event_data_,
+                                                    KRGestureEventType::kClick);
+                        }
+                        self->Reset();
                     },
                     250);
             } else if (current_tap_count_ == 2) {

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/run_tap_gesture_doubleclick_delay_test.sh
+++ b/core-render-ohos/src/test/cpp/run_tap_gesture_doubleclick_delay_test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Compile + run leftover KRTapGestureEventHandler 250ms delay host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_tap_gesture_doubleclick_delay_test.sh          # g++ default
+#   ./run_tap_gesture_doubleclick_delay_test.sh asan     # Address+UB sanitizers
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(
+    -std=c++17
+    -Wall
+    -Wextra
+    -Werror
+    -I"$SCRIPT_DIR"
+)
+
+SRCS=(
+    "$SCRIPT_DIR/tap_gesture_doubleclick_delay_test.cpp"
+)
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/tap_gesture_doubleclick_delay_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/tap_gesture_doubleclick_delay_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"

--- a/core-render-ohos/src/test/cpp/tap_gesture_doubleclick_delay_host.h
+++ b/core-render-ohos/src/test/cpp/tap_gesture_doubleclick_delay_host.h
@@ -1,0 +1,67 @@
+#ifndef CORE_RENDER_OHOS_TEST_TAP_GESTURE_DOUBLECLICK_DELAY_HOST_H
+#define CORE_RENDER_OHOS_TEST_TAP_GESTURE_DOUBLECLICK_DELAY_HOST_H
+
+#include <functional>
+#include <memory>
+
+// Extracted leftover KRTapGestureEventHandler double-click 250ms delay.
+//
+// Leftover (OnGestureEvent doubleClick ACCEPT, current_tap_count_==1):
+//   KRMainThread::RunOnMainThread([this, event] { ... current_tap_count_
+//     gesture_callback_ / Reset() ... }, 250)
+//   UnregisterGestureEvent drops the last shared_ptr; delay has no cancel.
+//   Timer then touches members on a freed handler (raw-this UAF).
+//   `event` is unused and dangling after the gesture call returns.
+//
+// Production (no ArkUI / KRMainThread in this helper):
+//   capture weak_from_this (static_pointer_cast then weak)
+//   lock before any member touch; return if expired
+//   do not capture event
+//   live path: count==1 fires click then Reset
+//
+// Header-only so host leftover tests compile without ArkUI / Harmony.
+
+struct TapDelayHostHandler : std::enable_shared_from_this<TapDelayHostHandler> {
+    int current_tap_count = 0;
+    bool click_fired = false;
+    bool reset_ran = false;
+    bool *dtor_ran = nullptr;
+
+    ~TapDelayHostHandler() {
+        if (dtor_ran != nullptr) {
+            *dtor_ran = true;
+        }
+    }
+
+    void Reset() {
+        current_tap_count = 0;
+        reset_ran = true;
+    }
+
+    // Models the delayed body after weak lock.
+    void FireDelayedClickIfSingle() {
+        if (current_tap_count == 1) {
+            click_fired = true;
+        }
+        Reset();
+    }
+
+    std::weak_ptr<TapDelayHostHandler> WeakSelf() {
+        return std::weak_ptr<TapDelayHostHandler>(
+            std::static_pointer_cast<TapDelayHostHandler>(shared_from_this()));
+    }
+};
+
+// 250ms-style delayed callback: weak capture, lock-or-return.
+inline std::function<void()> ScheduleTapDelay(const std::shared_ptr<TapDelayHostHandler> &handler) {
+    auto weak_self = handler->WeakSelf();
+    return [weak_self] {
+        auto self = weak_self.lock();
+        if (!self) {
+            return;
+        }
+        self->FireDelayedClickIfSingle();
+    };
+}
+
+#endif  // CORE_RENDER_OHOS_TEST_TAP_GESTURE_DOUBLECLICK_DELAY_HOST_H

--- a/core-render-ohos/src/test/cpp/tap_gesture_doubleclick_delay_test.cpp
+++ b/core-render-ohos/src/test/cpp/tap_gesture_doubleclick_delay_test.cpp
@@ -1,0 +1,76 @@
+// Host unit test for leftover KRTapGestureEventHandler 250ms raw-this UAF.
+//
+// Leftover: doubleClick ACCEPT schedules [this, event] for 250ms.
+// Unregister drops last shared_ptr; timer still touches members.
+//
+// Production: weak capture + lock; expired is a no-op (no member touch).
+// Live path: keep the shared_ptr, count==1 fires click then Reset.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_tap_gesture_doubleclick_delay_test.sh
+//   ./run_tap_gesture_doubleclick_delay_test.sh asan
+
+#include "tap_gesture_doubleclick_delay_host.h"
+
+#include <cstdio>
+#include <memory>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+int main() {
+    // Destroy-before-fire: drop last shared_ptr, then run the delayed
+    // callback. Must no-op (no member touch) — leftover raw-this UAF.
+    {
+        bool dtor_ran = false;
+        std::function<void()> delayed;
+        {
+            auto handler = std::make_shared<TapDelayHostHandler>();
+            handler->dtor_ran = &dtor_ran;
+            handler->current_tap_count = 1;
+            delayed = ScheduleTapDelay(handler);
+            expect_true("handler live before drop", handler.use_count() == 1);
+            handler.reset();
+        }
+        expect_true("last shared_ptr dropped before fire", dtor_ran);
+        delayed();
+        expect_true("expired delay is a no-op", true);
+    }
+
+    // Live path: keep the shared_ptr; count==1 fires click then Reset.
+    {
+        auto handler = std::make_shared<TapDelayHostHandler>();
+        handler->current_tap_count = 1;
+        auto delayed = ScheduleTapDelay(handler);
+        delayed();
+        expect_true("live delay fires click when count==1", handler->click_fired);
+        expect_true("live delay Reset after click", handler->reset_ran);
+        expect_true("live delay Reset cleared count", handler->current_tap_count == 0);
+    }
+
+    // Live path: count!=1 does not fire click, still Reset.
+    {
+        auto handler = std::make_shared<TapDelayHostHandler>();
+        handler->current_tap_count = 2;
+        auto delayed = ScheduleTapDelay(handler);
+        delayed();
+        expect_true("live delay skips click when count!=1", !handler->click_fired);
+        expect_true("live delay Reset when count!=1", handler->reset_ran);
+        expect_true("live delay Reset cleared count!=1", handler->current_tap_count == 0);
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all leftover tap gesture doubleclick delay tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Double-click path scheduled `KRMainThread::RunOnMainThread([this, event], 250)`. `UnregisterGestureEvent` drops the last `shared_ptr`; the delay has no cancel, so the timer UAFs on `current_tap_count_` / `tap_event_data_` / `gesture_callback_` / `Reset()`.
- Capture `weak_from_this()` (`static_pointer_cast<KRTapGestureEventHandler>` then weak). Lock before touching members; return if expired. Do not capture `event`.
- Click-only path, `RegisterEvent`, `Reset`, `UnregisterGestureEvent`, `KRGestureGroupHandler`, and `KRMainThread` are unchanged.

## Test plan
- [x] Host leftover test (no Harmony): `core-render-ohos/src/test/cpp/run_tap_gesture_doubleclick_delay_test.sh` default + asan
- [x] Destroy-before-fire: drop last `shared_ptr`, delayed callback no-ops
- [x] Live path: keep `shared_ptr`, count==1 fires click then Reset

Signed-off-by: Tony Coder <407243179@qq.com>