### PR TITLE
fix(ohos): leftover KRGradientRichTextShadow empty-color 0-size VLA

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/gradient_richtext/KRGradientRichTextShadow.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/gradient_richtext/KRGradientRichTextShadow.cpp
@@ -55,12 +55,17 @@ KRSize KRGradientRichTextShadow::CalculateRenderViewSize(double constraint_width
 
 void KRGradientRichTextShadow::DidBuildTextStyle(OH_Drawing_TextStyle *textStyle, double dpi) {
     if (calculate_width_ != 0 && calculate_height_ != 0 && text_linearGradient_ != nullptr) {
+        // leftover: Parse can succeed with no color-stop pair (empty colors/locations).
+        // 0-size VLA is UB; CreateLinearGradient(..., count=0) is not valid.
+        // Do not OH_Drawing_ShaderEffectDestroy — it crashes on API 13/17.
+        const std::vector<uint32_t> &colors = text_linearGradient_->GetColors();
+        const std::vector<float> &locations = text_linearGradient_->GetLocations();
+        if (colors.empty() || locations.empty()) {
+            return;
+        }
         // 文字渐变
         auto brush = OH_Drawing_BrushCreate();
         OH_Drawing_BrushSetAntiAlias(brush, true);  // 抗锯齿
-        // 获取 colors 和 locations
-        const std::vector<uint32_t> &colors = text_linearGradient_->GetColors();
-        const std::vector<float> &locations = text_linearGradient_->GetLocations();
 
         // 创建 C 风格数组
         uint32_t colorsArray[colors.size()];

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/gradient_richtext_empty_color_host.h
+++ b/core-render-ohos/src/test/cpp/gradient_richtext_empty_color_host.h
@@ -1,0 +1,46 @@
+#ifndef CORE_RENDER_OHOS_TEST_GRADIENT_RICHTEXT_EMPTY_COLOR_HOST_H
+#define CORE_RENDER_OHOS_TEST_GRADIENT_RICHTEXT_EMPTY_COLOR_HOST_H
+
+#include <cstdint>
+#include <vector>
+
+// Extracted leftover KRGradientRichTextShadow::DidBuildTextStyle
+// (empty colors / locations after a successful parse).
+//
+// Leftover:
+//   ParseFromCssLinearGradient can return true for linear-gradient(0)
+//   / linear-gradient(0, #ff0000) with no color-stop pair, leaving
+//   text_linearGradient_ non-null and GetColors()/GetLocations() empty.
+//   uint32_t colorsArray[colors.size()] is then a 0-size VLA (UB) and
+//   CreateLinearGradient(..., count=0).
+//
+// Production (no Drawing / Harmony in this helper):
+//   empty colors or empty locations => skip shader (no VLA, no create)
+//   non-empty => still build the C arrays
+//
+// Header-only so host leftover tests compile without ArkUI / Harmony.
+
+inline bool ShouldSkipGradientShader(const std::vector<uint32_t> &colors,
+                                     const std::vector<float> &locations) {
+    return colors.empty() || locations.empty();
+}
+
+inline void BuildGradientArrays(const std::vector<uint32_t> &colors,
+                                const std::vector<float> &locations,
+                                std::vector<uint32_t> &colors_array,
+                                std::vector<float> &stops_array) {
+    colors_array.resize(colors.size());
+    stops_array.resize(locations.size());
+    for (size_t i = 0; i < colors.size(); ++i) {
+        colors_array[i] = colors[i];
+    }
+    for (size_t i = 0; i < locations.size(); ++i) {
+        if (i == locations.size() - 1) {
+            stops_array[i] = 1.0f;
+        } else {
+            stops_array[i] = locations[i];
+        }
+    }
+}
+
+#endif  // CORE_RENDER_OHOS_TEST_GRADIENT_RICHTEXT_EMPTY_COLOR_HOST_H

--- a/core-render-ohos/src/test/cpp/gradient_richtext_empty_color_test.cpp
+++ b/core-render-ohos/src/test/cpp/gradient_richtext_empty_color_test.cpp
@@ -1,0 +1,59 @@
+// Host unit test for leftover KRGradientRichTextShadow empty-color 0-size VLA.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_gradient_richtext_empty_color_test.sh
+//   ./run_gradient_richtext_empty_color_test.sh asan
+
+#include "gradient_richtext_empty_color_host.h"
+
+#include <cstdio>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+int main() {
+    {
+        std::vector<uint32_t> colors;
+        std::vector<float> locations;
+        expect_true("empty colors+locations skip shader",
+                    ShouldSkipGradientShader(colors, locations));
+    }
+    {
+        std::vector<uint32_t> colors;
+        std::vector<float> locations{0.0f, 1.0f};
+        expect_true("empty colors skip shader", ShouldSkipGradientShader(colors, locations));
+    }
+    {
+        std::vector<uint32_t> colors{0xff0000u};
+        std::vector<float> locations;
+        expect_true("empty locations skip shader", ShouldSkipGradientShader(colors, locations));
+    }
+    {
+        std::vector<uint32_t> colors{0xff0000u, 0x00ff00u};
+        std::vector<float> locations{0.0f, 0.5f};
+        expect_true("non-empty does not skip", !ShouldSkipGradientShader(colors, locations));
+        std::vector<uint32_t> colors_array;
+        std::vector<float> stops_array;
+        BuildGradientArrays(colors, locations, colors_array, stops_array);
+        expect_true("non-empty builds color array",
+                    colors_array.size() == 2 && colors_array[0] == 0xff0000u &&
+                        colors_array[1] == 0x00ff00u);
+        expect_true("non-empty builds stops (last forced 1.0)",
+                    stops_array.size() == 2 && stops_array[0] == 0.0f && stops_array[1] == 1.0f);
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all leftover gradient richtext empty-color tests passed\n");
+    return 0;
+}

--- a/core-render-ohos/src/test/cpp/run_gradient_richtext_empty_color_test.sh
+++ b/core-render-ohos/src/test/cpp/run_gradient_richtext_empty_color_test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Compile + run leftover KRGradientRichTextShadow empty-color host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_gradient_richtext_empty_color_test.sh
+#   ./run_gradient_richtext_empty_color_test.sh asan
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(-std=c++17 -Wall -Wextra -Werror -I"$SCRIPT_DIR")
+SRCS=("$SCRIPT_DIR/gradient_richtext_empty_color_test.cpp")
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/gradient_richtext_empty_color_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/gradient_richtext_empty_color_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"


### PR DESCRIPTION
## Summary
- `DidBuildTextStyle` built `uint32_t colorsArray[colors.size()]` after a successful parse with empty colors/locations (`linear-gradient(0)` / `linear-gradient(0, #ff0000)`). 0-size VLA is UB; `CreateLinearGradient(..., count=0)` is not valid.
- Skip the shader when `colors` or `locations` is empty. Do not call `OH_Drawing_ShaderEffectDestroy` (crashes on API 13/17).
- `SetProp`, `CalculateRenderViewSize`, and `KRLinearGradientParser` are unchanged.

## Test plan
- [x] Host leftover test (no Harmony): `core-render-ohos/src/test/cpp/run_gradient_richtext_empty_color_test.sh` default + asan
- [x] Empty colors/locations skip the array/create path
- [x] Non-empty still builds the arrays

Signed-off-by: Tony Coder <407243179@qq.com>