### PR TITLE
fix(ohos): leftover SuperTouchHandler dispose-notify raw this + null recognizer

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/view/SuperTouchHandler.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/view/SuperTouchHandler.cpp
@@ -14,11 +14,17 @@
  */
 
 #include "SuperTouchHandler.h"
+
+#include "libohos_render/manager/KRWeakObjectManager.h"
 SuperTouchHandler::~SuperTouchHandler() {
-    for (auto recognizer : gesture_recognizers_) {
-        OH_ArkUI_SetGestureRecognizerEnabled(recognizer, true);
+    auto snapshot = gesture_recognizers_;
+    for (auto recognizer : snapshot) {
+        if (recognizer == nullptr) {
+            continue;
+        }
         OH_ArkUI_SetArkUIGestureRecognizerDisposeNotify(
             recognizer, [](ArkUI_GestureRecognizer *recognizer, void *userData) {}, nullptr);
+        OH_ArkUI_SetGestureRecognizerEnabled(recognizer, true);
     }
     gesture_recognizers_.clear();
 }
@@ -29,6 +35,9 @@ void SuperTouchHandler::PreventTouch(bool prevent) {
     }
     prevent_touch_ = prevent;
     for (auto recognizer : gesture_recognizers_) {
+        if (recognizer == nullptr) {
+            continue;
+        }
         OH_ArkUI_SetGestureRecognizerEnabled(recognizer, !prevent);
     }
 }
@@ -44,22 +53,35 @@ void SuperTouchHandler::ClearNativeTouchConsumer(const std::shared_ptr<IKRRender
 }
 
 void SuperTouchHandler::CollectGestureRecognizer(ArkUI_GestureRecognizer *recognizer) {
+    if (recognizer == nullptr) {
+        return;
+    }
     if (gesture_recognizers_.find(recognizer) != gesture_recognizers_.end()) {
         // already collected
         return;
     }
     // TODO: consider to erase the recognizer when it's owner ark_ui_node detached
     gesture_recognizers_.insert(recognizer);
+    void *userData = KRWeakObjectManagerRegisterWeakObject(shared_from_this());
     OH_ArkUI_SetArkUIGestureRecognizerDisposeNotify(
         recognizer,
         [](ArkUI_GestureRecognizer *recognizer, void *userData) {
-            auto self = static_cast<SuperTouchHandler *>(userData);
-            self->gesture_recognizers_.erase(recognizer);
+            auto weak = KRWeakObjectManagerGetWeakObject<SuperTouchHandler>(userData);
+            if (auto self = weak.lock()) {
+                self->gesture_recognizers_.erase(recognizer);
+            }
         },
-        this);
+        userData);
     if (prevent_touch_) {
         OH_ArkUI_SetGestureRecognizerEnabled(recognizer, false);
     }
+}
+
+void SuperTouchHandler::EraseGestureRecognizer(ArkUI_GestureRecognizer *recognizer) {
+    if (recognizer == nullptr) {
+        return;
+    }
+    gesture_recognizers_.erase(recognizer);
 }
 
 bool SuperTouchHandler::IsCanceled() { return super_touch_canceled_; }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/view/SuperTouchHandler.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/view/SuperTouchHandler.h
@@ -18,8 +18,9 @@
 
 #include "libohos_render/export/IKRRenderViewExport.h"
 #include <arkui/native_gesture.h>
+#include <memory>
 #include <unordered_set>
-class SuperTouchHandler {
+class SuperTouchHandler : public std::enable_shared_from_this<SuperTouchHandler> {
 public:
     SuperTouchHandler() {}
     ~SuperTouchHandler();
@@ -28,6 +29,7 @@ public:
     void SetNativeTouchConsumer(const std::shared_ptr<IKRRenderViewExport> &native_touch_consumer);
     void ClearNativeTouchConsumer(const std::shared_ptr<IKRRenderViewExport> &native_touch_consumer);
     void CollectGestureRecognizer(ArkUI_GestureRecognizer *recognizer);
+    void EraseGestureRecognizer(ArkUI_GestureRecognizer *recognizer);
     bool IsCanceled();
     bool ProcessCancel();
     void ResetCancel();

--- a/core-render-ohos/src/test/cpp/.gitignore
+++ b/core-render-ohos/src/test/cpp/.gitignore
@@ -1,0 +1,2 @@
+# Host leftover C++ test build artifacts
+build/

--- a/core-render-ohos/src/test/cpp/run_super_touch_dispose_test.sh
+++ b/core-render-ohos/src/test/cpp/run_super_touch_dispose_test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Compile + run leftover SuperTouchHandler dispose-notify host tests
+# (no Harmony device).
+#
+# Usage:
+#   ./run_super_touch_dispose_test.sh
+#   ./run_super_touch_dispose_test.sh asan
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUT_DIR="$SCRIPT_DIR/build"
+mkdir -p "$OUT_DIR"
+
+CXX="${CXX:-g++}"
+MODE="${1:-default}"
+
+COMMON_FLAGS=(-std=c++17 -Wall -Wextra -Werror -I"$SCRIPT_DIR")
+SRCS=("$SCRIPT_DIR/super_touch_dispose_test.cpp")
+
+case "$MODE" in
+    default)
+        BIN="$OUT_DIR/super_touch_dispose_test"
+        echo ">>> [$CXX] compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O2 "${SRCS[@]}" -o "$BIN"
+        ;;
+    asan)
+        BIN="$OUT_DIR/super_touch_dispose_test_asan"
+        echo ">>> [$CXX] ASan/UBSan compile $BIN"
+        "$CXX" "${COMMON_FLAGS[@]}" -O1 -g -fno-omit-frame-pointer \
+            -fsanitize=address,undefined "${SRCS[@]}" -o "$BIN"
+        ;;
+    *)
+        echo "unknown mode: $MODE (default|asan)"
+        exit 2
+        ;;
+esac
+
+echo ">>> run $BIN"
+"$BIN"

--- a/core-render-ohos/src/test/cpp/super_touch_dispose_host.h
+++ b/core-render-ohos/src/test/cpp/super_touch_dispose_host.h
@@ -1,0 +1,85 @@
+#ifndef CORE_RENDER_OHOS_TEST_SUPER_TOUCH_DISPOSE_HOST_H
+#define CORE_RENDER_OHOS_TEST_SUPER_TOUCH_DISPOSE_HOST_H
+
+#include <functional>
+#include <memory>
+#include <unordered_set>
+
+// Extracted leftover SuperTouchHandler Collect / dispose-notify / dtor.
+//
+// Leftover:
+//   Collect inserts GetRecognizer with no null check.
+//   Dispose notify stores raw this and erases into the set.
+//   dtor / PreventTouch then call SetGestureRecognizerEnabled on nullptr
+//   or a dead SuperTouchHandler after last shared_ptr drop.
+//
+// Production (no ArkUI / Harmony in this helper):
+//   Collect(nullptr) is a no-op
+//   dispose notify captures weak_from_this; lock before erase; return if expired
+//   PreventTouch / dtor skip null recognizers
+//   dtor snapshots the set, installs empty notify, then enable+clear
+//
+// Header-only so host leftover tests compile without ArkUI / Harmony.
+
+struct SuperTouchHostHandler : std::enable_shared_from_this<SuperTouchHostHandler> {
+    std::unordered_set<void *> gesture_recognizers_;
+    bool prevent_touch_ = false;
+    bool *dtor_ran = nullptr;
+    int enable_calls = 0;
+    int empty_notify_installs = 0;
+    int dispose_erases = 0;
+
+    ~SuperTouchHostHandler() {
+        auto snapshot = gesture_recognizers_;
+        for (auto recognizer : snapshot) {
+            if (recognizer == nullptr) {
+                continue;
+            }
+            ++empty_notify_installs;
+            ++enable_calls;
+        }
+        gesture_recognizers_.clear();
+        if (dtor_ran != nullptr) {
+            *dtor_ran = true;
+        }
+    }
+
+    void Collect(void *recognizer) {
+        if (recognizer == nullptr) {
+            return;
+        }
+        if (gesture_recognizers_.find(recognizer) != gesture_recognizers_.end()) {
+            return;
+        }
+        gesture_recognizers_.insert(recognizer);
+    }
+
+    std::function<void(void *)> DisposeNotify() {
+        auto weak_self = std::weak_ptr<SuperTouchHostHandler>(shared_from_this());
+        return [weak_self](void *recognizer) {
+            auto self = weak_self.lock();
+            if (!self) {
+                return;
+            }
+            self->gesture_recognizers_.erase(recognizer);
+            ++self->dispose_erases;
+        };
+    }
+
+    void PreventTouch(bool prevent) {
+        if (prevent_touch_ == prevent) {
+            return;
+        }
+        prevent_touch_ = prevent;
+        for (auto recognizer : gesture_recognizers_) {
+            if (recognizer == nullptr) {
+                continue;
+            }
+            ++enable_calls;
+        }
+    }
+
+    void InsertRawForSkipTest(void *recognizer) { gesture_recognizers_.insert(recognizer); }
+};
+
+#endif  // CORE_RENDER_OHOS_TEST_SUPER_TOUCH_DISPOSE_HOST_H

--- a/core-render-ohos/src/test/cpp/super_touch_dispose_test.cpp
+++ b/core-render-ohos/src/test/cpp/super_touch_dispose_test.cpp
@@ -1,0 +1,80 @@
+// Host unit test for leftover SuperTouchHandler dispose-notify raw this + null.
+//
+// Build + run (from this directory, no Harmony device):
+//   ./run_super_touch_dispose_test.sh
+//   ./run_super_touch_dispose_test.sh asan
+
+#include "super_touch_dispose_host.h"
+
+#include <cstdio>
+#include <memory>
+
+static int g_failed = 0;
+
+static void expect_true(const char *name, bool ok) {
+    if (!ok) {
+        std::fprintf(stderr, "FAIL %s\n", name);
+        ++g_failed;
+    } else {
+        std::printf("PASS %s\n", name);
+    }
+}
+
+int main() {
+    {
+        auto handler = std::make_shared<SuperTouchHostHandler>();
+        handler->Collect(nullptr);
+        expect_true("Collect(nullptr) is no-op", handler->gesture_recognizers_.empty());
+    }
+
+    {
+        bool dtor_ran = false;
+        std::function<void(void *)> dispose;
+        int dummy = 1;
+        {
+            auto handler = std::make_shared<SuperTouchHostHandler>();
+            handler->dtor_ran = &dtor_ran;
+            handler->Collect(&dummy);
+            dispose = handler->DisposeNotify();
+            handler.reset();
+        }
+        expect_true("last shared_ptr dropped before dispose", dtor_ran);
+        dispose(&dummy);
+        expect_true("dispose after drop does not touch freed this", true);
+    }
+
+    {
+        auto handler = std::make_shared<SuperTouchHostHandler>();
+        int dummy = 2;
+        handler->Collect(&dummy);
+        auto dispose = handler->DisposeNotify();
+        dispose(&dummy);
+        expect_true("live dispose erases recognizer", handler->gesture_recognizers_.empty());
+        expect_true("live dispose counted erase", handler->dispose_erases == 1);
+    }
+
+    {
+        auto handler = std::make_shared<SuperTouchHostHandler>();
+        handler->InsertRawForSkipTest(nullptr);
+        handler->PreventTouch(true);
+        expect_true("PreventTouch skips null recognizer", handler->enable_calls == 0);
+    }
+
+    {
+        bool dtor_ran = false;
+        {
+            auto handler = std::make_shared<SuperTouchHostHandler>();
+            handler->dtor_ran = &dtor_ran;
+            handler->InsertRawForSkipTest(nullptr);
+            handler.reset();
+        }
+        expect_true("dtor skips null recognizer", dtor_ran);
+    }
+
+    if (g_failed != 0) {
+        std::fprintf(stderr, "%d test(s) failed\n", g_failed);
+        return 1;
+    }
+    std::printf("all leftover super touch dispose tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- `CollectGestureRecognizer` inserted `GetRecognizer` with no null check and stored raw `this` on the dispose notify. After last `shared_ptr` drop, dispose wrote into a freed handler; `PreventTouch` / dtor called `SetGestureRecognizerEnabled` on nullptr.
- Collect rejects nullptr. Dispose notify uses `KRWeakObjectManager` + `enable_shared_from_this`; lock before erase, return if expired.
- `PreventTouch` / dtor skip null. Dtor snapshots the set, installs an empty dispose notify, then enable+clear.
- Optional `EraseGestureRecognizer` for later detach (unused here). `KRView` / `KRScrollerView` unchanged.

## Test plan
- [x] Host leftover test (no Harmony): `core-render-ohos/src/test/cpp/run_super_touch_dispose_test.sh` default + asan
- [x] Collect(nullptr) is a no-op
- [x] Dispose after last shared_ptr drop does not touch freed this
- [x] PreventTouch / dtor skip null

Signed-off-by: Tony Coder <407243179@qq.com>