### PR TITLE
fix(ohos): close unpaired napi handle scopes to stop ArkTS view leaks

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/forward/KRForwardArkTSView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/forward/KRForwardArkTSView.cpp
@@ -15,6 +15,7 @@
 
 #include "libohos_render/expand/components/forward/KRForwardArkTSView.h"
 #include "libohos_render/manager/KRArkTSManager.h"
+#include "libohos_render/utils/KRNapiHandleScope.h"
 
 void KRForwardArkTSView::DidInit() {
     KRArkTSManager::GetInstance().CallArkTSMethod(
@@ -93,9 +94,8 @@ void KRForwardArkTSView::DidMoveToParentView() {
         if (!uiContext) {
             return;
         }
-        napi_handle_scope scope;
         napi_env g_env = KRArkTSManager::GetInstance().GetEnv();
-        napi_open_handle_scope(g_env, &scope);
+        KRNapiHandleScope handle_scope(g_env);
         ArkUI_NodeHandle node = nullptr;
         KRArkTSManager::GetInstance().CallArkTSMethod(GetInstanceId(), KRNativeCallArkTSMethod::CreateArkUINode,
                                                       KRRenderValue::Make(GetViewTag()),

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/forward/KRForwardArkTSViewV2.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/forward/KRForwardArkTSViewV2.cpp
@@ -16,6 +16,7 @@
 #include "libohos_render/expand/components/forward/KRForwardArkTSViewV2.h"
 
 #include "libohos_render/manager/KRArkTSManager.h"
+#include "libohos_render/utils/KRNapiHandleScope.h"
 
 std::shared_ptr<KRBaseEventHandler>  KRForwardArkTSViewV2::CreateBaseEventHandler(std::shared_ptr<IKRRenderView> rootView) {
     if(rootView){
@@ -115,9 +116,8 @@ ArkUI_NodeHandle KRForwardArkTSViewV2::CreateNode(){
         this->GetInstanceId(), KRNativeCallArkTSMethod::CreateView, KRRenderValue::Make(this->GetViewTag()),
         KRRenderValue::Make(this->GetViewName()), nullptr, nullptr, nullptr, nullptr);
 
-        napi_handle_scope scope;
         napi_env g_env = KRArkTSManager::GetInstance().GetEnv();
-        napi_open_handle_scope(g_env, &scope);
+        KRNapiHandleScope handle_scope(g_env);
         ArkUI_NodeHandle node = nullptr;
         
         KRArkTSManager::GetInstance().CallArkTSMethod(this->GetInstanceId(), KRNativeCallArkTSMethod::CreateArkUINode,

--- a/core-render-ohos/src/main/cpp/libohos_render/utils/KRNapiHandleScope.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/utils/KRNapiHandleScope.h
@@ -1,0 +1,46 @@
+/*
+ * Tencent is pleased to support the open source community by making KuiklyUI
+ * available.
+ * Copyright (C) 2026 Tencent. All rights reserved.
+ * Licensed under the License of KuiklyUI;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://github.com/Tencent-TDS/KuiklyUI/blob/main/LICENSE
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CORE_RENDER_OHOS_KRNAPIHANDLESCOPE_H
+#define CORE_RENDER_OHOS_KRNAPIHANDLESCOPE_H
+
+#include "napi/native_api.h"
+
+// RAII wrapper so napi_open_handle_scope is always paired with
+// napi_close_handle_scope, including early-return paths.
+class KRNapiHandleScope {
+ public:
+    explicit KRNapiHandleScope(napi_env env) : env_(env), scope_(nullptr), opened_(false) {
+        if (env_ != nullptr && napi_open_handle_scope(env_, &scope_) == napi_ok && scope_ != nullptr) {
+            opened_ = true;
+        }
+    }
+
+    KRNapiHandleScope(const KRNapiHandleScope &) = delete;
+    KRNapiHandleScope &operator=(const KRNapiHandleScope &) = delete;
+
+    ~KRNapiHandleScope() {
+        if (opened_ && env_ != nullptr && scope_ != nullptr) {
+            napi_close_handle_scope(env_, scope_);
+        }
+    }
+
+ private:
+    napi_env env_;
+    napi_handle_scope scope_;
+    bool opened_;
+};
+
+#endif  // CORE_RENDER_OHOS_KRNAPIHANDLESCOPE_H

--- a/ohosApp/entry/src/ohosTest/ets/test/ForwardArkTSView.test.ets
+++ b/ohosApp/entry/src/ohosTest/ets/test/ForwardArkTSView.test.ets
@@ -1,0 +1,96 @@
+import { describe, beforeAll, it, expect } from '@ohos/hypium';
+import { abilityDelegatorRegistry } from '@kit.TestKit';
+import { Want } from '@kit.AbilityKit';
+import { hilog } from '@kit.PerformanceAnalysisKit';
+import { Driver, ON, Component } from '@ohos.UiTest';
+
+const TAG = 'ForwardArkTSViewTest';
+const PAGE_NAME = 'CustomViewExamplePage';
+const ROUTER_TITLE = 'Kuikly页面路由';
+const CUSTOM_TITLE = 'CustomViewExamplePage';
+const TAP_ME = 'Tap Me';
+const MY_VIEW_TEXT = 'hello this is My view';
+const KUIKLY_CHILD_TEXT = 'Static text element from kuikly';
+const JUMP_TEXTS = ['跳转', '跳转2'];
+const LOOP_COUNT = 5;
+
+async function waitForText(driver: Driver, text: string, timeoutMs: number = 12000): Promise<Component> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const component = await driver.findComponent(ON.text(text));
+    if (component) {
+      return component;
+    }
+    await driver.delayMs(400);
+  }
+  throw new Error(`timeout waiting for text: ${text}`);
+}
+
+async function clickFirstAvailable(driver: Driver, texts: string[]): Promise<void> {
+  for (const text of texts) {
+    const component = await driver.findComponent(ON.text(text));
+    if (component) {
+      await component.click();
+      return;
+    }
+  }
+  throw new Error(`none of texts found: ${texts.join(',')}`);
+}
+
+async function openCustomViewPage(driver: Driver): Promise<void> {
+  await waitForText(driver, ROUTER_TITLE, 15000);
+  const inputs = await driver.findComponents(ON.type('TextInput'));
+  expect(inputs.length > 0).assertTrue();
+  await inputs[0].inputText(PAGE_NAME);
+  await driver.delayMs(400);
+  await clickFirstAvailable(driver, JUMP_TEXTS);
+  await waitForText(driver, CUSTOM_TITLE, 15000);
+}
+
+export default function forwardArkTSViewTest() {
+  describe('ForwardArkTSViewHandleScopeTest', () => {
+    beforeAll(async () => {
+      const delegator = abilityDelegatorRegistry.getAbilityDelegator();
+      const args = abilityDelegatorRegistry.getArguments();
+      const want: Want = {
+        bundleName: args.bundleName,
+        abilityName: 'EntryAbility',
+        moduleName: 'entry'
+      };
+      hilog.info(0x0000, TAG, 'start EntryAbility for %{public}s', args.bundleName);
+      await delegator.startAbility(want);
+      const driver = Driver.create();
+      await driver.delayMs(2500);
+    })
+
+    it('create_destroy_forward_arkts_view_loop', 0, async (done: Function) => {
+      const driver = Driver.create();
+      try {
+        for (let i = 0; i < LOOP_COUNT; i++) {
+          hilog.info(0x0000, TAG, 'loop %{public}d open CustomViewExamplePage', i);
+          await openCustomViewPage(driver);
+
+          const myView = await waitForText(driver, MY_VIEW_TEXT);
+          expect(myView !== undefined).assertTrue();
+          const kuiklyChild = await waitForText(driver, KUIKLY_CHILD_TEXT);
+          expect(kuiklyChild !== undefined).assertTrue();
+          const tapMe = await waitForText(driver, TAP_ME);
+          await tapMe.click();
+          await driver.delayMs(500);
+          const updated = await waitForText(driver, '1');
+          expect(updated !== undefined).assertTrue();
+
+          await driver.pressBack();
+          await waitForText(driver, ROUTER_TITLE, 12000);
+        }
+        hilog.info(0x0000, TAG, 'PASS create/destroy %{public}d times', LOOP_COUNT);
+        done();
+      } catch (e) {
+        const message = (e as Error).message ?? String(e);
+        hilog.error(0x0000, TAG, 'FAIL %{public}s', message);
+        expect(message).assertEqual('');
+        done();
+      }
+    })
+  })
+}

--- a/ohosApp/entry/src/ohosTest/ets/test/List.test.ets
+++ b/ohosApp/entry/src/ohosTest/ets/test/List.test.ets
@@ -1,5 +1,7 @@
 import abilityTest from './Ability.test';
+import forwardArkTSViewTest from './ForwardArkTSView.test';
 
 export default function testsuite() {
   abilityTest();
+  forwardArkTSViewTest();
 }


### PR DESCRIPTION
ForwardArkTSView opened a handle scope without closing it, including on early returns. Use RAII so every exit path closes the scope. Fixes #1682