### PR TITLE
fix(ohos): 修复双击手势 250ms 延迟任务访问悬空对象导致的崩溃

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/events/KRBaseEventHandler.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/events/KRBaseEventHandler.cpp
@@ -172,7 +172,7 @@ bool KRBaseEventHandler::FireOnLongPressCallback(const std::shared_ptr<KRGesture
     if (!long_press_callback_) {
         return false;
     }
-    std::string state = kuikly::util::GetArkUIGestureActionState(gesture_event_data->gesture_event_);
+    std::string state = gesture_event_data->GetActionState();
     if ((is_long_press_happening && state == kStartState) || (!is_long_press_happening && state == kEndState)) {
         return false;
     }
@@ -182,8 +182,8 @@ bool KRBaseEventHandler::FireOnLongPressCallback(const std::shared_ptr<KRGesture
     params[kParamKeyY] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_point_.y));
     params[kParamKeyPageX] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_window_point_.x));
     params[kParamKeyPageY] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_window_point_.y));
-    params[kParamKeyState] = NewKRRenderValue(kuikly::util::GetArkUIGestureActionState(gesture_event_data->gesture_event_));
-    params[kParamKeyIsCancel] = NewKRRenderValue(kuikly::util::GetArkUIGestureActionType(gesture_event_data->gesture_event_) == GESTURE_EVENT_ACTION_CANCEL);
+    params[kParamKeyState] = NewKRRenderValue(gesture_event_data->GetActionState());
+    params[kParamKeyIsCancel] = NewKRRenderValue(gesture_event_data->GetActionType() == GESTURE_EVENT_ACTION_CANCEL);
     long_press_callback_(NewKRRenderValue(params));
     return true;
 }
@@ -205,7 +205,7 @@ bool KRBaseEventHandler::FireOnPanCallback(const std::shared_ptr<KRGestureEventD
     params[kParamKeyY] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_point_.y));
     params[kParamKeyPageX] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_window_point_.x));
     params[kParamKeyPageY] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_window_point_.y));
-    params[kParamKeyState] = NewKRRenderValue(kuikly::util::GetArkUIGestureActionState(gesture_event_data->gesture_event_));
+    params[kParamKeyState] = NewKRRenderValue(gesture_event_data->GetActionState());
     pan_event_callback_(NewKRRenderValue(params));
     return true;
 }
@@ -227,8 +227,8 @@ bool KRBaseEventHandler::FireOnPinchCallback(const std::shared_ptr<KRGestureEven
     params[kParamKeyY] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_point_.y));
     params[kParamKeyPageX] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_window_point_.x));
     params[kParamKeyPageY] = NewKRRenderValue(kr_config_->Px2Vp(gesture_event_data->gesture_event_window_point_.y));
-    params[kParamKeyScale] = NewKRRenderValue(kuikly::util::GetArkUIGesturePinchScale(gesture_event_data->gesture_event_));
-    params[kParamKeyState] = NewKRRenderValue(kuikly::util::GetArkUIGestureActionState(gesture_event_data->gesture_event_));
+    params[kParamKeyScale] = NewKRRenderValue(gesture_event_data->GetScale());
+    params[kParamKeyState] = NewKRRenderValue(gesture_event_data->GetActionState());
     pinch_event_callback_(NewKRRenderValue(params));
     return true;
 }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/events/gesture/KRGestueEventType.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/events/gesture/KRGestueEventType.h
@@ -19,6 +19,7 @@
 #include <arkui/native_gesture.h>
 #include <arkui/native_type.h>
 #include <functional>
+#include <string>
 #include "libohos_render/foundation/KRPoint.h"
 #include "libohos_render/utils/KREventUtil.h"
 
@@ -33,15 +34,39 @@ enum class KRGestureEventType {
 
 struct KRGestureEventData {
  public:
-    explicit KRGestureEventData(ArkUI_GestureEvent *event) : gesture_event_(event) {
-        gesture_event_point_ = kuikly::util::GetArkUIGestureEventPoint(event);
-        gesture_event_window_point_ = kuikly::util::GetArkUIGestureEventWindowPoint(event);
+    explicit KRGestureEventData(ArkUI_GestureEvent *event) {
+        if (event) {
+            // 在手势回调当帧把所有需要的字段深拷贝出来，之后不再依赖
+            // event 指针。ArkUI 的 ArkUI_GestureEvent 由系统管理，回调返回后
+            // 即可能被回收/复用，跨生命周期持有裸指针会在延迟任务中踩野指针。
+            gesture_event_point_ = kuikly::util::GetArkUIGestureEventPoint(event);
+            gesture_event_window_point_ = kuikly::util::GetArkUIGestureEventWindowPoint(event);
+            action_type_ = kuikly::util::GetArkUIGestureActionType(event);
+            scale_ = kuikly::util::GetArkUIGesturePinchScale(event);
+        }
+    }
+
+    // 以下访问器均读构造时深拷贝的字段，不触碰任何悬空指针。
+    ArkUI_GestureEventActionType GetActionType() const { return action_type_; }
+
+    float GetScale() const { return scale_; }
+
+    std::string GetActionState() const {
+        if (action_type_ == GESTURE_EVENT_ACTION_ACCEPT) {
+            return "start";
+        } else if (action_type_ == GESTURE_EVENT_ACTION_UPDATE) {
+            return "move";
+        }
+        return "end";
     }
 
  public:
     KRPoint gesture_event_point_;
     KRPoint gesture_event_window_point_;
-    ArkUI_GestureEvent *gesture_event_;
+    ArkUI_GestureEventActionType action_type_ = GESTURE_EVENT_ACTION_CANCEL;
+    float scale_ = 1.0f;
+    // 原始事件指针仅保留作兼容；不得在回调返回后（尤其是延迟任务中）解引用。
+    ArkUI_GestureEvent *gesture_event_ = nullptr;
 };
 
 using KRGestureEventCallback = std::function<void(const ArkUI_NodeHandle node_handle,

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/events/gesture/KRGestueEventType.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/events/gesture/KRGestueEventType.h
@@ -65,8 +65,6 @@ struct KRGestureEventData {
     KRPoint gesture_event_window_point_;
     ArkUI_GestureEventActionType action_type_ = GESTURE_EVENT_ACTION_CANCEL;
     float scale_ = 1.0f;
-    // 原始事件指针仅保留作兼容；不得在回调返回后（尤其是延迟任务中）解引用。
-    ArkUI_GestureEvent *gesture_event_ = nullptr;
 };
 
 using KRGestureEventCallback = std::function<void(const ArkUI_NodeHandle node_handle,

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/events/gesture/KRGestureEventHandler.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/events/gesture/KRGestureEventHandler.cpp
@@ -173,7 +173,10 @@ void KRTapGestureEventHandler::OnGestureEvent(ArkUI_GestureEvent *event) {
                 auto weak_self = weak_from_this();
                 KRMainThread::RunOnMainThread(
                     [weak_self] {
-                        auto self = weak_self.lock();
+                        // weak_from_this() 返回基类 weak_ptr，需 downcast 到派生类才能访问
+                        // current_tap_count_ / tap_event_data_ / Reset() 及 protected 成员 node_ / gesture_callback_；
+                        // 此处 lambda 位于 KRTapGestureEventHandler 成员函数作用域内，对派生类对象拥有访问权限。
+                        auto self = std::dynamic_pointer_cast<KRTapGestureEventHandler>(weak_self.lock());
                         if (!self) {
                             return;
                         }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/events/gesture/KRGestureEventHandler.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/events/gesture/KRGestureEventHandler.cpp
@@ -163,16 +163,24 @@ void KRTapGestureEventHandler::OnGestureEvent(ArkUI_GestureEvent *event) {
     auto action_type = kuikly::util::GetArkUIGestureActionType(event);
     if (register_double_tap_event_) {
         if (action_type == GESTURE_EVENT_ACTION_ACCEPT) {
+            // 当帧深拷贝事件数据，之后不再依赖悬空的 ArkUI_GestureEvent*。
             tap_event_data_ = std::make_shared<KRGestureEventData>(event);
             current_tap_count_++;
             if (current_tap_count_ == 1) {
                 last_tap_down_time_stamp_ = CurrentTimeStamp();
+                // 用 weak_from_this 取代裸 this 捕获：250ms 延迟任务可能在 view 卸载、
+                // handler 已销毁后才执行，弱引用 lock 失败即直接丢弃，避免访问悬空 this。
+                auto weak_self = weak_from_this();
                 KRMainThread::RunOnMainThread(
-                    [this, event] {
-                        if (current_tap_count_ == 1) {
-                            gesture_callback_(node_, tap_event_data_, KRGestureEventType::kClick);
+                    [weak_self] {
+                        auto self = weak_self.lock();
+                        if (!self) {
+                            return;
                         }
-                        Reset();
+                        if (self->current_tap_count_ == 1) {
+                            self->gesture_callback_(self->node_, self->tap_event_data_, KRGestureEventType::kClick);
+                        }
+                        self->Reset();
                     },
                     250);
             } else if (current_tap_count_ == 2) {

--- a/core-render-ohos/src/main/cpp/libohos_render/export/IKRRenderViewExport.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/export/IKRRenderViewExport.h
@@ -280,7 +280,7 @@ class IKRRenderViewExport : public std::enable_shared_from_this<IKRRenderViewExp
 
         base_event_handler_->OnGestureEvent(gesture_event_data, event_type);
         if (base_event_handler_->HasCaptureRule()) {
-            auto action_type = kuikly::util::GetArkUIGestureActionType(gesture_event_data->gesture_event_);
+            auto action_type = gesture_event_data->GetActionType();
             handling_capture_event_ =
                 action_type == GESTURE_EVENT_ACTION_ACCEPT || action_type == GESTURE_EVENT_ACTION_UPDATE;
         }


### PR DESCRIPTION
## 原因 (Root Cause)
在 core-render-ohos 手势处理中，存在两处悬空指针（use-after-free）隐患， 崩溃栈来自 KRTapGestureEventHandler::OnGestureEvent 的 250ms 延迟 lambda：

1. 延迟任务裸捕获 this KRTapGestureEventHandler::OnGestureEvent 双击分支用 `KRMainThread::RunOnMainThread([this, event]{...}, 250)` 投递一个 250ms 延迟任务，闭包直接捕获了 `this`（KRTapGestureEventHandler）与 `event`。 当该 250ms 窗口内 view 被卸载 / 节点回收，`KRGestureGroupHandler` 析构会 将 gesture_event_handlers_ 清空，handler 引用计数归零被销毁；但已排队的 延迟任务没有任何取消机制，到点仍会在主线程执行并访问已释放的 this （current_tap_count_ / node_ / tap_event_data_ / Reset()），触发 UAF。 栈顶 #00 的 std::function::__value_func::operator() 即目标对象内存已被回收。

2. KRGestureEventData 持有悬空的 ArkUI_GestureEvent* KRGestureEventData 仅以 `gesture_event_(event)` 保存原始事件裸指针，不拷贝。 ArkUI 的 ArkUI_GestureEvent 由系统管理，手势回调返回后即可能被回收/复用。 下游客体 KRBaseEventHandler::FireOnLongPress/Pan/PinchCallback 直接 `GetArkUIGestureActionState/Type/PinchScale(gesture_event_data->gesture_event_)` 解引用该裸指针，延迟场景下同样踩野指针。

## 修复方案 (Fix)
1. 延迟任务改用弱引用：250ms lambda 以 weak_from_this() 捕获，执行时 lock() 失败（对象已销毁）直接 return，不再访问悬空 this。同时移除未使用的 `[event]` 裸捕获。基类 KRGestureEventHandler 已是 enable_shared_from_this。
2. KRGestureEventData 在构造当帧深拷贝所需字段（action_type / scale / point / window_point），新增 GetActionType()/GetScale()/GetActionState() 访问器， 全程只读深拷贝值，原始 gesture_event_ 指针仅保留作兼容、不再被解引用。
3. 下游消费者（KRBaseEventHandler 各 FireOn*Callback、IKRRenderViewExport ::ToOnGestureEvent）改为调用 KRGestureEventData 的深拷贝访问器，彻底消除 对悬空 ArkUI_GestureEvent* 的访问。

涉及版本基线：2.19.2-beta-map1