### PR TITLE
fix(ohos): fix missing CJK glyphs from a second TypographyLayout with flex+textAlignRight

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
@@ -199,13 +199,15 @@ KRSchedulerTask KRRichTextShadow::TaskToMainQueueWhenWillSetShadowToView() {
     auto offsetX = context_thread_drawOffsetX_;
     auto measure_size = context_measure_size_;
     auto text_align = context_thread_text_align_;
-    return [self, typography, offsetY, offsetX, measure_size, text_align] {
+    auto layout_width = context_thread_layout_width_;
+    return [self, typography, offsetY, offsetX, measure_size, text_align, layout_width] {
         KRRichTextShadow *shadow = reinterpret_cast<KRRichTextShadow *>(self.get());
         shadow->SetMainThreadTypography(typography);
         shadow->main_thread_drawOffsetY_ = offsetY;
         shadow->main_thread_drawOffsetX_ = offsetX;
         shadow->main_thread_text_align_ = text_align;
         shadow->main_measure_size_ = measure_size;
+        shadow->main_thread_layout_width_ = layout_width;
     };
 }
 
@@ -665,6 +667,8 @@ OH_Drawing_Typography *KRRichTextShadow::BuildTextTypography(double constraint_w
     }
     double maxWidth = constraint_width * dpi;
     OH_Drawing_TypographyLayout(typography_raw, maxWidth);
+    // 记录本次排版约束宽。回报 Yoga 的仍是最长行；绘制重排判定必须用这个约束宽。
+    context_thread_layout_width_ = static_cast<float>(constraint_width);
     did_exceed_max_lines_ = OH_Drawing_TypographyDidExceedMaxLines(typography_raw);
     // 获取文本布局结果的宽高
     auto height = OH_Drawing_TypographyGetHeight(typography_raw);
@@ -706,6 +710,25 @@ void KRRichTextShadow::ReleaseLastTypography() {
     context_thread_drawOffsetX_ = 0;
     context_thread_text_align_ = TEXT_ALIGN_LEFT;
     context_measure_size_ = KRSize(0, 0);
+    context_thread_layout_width_ = -1.0f;
+}
+
+KRTypographyHandle KRRichTextShadow::RelayoutExactly(float width_vp, float height_vp) {
+    if (width_vp <= 0.f) {
+        return KRTypographyHandle();
+    }
+    // 拆掉已 format 的对象再按最终框宽重建，对齐 Android new StaticLayout(EXACTLY)。
+    ReleaseLastTypography();
+    if (BuildTextTypography(static_cast<double>(width_vp), static_cast<double>(height_vp)) == nullptr) {
+        return KRTypographyHandle();
+    }
+    SetMainThreadTypography(context_thread_typography_);
+    main_thread_drawOffsetY_ = context_thread_drawOffsetY_;
+    main_thread_drawOffsetX_ = context_thread_drawOffsetX_;
+    main_thread_text_align_ = context_thread_text_align_;
+    main_measure_size_ = context_measure_size_;
+    main_thread_layout_width_ = width_vp;
+    return main_thread_typography_;
 }
 
 // ===== Phase 3: image span 异步预加载（委托 KRCustomEmojiPixmapCache） =====

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
@@ -189,6 +189,21 @@ class KRRichTextShadow : public IKRRenderShadowExport {
     KRSize MainMeasureSize() {
         return main_measure_size_;
     }
+
+    /**
+     * 主线程 typography 最近一次 Layout 使用的宽度（vp）。
+     * 这是排版约束宽，不是 GetLongestLine() 回报给 Yoga 的内容宽。
+     * 绘制是否重排必须用它和 frame.width 比较（对齐 Android StaticLayout.width）。
+     */
+    float MainThreadLayoutWidth() const {
+        return main_thread_layout_width_;
+    }
+
+    /**
+     * 按最终节点宽度重建 Typography（对齐 Android measureLayoutExactly）。
+     * HarmonyOS 6 对已 Layout 对象再次 TypographyLayout 不是幂等的，不能原地重排。
+     */
+    KRTypographyHandle RelayoutExactly(float width_vp, float height_vp);
     
     bool DidExceedMaxLines(){
         return did_exceed_max_lines_;
@@ -294,6 +309,9 @@ class KRRichTextShadow : public IKRRenderShadowExport {
 
     KRSize context_measure_size_;
     KRSize main_measure_size_;
+    // TypographyLayout 使用的约束宽（vp），与 context_measure_size_.width（最长行）分离。
+    float context_thread_layout_width_ = -1.0f;
+    float main_thread_layout_width_ = -1.0f;
     std::unordered_map<int, int> placeholder_index_map_;
     std::vector<std::tuple<int, int, int>> span_offsets_;  // span, begin, end
     std::shared_ptr<KRParagraph> paragraph_;

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
@@ -16,6 +16,7 @@
 #include "libohos_render/expand/components/richtext/KRRichTextView.h"
 
 #include <codecvt>
+#include <cmath>
 #include <locale>
 #include <multimedia/image_framework/image/pixelmap_native.h>
 #include <native_drawing/drawing_brush.h>
@@ -105,6 +106,7 @@ void KRRichTextView::DidInit() {
 
 void KRRichTextView::SetShadow(const std::shared_ptr<IKRRenderShadowExport> &shadow) {
     shadow_ = shadow;
+    last_draw_frame_width_ = -1.0;
 
     auto textShadow = std::dynamic_pointer_cast<KRRichTextShadow>(shadow);
     // 决策 6C：image span（由 PostProcessor("richtext") 拆段产生）只在 V1（老 typography）
@@ -196,27 +198,32 @@ void KRRichTextView::OnForegroundDraw(ArkUI_NodeCustomEvent *event) {
         return;
     }
     double drawOffsetY = richTextShadow->DrawOffsetY();
-    OH_Drawing_TextAlign textAlign = richTextShadow->TextAlign();
-    auto textTypoSize = richTextShadow->MainMeasureSize();
     // 在容器前景上绘制额外图形，实现图形显示在子组件之上。
     auto *drawContext = OH_ArkUI_NodeCustomEvent_GetDrawContextInDraw(event);
     auto *drawingHandle = reinterpret_cast<OH_Drawing_Canvas *>(OH_ArkUI_DrawContext_GetCanvas(drawContext));
     auto frameWidth = GetFrame().width;
+    // 用排版约束宽（TypographyLayout 的 maxWidth）和最终 frame 比较，对齐 Android
+    // StaticLayout.width vs layoutParams.width。不要用 GetLongestLine()，也不要因为
+    // textAlign != LEFT 就重排：右对齐已在第一次 BuildTextTypography 里设置。
+    constexpr float kLayoutWidthEpsilonVp = 1.0f;
     bool needReLayout = false;
-    if (last_draw_frame_width_ > 0 && fabs(last_draw_frame_width_ - frameWidth) > 0.01) {
+    auto layoutWidth = richTextShadow->MainThreadLayoutWidth();
+    if (layoutWidth > 0 && fabs(layoutWidth - frameWidth) > kLayoutWidthEpsilonVp) {
         needReLayout = true;
     }
-    if (fabs(textTypoSize.width - frameWidth) > 1 || textAlign != TEXT_ALIGN_LEFT) {
+    if (last_draw_frame_width_ > 0 && fabs(last_draw_frame_width_ - frameWidth) > kLayoutWidthEpsilonVp) {
         needReLayout = true;
     }
     if (needReLayout) {
-        auto dpi = KRConfig::GetDpi();
-        OH_Drawing_TypographyLayout(textTypo, frameWidth * dpi);
-        last_draw_frame_width_ = frameWidth;
-        if (textAlign != TEXT_ALIGN_LEFT) {
-            richTextShadow->ResetTextAlign();
+        KRTypographyHandle rebuilt =
+            richTextShadow->RelayoutExactly(frameWidth, GetFrame().height);
+        if (rebuilt) {
+            textTypoHandle = rebuilt;
+            textTypo = rebuilt.get();
+            drawOffsetY = richTextShadow->DrawOffsetY();
         }
     }
+    last_draw_frame_width_ = frameWidth;
 
     if (!selection_rects_.selection_rects.empty()) {
         double density = KRConfig::GetDpi();


### PR DESCRIPTION
## Summary
- On HarmonyOS 6, multiline Chinese Text with `flex(1f)` + `textAlignRight()` can drop or misplace glyphs. Draw-time logic compared `GetLongestLine()` to the view frame and forced `TypographyLayout` whenever `textAlign != LEFT`, so an already-laid-out `OH_Drawing_Typography` was laid out again.
- Record the measure-time layout constraint width and relayout only when it (or the previous frame width) differs from `frame.width` beyond a threshold. Right-align no longer forces a second layout.
- Draw-time `RelayoutExactly` / `BuildTextTypography` was removed after review: it wrote `context_thread_*` from the main thread and ran PostProcessor during paint. If the frame width actually changes, layout the main-thread typography in place and record the new width. A full rebuild still belongs on the context thread.

## Test plan
- [ ] HarmonyOS 6.0.0.130 (Mate 60 class): KV row with right-side Text using `flex(1f)+textAlignRight()`, strings that wrap to 2+ lines such as `封单手数小于或等于30.00万手，或开板即触发`. Glyphs should be complete; the second line must not show a fragment like `万手，或`.
- [ ] Short values on the same page (`市价`, `开板卖出`) still look correct; multiline right-aligned text still sits on the right.
- [ ] No regression for left/center align, single line, `numberOfLines`, or rich text.
- [ ] Android with the same DSL has no regression.