### PR TITLE
 fix(ohos): fix missing CJK glyphs from a second TypographyLayout with flex+textAlignRight 

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
@@ -199,13 +199,15 @@ KRSchedulerTask KRRichTextShadow::TaskToMainQueueWhenWillSetShadowToView() {
     auto offsetX = context_thread_drawOffsetX_;
     auto measure_size = context_measure_size_;
     auto text_align = context_thread_text_align_;
-    return [self, typography, offsetY, offsetX, measure_size, text_align] {
+    auto layout_width = context_thread_layout_width_;
+    return [self, typography, offsetY, offsetX, measure_size, text_align, layout_width] {
         KRRichTextShadow *shadow = reinterpret_cast<KRRichTextShadow *>(self.get());
         shadow->SetMainThreadTypography(typography);
         shadow->main_thread_drawOffsetY_ = offsetY;
         shadow->main_thread_drawOffsetX_ = offsetX;
         shadow->main_thread_text_align_ = text_align;
         shadow->main_measure_size_ = measure_size;
+        shadow->main_thread_layout_width_ = layout_width;
     };
 }
 
@@ -665,6 +667,8 @@ OH_Drawing_Typography *KRRichTextShadow::BuildTextTypography(double constraint_w
     }
     double maxWidth = constraint_width * dpi;
     OH_Drawing_TypographyLayout(typography_raw, maxWidth);
+    // 记录本次排版约束宽。回报 Yoga 的仍是最长行；绘制重排判定必须用这个约束宽。
+    context_thread_layout_width_ = static_cast<float>(constraint_width);
     did_exceed_max_lines_ = OH_Drawing_TypographyDidExceedMaxLines(typography_raw);
     // 获取文本布局结果的宽高
     auto height = OH_Drawing_TypographyGetHeight(typography_raw);
@@ -706,6 +710,25 @@ void KRRichTextShadow::ReleaseLastTypography() {
     context_thread_drawOffsetX_ = 0;
     context_thread_text_align_ = TEXT_ALIGN_LEFT;
     context_measure_size_ = KRSize(0, 0);
+    context_thread_layout_width_ = -1.0f;
+}
+
+KRTypographyHandle KRRichTextShadow::RelayoutExactly(float width_vp, float height_vp) {
+    if (width_vp <= 0.f) {
+        return KRTypographyHandle();
+    }
+    // 拆掉已 format 的对象再按最终框宽重建，对齐 Android new StaticLayout(EXACTLY)。
+    ReleaseLastTypography();
+    if (BuildTextTypography(static_cast<double>(width_vp), static_cast<double>(height_vp)) == nullptr) {
+        return KRTypographyHandle();
+    }
+    SetMainThreadTypography(context_thread_typography_);
+    main_thread_drawOffsetY_ = context_thread_drawOffsetY_;
+    main_thread_drawOffsetX_ = context_thread_drawOffsetX_;
+    main_thread_text_align_ = context_thread_text_align_;
+    main_measure_size_ = context_measure_size_;
+    main_thread_layout_width_ = width_vp;
+    return main_thread_typography_;
 }
 
 // ===== Phase 3: image span 异步预加载（委托 KRCustomEmojiPixmapCache） =====

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
@@ -713,24 +713,6 @@ void KRRichTextShadow::ReleaseLastTypography() {
     context_thread_layout_width_ = -1.0f;
 }
 
-KRTypographyHandle KRRichTextShadow::RelayoutExactly(float width_vp, float height_vp) {
-    if (width_vp <= 0.f) {
-        return KRTypographyHandle();
-    }
-    // 拆掉已 format 的对象再按最终框宽重建，对齐 Android new StaticLayout(EXACTLY)。
-    ReleaseLastTypography();
-    if (BuildTextTypography(static_cast<double>(width_vp), static_cast<double>(height_vp)) == nullptr) {
-        return KRTypographyHandle();
-    }
-    SetMainThreadTypography(context_thread_typography_);
-    main_thread_drawOffsetY_ = context_thread_drawOffsetY_;
-    main_thread_drawOffsetX_ = context_thread_drawOffsetX_;
-    main_thread_text_align_ = context_thread_text_align_;
-    main_measure_size_ = context_measure_size_;
-    main_thread_layout_width_ = width_vp;
-    return main_thread_typography_;
-}
-
 // ===== Phase 3: image span 异步预加载（委托 KRCustomEmojiPixmapCache） =====
 // 在 BuildTextTypography 末尾被调用：遍历 image_draw_records_，对每个 uri 调用
 // KRCustomEmojiPixmapCache::Prefetch。缓存 / 去重 / 后台解码 / 主线程回调都由

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
@@ -199,15 +199,13 @@ KRSchedulerTask KRRichTextShadow::TaskToMainQueueWhenWillSetShadowToView() {
     auto offsetX = context_thread_drawOffsetX_;
     auto measure_size = context_measure_size_;
     auto text_align = context_thread_text_align_;
-    auto layout_width = context_thread_layout_width_;
-    return [self, typography, offsetY, offsetX, measure_size, text_align, layout_width] {
+    return [self, typography, offsetY, offsetX, measure_size, text_align] {
         KRRichTextShadow *shadow = reinterpret_cast<KRRichTextShadow *>(self.get());
         shadow->SetMainThreadTypography(typography);
         shadow->main_thread_drawOffsetY_ = offsetY;
         shadow->main_thread_drawOffsetX_ = offsetX;
         shadow->main_thread_text_align_ = text_align;
         shadow->main_measure_size_ = measure_size;
-        shadow->main_thread_layout_width_ = layout_width;
     };
 }
 
@@ -667,8 +665,6 @@ OH_Drawing_Typography *KRRichTextShadow::BuildTextTypography(double constraint_w
     }
     double maxWidth = constraint_width * dpi;
     OH_Drawing_TypographyLayout(typography_raw, maxWidth);
-    // 记录本次排版约束宽。回报 Yoga 的仍是最长行；绘制重排判定必须用这个约束宽。
-    context_thread_layout_width_ = static_cast<float>(constraint_width);
     did_exceed_max_lines_ = OH_Drawing_TypographyDidExceedMaxLines(typography_raw);
     // 获取文本布局结果的宽高
     auto height = OH_Drawing_TypographyGetHeight(typography_raw);
@@ -710,7 +706,6 @@ void KRRichTextShadow::ReleaseLastTypography() {
     context_thread_drawOffsetX_ = 0;
     context_thread_text_align_ = TEXT_ALIGN_LEFT;
     context_measure_size_ = KRSize(0, 0);
-    context_thread_layout_width_ = -1.0f;
 }
 
 // ===== Phase 3: image span 异步预加载（委托 KRCustomEmojiPixmapCache） =====

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
@@ -28,6 +28,7 @@
 #include <multimedia/image_framework/image/image_source_native.h>
 #include <multimedia/image_framework/image/pixelmap_native.h>
 
+#include <cmath>
 #include <codecvt>
 #include <thread>
 #include <unordered_set>
@@ -110,6 +111,9 @@ KRAnyValue KRRichTextShadow::Call(const std::string &method_name, const std::str
         return SpanRect(NewKRRenderValue(params)->toInt());
     } else if(method_name == "isLineBreakMargin"){
         return NewKRRenderValue(did_exceed_max_lines_ && OH_Drawing_DestroyTextLines? "1" : "0");
+    } else if (method_name == "relayoutToWidth") {
+        RelayoutToWidth(NewKRRenderValue(params)->toFloat());
+        return KRRenderValue::Make(nullptr);
     }
     return KRRenderValue::Make(nullptr);
 }
@@ -121,8 +125,10 @@ KRAnyValue KRRichTextShadow::Call(const std::string &method_name, const std::str
  * @return
  */
 KRSize KRRichTextShadow::CalculateRenderViewSize(double constraint_width, double constraint_height) {
+    context_thread_constraint_height_ = static_cast<float>(constraint_height);
     if(StyledStringEnabled()){
         KRSize sz = CalculateRenderViewSizeWithStyledString(constraint_width, constraint_height);
+        context_thread_layout_width_ = static_cast<float>(constraint_width);
         return sz;
     }else{
         SetParagraph(nullptr);
@@ -130,6 +136,30 @@ KRSize KRRichTextShadow::CalculateRenderViewSize(double constraint_width, double
     ReleaseLastTypography();
     BuildTextTypography(constraint_width, constraint_height);
     return context_measure_size_;
+}
+
+void KRRichTextShadow::RelayoutToWidth(float width_vp) {
+    if (width_vp <= 0) {
+        return;
+    }
+    constexpr float kLayoutWidthEpsilonVp = 1.0f;
+    if (context_thread_layout_width_ > 0 &&
+        std::fabs(width_vp - context_thread_layout_width_) <= kLayoutWidthEpsilonVp) {
+        return;
+    }
+    double constraint_height = context_thread_constraint_height_;
+    if (StyledStringEnabled()) {
+        CalculateRenderViewSizeWithStyledString(width_vp, constraint_height);
+        context_thread_layout_width_ = width_vp;
+        return;
+    }
+    // 左对齐时字形从 x=0 起排，约束宽大于节点宽不会把字画到框外。
+    if (context_thread_text_align_ == TEXT_ALIGN_LEFT) {
+        return;
+    }
+    SetParagraph(nullptr);
+    ReleaseLastTypography();
+    BuildTextTypography(width_vp, constraint_height);
 }
 
 KRSize KRRichTextShadow::CalculateRenderViewSizeWithStyledString(double constraint_width, double constraint_height) {
@@ -665,6 +695,7 @@ OH_Drawing_Typography *KRRichTextShadow::BuildTextTypography(double constraint_w
     }
     double maxWidth = constraint_width * dpi;
     OH_Drawing_TypographyLayout(typography_raw, maxWidth);
+    context_thread_layout_width_ = static_cast<float>(constraint_width);
     did_exceed_max_lines_ = OH_Drawing_TypographyDidExceedMaxLines(typography_raw);
     // 获取文本布局结果的宽高
     auto height = OH_Drawing_TypographyGetHeight(typography_raw);
@@ -706,6 +737,7 @@ void KRRichTextShadow::ReleaseLastTypography() {
     context_thread_drawOffsetX_ = 0;
     context_thread_text_align_ = TEXT_ALIGN_LEFT;
     context_measure_size_ = KRSize(0, 0);
+    context_thread_layout_width_ = -1.0f;
 }
 
 // ===== Phase 3: image span 异步预加载（委托 KRCustomEmojiPixmapCache） =====

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
@@ -199,11 +199,6 @@ class KRRichTextShadow : public IKRRenderShadowExport {
         return main_thread_layout_width_;
     }
 
-    /** 仅主线程：绘制期原地 Layout 后同步已使用的约束宽，避免每帧重复 Layout。 */
-    void SetMainThreadLayoutWidth(float width_vp) {
-        main_thread_layout_width_ = width_vp;
-    }
-
     bool DidExceedMaxLines(){
         return did_exceed_max_lines_;
     }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
@@ -190,15 +190,6 @@ class KRRichTextShadow : public IKRRenderShadowExport {
         return main_measure_size_;
     }
 
-    /**
-     * 主线程 typography 最近一次 Layout 使用的宽度（vp）。
-     * 这是排版约束宽，不是 GetLongestLine() 回报给 Yoga 的内容宽。
-     * 绘制是否重排必须用它和 frame.width 比较（对齐 Android StaticLayout.width）。
-     */
-    float MainThreadLayoutWidth() const {
-        return main_thread_layout_width_;
-    }
-
     bool DidExceedMaxLines(){
         return did_exceed_max_lines_;
     }
@@ -303,9 +294,6 @@ class KRRichTextShadow : public IKRRenderShadowExport {
 
     KRSize context_measure_size_;
     KRSize main_measure_size_;
-    // TypographyLayout 使用的约束宽（vp），与 context_measure_size_.width（最长行）分离。
-    float context_thread_layout_width_ = -1.0f;
-    float main_thread_layout_width_ = -1.0f;
     std::unordered_map<int, int> placeholder_index_map_;
     std::vector<std::tuple<int, int, int>> span_offsets_;  // span, begin, end
     std::shared_ptr<KRParagraph> paragraph_;

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
@@ -189,6 +189,21 @@ class KRRichTextShadow : public IKRRenderShadowExport {
     KRSize MainMeasureSize() {
         return main_measure_size_;
     }
+
+    /**
+     * 主线程 typography 最近一次 Layout 使用的宽度（vp）。
+     * 这是排版约束宽，不是 GetLongestLine() 回报给 Yoga 的内容宽。
+     * 绘制是否重排必须用它和 frame.width 比较（对齐 Android StaticLayout.width）。
+     */
+    float MainThreadLayoutWidth() const {
+        return main_thread_layout_width_;
+    }
+
+    /**
+     * 按最终节点宽度重建 Typography（对齐 Android measureLayoutExactly）。
+     * HarmonyOS 6 对已 Layout 对象再次 TypographyLayout 不是幂等的，不能原地重排。
+     */
+    KRTypographyHandle RelayoutExactly(float width_vp, float height_vp);
     
     bool DidExceedMaxLines(){
         return did_exceed_max_lines_;
@@ -294,6 +309,9 @@ class KRRichTextShadow : public IKRRenderShadowExport {
 
     KRSize context_measure_size_;
     KRSize main_measure_size_;
+    // TypographyLayout 使用的约束宽（vp），与 context_measure_size_.width（最长行）分离。
+    float context_thread_layout_width_ = -1.0f;
+    float main_thread_layout_width_ = -1.0f;
     std::unordered_map<int, int> placeholder_index_map_;
     std::vector<std::tuple<int, int, int>> span_offsets_;  // span, begin, end
     std::shared_ptr<KRParagraph> paragraph_;

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
@@ -189,7 +189,7 @@ class KRRichTextShadow : public IKRRenderShadowExport {
     KRSize MainMeasureSize() {
         return main_measure_size_;
     }
-
+    
     bool DidExceedMaxLines(){
         return did_exceed_max_lines_;
     }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
@@ -199,12 +199,11 @@ class KRRichTextShadow : public IKRRenderShadowExport {
         return main_thread_layout_width_;
     }
 
-    /**
-     * 按最终节点宽度重建 Typography（对齐 Android measureLayoutExactly）。
-     * HarmonyOS 6 对已 Layout 对象再次 TypographyLayout 不是幂等的，不能原地重排。
-     */
-    KRTypographyHandle RelayoutExactly(float width_vp, float height_vp);
-    
+    /** 仅主线程：绘制期原地 Layout 后同步已使用的约束宽，避免每帧重复 Layout。 */
+    void SetMainThreadLayoutWidth(float width_vp) {
+        main_thread_layout_width_ = width_vp;
+    }
+
     bool DidExceedMaxLines(){
         return did_exceed_max_lines_;
     }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
@@ -189,7 +189,7 @@ class KRRichTextShadow : public IKRRenderShadowExport {
     KRSize MainMeasureSize() {
         return main_measure_size_;
     }
-    
+
     bool DidExceedMaxLines(){
         return did_exceed_max_lines_;
     }
@@ -294,6 +294,9 @@ class KRRichTextShadow : public IKRRenderShadowExport {
 
     KRSize context_measure_size_;
     KRSize main_measure_size_;
+    // TypographyLayout 使用的约束宽（vp）。与 context_measure_size_.width（最长行）分离。
+    float context_thread_layout_width_ = -1.0f;
+    float context_thread_constraint_height_ = -1.0f;
     std::unordered_map<int, int> placeholder_index_map_;
     std::vector<std::tuple<int, int, int>> span_offsets_;  // span, begin, end
     std::shared_ptr<KRParagraph> paragraph_;
@@ -318,6 +321,11 @@ class KRRichTextShadow : public IKRRenderShadowExport {
      * 使用，生命周期由 context_thread_typography_ 管理）。
      */
     OH_Drawing_Typography *BuildTextTypography(double constraint_width, double constraint_height);
+    /**
+     * context 线程：若最终节点宽与第一次排版约束宽不同，按最终宽创建新 Typography。
+     * 不要对旧对象再次 TypographyLayout。
+     */
+    void RelayoutToWidth(float width_vp);
 
     void ReleaseLastTypography();
     /**

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
@@ -16,7 +16,6 @@
 #include "libohos_render/expand/components/richtext/KRRichTextView.h"
 
 #include <codecvt>
-#include <cmath>
 #include <locale>
 #include <multimedia/image_framework/image/pixelmap_native.h>
 #include <native_drawing/drawing_brush.h>
@@ -106,7 +105,6 @@ void KRRichTextView::DidInit() {
 
 void KRRichTextView::SetShadow(const std::shared_ptr<IKRRenderShadowExport> &shadow) {
     shadow_ = shadow;
-    last_draw_frame_width_ = -1.0;
 
     auto textShadow = std::dynamic_pointer_cast<KRRichTextShadow>(shadow);
     // 决策 6C：image span（由 PostProcessor("richtext") 拆段产生）只在 V1（老 typography）
@@ -160,7 +158,6 @@ void KRRichTextView::DidRemoveFromParentView() {
     IKRRenderViewExport::DidRemoveFromParentView();
     shadow_ = nullptr;
     paragraph_ = nullptr;
-    last_draw_frame_width_ = -1.0;
 }
 
 void KRRichTextView::OnForegroundDraw(ArkUI_NodeCustomEvent *event) {
@@ -202,27 +199,11 @@ void KRRichTextView::OnForegroundDraw(ArkUI_NodeCustomEvent *event) {
     auto *drawContext = OH_ArkUI_NodeCustomEvent_GetDrawContextInDraw(event);
     auto *drawingHandle = reinterpret_cast<OH_Drawing_Canvas *>(OH_ArkUI_DrawContext_GetCanvas(drawContext));
     auto frameWidth = GetFrame().width;
-    // 用排版约束宽（TypographyLayout 的 maxWidth）和最终 frame 比较，对齐 Android
-    // StaticLayout.width vs layoutParams.width。不要用 GetLongestLine()，也不要因为
-    // textAlign != LEFT 就重排：右对齐已在第一次 BuildTextTypography 里设置。
-    constexpr float kLayoutWidthEpsilonVp = 1.0f;
-    bool needReLayout = false;
-    auto layoutWidth = richTextShadow->MainThreadLayoutWidth();
-    if (layoutWidth > 0 && fabs(layoutWidth - frameWidth) > kLayoutWidthEpsilonVp) {
-        needReLayout = true;
-    }
-    if (last_draw_frame_width_ > 0 && fabs(last_draw_frame_width_ - frameWidth) > kLayoutWidthEpsilonVp) {
-        needReLayout = true;
-    }
-    if (needReLayout) {
-        // 框宽相对测量约束确实变了：只对主线程已持有的 typography 原地 Layout。
-        // 不要在绘制回调里 BuildTextTypography（会写 context_thread_*，且会跑
-        // PostProcessor / 字体注册）。完整重建应留在 context 线程。
-        auto dpi = KRConfig::GetDpi();
-        OH_Drawing_TypographyLayout(textTypo, frameWidth * dpi);
-        richTextShadow->SetMainThreadLayoutWidth(frameWidth);
-    }
-    last_draw_frame_width_ = frameWidth;
+    // 不要在绘制期对已 Layout 的 Typography 再 TypographyLayout：HarmonyOS 6 上
+    // 同一对象二次 Layout 不是幂等的（flex+textAlignRight 多行中文漏字）。
+    // 测量已按约束宽 Layout，并带上 textAlign；旋转/分屏等真实改宽由 Yoga
+    // 重新测量 + SetShadow 交付新对象。框宽真变且尚未重测时的重建，应在
+    // context 线程做，不能在这里原地 Layout。
 
     if (!selection_rects_.selection_rects.empty()) {
         double density = KRConfig::GetDpi();

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
@@ -16,7 +16,6 @@
 #include "libohos_render/expand/components/richtext/KRRichTextView.h"
 
 #include <codecvt>
-#include <cmath>
 #include <locale>
 #include <multimedia/image_framework/image/pixelmap_native.h>
 #include <native_drawing/drawing_brush.h>

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
@@ -16,6 +16,7 @@
 #include "libohos_render/expand/components/richtext/KRRichTextView.h"
 
 #include <codecvt>
+#include <cmath>
 #include <locale>
 #include <multimedia/image_framework/image/pixelmap_native.h>
 #include <native_drawing/drawing_brush.h>

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
@@ -201,9 +201,8 @@ void KRRichTextView::OnForegroundDraw(ArkUI_NodeCustomEvent *event) {
     auto frameWidth = GetFrame().width;
     // 不要在绘制期对已 Layout 的 Typography 再 TypographyLayout：HarmonyOS 6 上
     // 同一对象二次 Layout 不是幂等的（flex+textAlignRight 多行中文漏字）。
-    // 测量已按约束宽 Layout，并带上 textAlign；旋转/分屏等真实改宽由 Yoga
-    // 重新测量 + SetShadow 交付新对象。框宽真变且尚未重测时的重建，应在
-    // context 线程做，不能在这里原地 Layout。
+    // 测量按约束宽 Layout；若 Kotlin 算出的节点宽与约束宽不同，context 线程
+    // relayoutToWidth 会创建新对象，再经 SetShadow 交给主线程。
 
     if (!selection_rects_.selection_rects.empty()) {
         double density = KRConfig::GetDpi();

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
@@ -16,6 +16,7 @@
 #include "libohos_render/expand/components/richtext/KRRichTextView.h"
 
 #include <codecvt>
+#include <cmath>
 #include <locale>
 #include <multimedia/image_framework/image/pixelmap_native.h>
 #include <native_drawing/drawing_brush.h>
@@ -105,6 +106,7 @@ void KRRichTextView::DidInit() {
 
 void KRRichTextView::SetShadow(const std::shared_ptr<IKRRenderShadowExport> &shadow) {
     shadow_ = shadow;
+    last_draw_frame_width_ = -1.0;
 
     auto textShadow = std::dynamic_pointer_cast<KRRichTextShadow>(shadow);
     // 决策 6C：image span（由 PostProcessor("richtext") 拆段产生）只在 V1（老 typography）
@@ -196,27 +198,32 @@ void KRRichTextView::OnForegroundDraw(ArkUI_NodeCustomEvent *event) {
         return;
     }
     double drawOffsetY = richTextShadow->DrawOffsetY();
-    OH_Drawing_TextAlign textAlign = richTextShadow->TextAlign();
-    auto textTypoSize = richTextShadow->MainMeasureSize();
     // 在容器前景上绘制额外图形，实现图形显示在子组件之上。
     auto *drawContext = OH_ArkUI_NodeCustomEvent_GetDrawContextInDraw(event);
     auto *drawingHandle = reinterpret_cast<OH_Drawing_Canvas *>(OH_ArkUI_DrawContext_GetCanvas(drawContext));
     auto frameWidth = GetFrame().width;
+    // 用排版约束宽（TypographyLayout 的 maxWidth）和最终 frame 比较，对齐 Android
+    // StaticLayout.width vs layoutParams.width。不要用 GetLongestLine()，也不要因为
+    // textAlign != LEFT 就重排：右对齐已在第一次 BuildTextTypography 里设置。
+    constexpr float kLayoutWidthEpsilonVp = 1.0f;
     bool needReLayout = false;
-    if (last_draw_frame_width_ > 0 && fabs(last_draw_frame_width_ - frameWidth) > 0.01) {
+    auto layoutWidth = richTextShadow->MainThreadLayoutWidth();
+    if (layoutWidth > 0 && fabs(layoutWidth - frameWidth) > kLayoutWidthEpsilonVp) {
         needReLayout = true;
     }
-    if (fabs(textTypoSize.width - frameWidth) > 1 || textAlign != TEXT_ALIGN_LEFT) {
+    if (last_draw_frame_width_ > 0 && fabs(last_draw_frame_width_ - frameWidth) > kLayoutWidthEpsilonVp) {
         needReLayout = true;
     }
     if (needReLayout) {
-        auto dpi = KRConfig::GetDpi();
-        OH_Drawing_TypographyLayout(textTypo, frameWidth * dpi);
-        last_draw_frame_width_ = frameWidth;
-        if (textAlign != TEXT_ALIGN_LEFT) {
-            richTextShadow->ResetTextAlign();
+        KRTypographyHandle rebuilt =
+            richTextShadow->RelayoutExactly(frameWidth, GetFrame().height);
+        if (rebuilt) {
+            textTypoHandle = rebuilt;
+            textTypo = rebuilt.get();
+            drawOffsetY = richTextShadow->DrawOffsetY();
         }
     }
+    last_draw_frame_width_ = frameWidth;
 
     if (!selection_rects_.selection_rects.empty()) {
         double density = KRConfig::GetDpi();

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
@@ -215,13 +215,12 @@ void KRRichTextView::OnForegroundDraw(ArkUI_NodeCustomEvent *event) {
         needReLayout = true;
     }
     if (needReLayout) {
-        KRTypographyHandle rebuilt =
-            richTextShadow->RelayoutExactly(frameWidth, GetFrame().height);
-        if (rebuilt) {
-            textTypoHandle = rebuilt;
-            textTypo = rebuilt.get();
-            drawOffsetY = richTextShadow->DrawOffsetY();
-        }
+        // 框宽相对测量约束确实变了：只对主线程已持有的 typography 原地 Layout。
+        // 不要在绘制回调里 BuildTextTypography（会写 context_thread_*，且会跑
+        // PostProcessor / 字体注册）。完整重建应留在 context 线程。
+        auto dpi = KRConfig::GetDpi();
+        OH_Drawing_TypographyLayout(textTypo, frameWidth * dpi);
+        richTextShadow->SetMainThreadLayoutWidth(frameWidth);
     }
     last_draw_frame_width_ = frameWidth;
 

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.h
@@ -169,7 +169,6 @@ class KRRichTextView : public IKRRenderViewExport {
  private:
     std::shared_ptr<KRParagraph> paragraph_;
     std::shared_ptr<IKRRenderShadowExport> shadow_;
-    float last_draw_frame_width_ = -1.0;
     float line_break_margin_ = 0;
     KRParagraphSelectionInfo selection_rects_;
     void OnForegroundDraw(ArkUI_NodeCustomEvent *event);

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/RichTextView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/RichTextView.kt
@@ -224,6 +224,9 @@ open class RichTextView : DeclarativeBaseView<RichTextAttr, RichTextEvent>(),
         if (!flexNode.styleMinHeight.isUndefined()) {
             size = heightLayoutSize(size, width, flexNode.styleMinHeight)
         }
+        if (!shouldSkipOhosRelayoutToNodeWidth(size.width, cWidth)) {
+            shadow?.relayoutToWidthIfNeeded(cWidth, size.width)
+        }
         didLayout = true
         if (shadow?.calculateFromCache != true) {
             renderView?.setShadow()
@@ -244,6 +247,13 @@ open class RichTextView : DeclarativeBaseView<RichTextAttr, RichTextEvent>(),
                 }
             }
         }
+    }
+
+    private fun shouldSkipOhosRelayoutToNodeWidth(nodeWidth: Float, constraintWidth: Float): Boolean {
+        if (!flexNode.styleWidth.isUndefined()) {
+            return false
+        }
+        return flexNode.widthStretchedToMeasureConstraint() && nodeWidth < constraintWidth
     }
 
     fun buildValuesPropValue(): String {

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextView.kt
@@ -27,6 +27,7 @@ import com.tencent.kuikly.core.base.ViewContainer
 import com.tencent.kuikly.core.base.event.Event
 import com.tencent.kuikly.core.base.event.EventHandlerFn
 import com.tencent.kuikly.core.base.toInt
+import com.tencent.kuikly.core.layout.FlexAlign
 import com.tencent.kuikly.core.layout.FlexDirection
 import com.tencent.kuikly.core.layout.FlexNode
 import com.tencent.kuikly.core.layout.FlexPositionType
@@ -132,6 +133,9 @@ open class TextView : DeclarativeBaseView<TextAttr, TextEvent>(), MeasureFunctio
         if (!flexNode.styleMinHeight.isUndefined()) {
             size = heightLayoutSize(size, width, flexNode.styleMinHeight)
         }
+        if (!shouldSkipOhosRelayoutToNodeWidth(size.width, cWidth)) {
+            shadow?.relayoutToWidthIfNeeded(cWidth, size.width)
+        }
         didLayout = true
 
         updateShadow()
@@ -150,6 +154,13 @@ open class TextView : DeclarativeBaseView<TextAttr, TextEvent>(), MeasureFunctio
                 }
             }
         }
+    }
+
+    private fun shouldSkipOhosRelayoutToNodeWidth(nodeWidth: Float, constraintWidth: Float): Boolean {
+        if (!flexNode.styleWidth.isUndefined()) {
+            return false
+        }
+        return flexNode.widthStretchedToMeasureConstraint() && nodeWidth < constraintWidth
     }
 
     private fun canSyncToRenderView(propKey: String): Boolean {
@@ -559,6 +570,19 @@ object TextConst {
     const val PLACEHOLDER_COLOR = "placeholderColor"
     const val SELECTION_COLOR = "selectionColor"
     const val AUTO_HIDE_KEYBOARD_ON_IME_ACTION = "autoHideKeyboardOnImeAction"
+}
+
+internal fun FlexNode.widthStretchedToMeasureConstraint(): Boolean {
+    if (positionType != FlexPositionType.RELATIVE) {
+        return false
+    }
+    val parentNode = parent ?: return false
+    val direction = parentNode.flexDirection
+    if (direction != FlexDirection.COLUMN && direction != FlexDirection.COLUMN_REVERSE) {
+        return false
+    }
+    val align = if (alignSelf == FlexAlign.AUTO) parentNode.alignItems else alignSelf
+    return align == FlexAlign.STRETCH
 }
 
 enum class TextAlign(val value: String) {

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/shadow/TextShadow.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/shadow/TextShadow.kt
@@ -17,6 +17,8 @@ package com.tencent.kuikly.core.views.shadow
 
 import com.tencent.kuikly.core.base.Shadow
 import com.tencent.kuikly.core.base.Size
+import com.tencent.kuikly.core.manager.PagerManager
+import kotlin.math.abs
 
 open class TextShadow(pagerId: String, viewRef: Int, viewName: String) : Shadow(
     pagerId, viewRef,
@@ -53,6 +55,24 @@ open class TextShadow(pagerId: String, viewRef: Int, viewName: String) : Shadow(
         return size
     }
 
+    /**
+     * OHOS V1：Yoga 最终节点宽若与第一次排版约束宽不同，在 context 线程按节点宽
+     * 创建新 Typography。不要改 lastWidth 缓存，以免每帧都重新测自然宽。
+     */
+    fun relayoutToWidthIfNeeded(constraintWidth: Float, nodeWidth: Float) {
+        val pager = PagerManager.getPager(pagerId)
+        if (!pager.pageData.isOhOs) {
+            return
+        }
+        if (nodeWidth <= 0f) {
+            return
+        }
+        if (abs(nodeWidth - constraintWidth) <= LAYOUT_WIDTH_EPSILON_VP) {
+            return
+        }
+        callMethod(SHADOW_METHOD_RELAYOUT_TO_WIDTH, nodeWidth.toString())
+    }
+
     fun markDirty() {
         if (isDirty) {
             return
@@ -63,5 +83,10 @@ open class TextShadow(pagerId: String, viewRef: Int, viewName: String) : Shadow(
 
     private fun markNotDirty() {
         isDirty = false
+    }
+
+    companion object {
+        private const val LAYOUT_WIDTH_EPSILON_VP = 1f
+        private const val SHADOW_METHOD_RELAYOUT_TO_WIDTH = "relayoutToWidth"
     }
 }


### PR DESCRIPTION
## Summary

- `OnForegroundDraw` no longer calls `OH_Drawing_TypographyLayout` on an already-laid-out Typography. On HarmonyOS 6 that second in-place Layout is not idempotent and can drop/misplace multiline Chinese glyphs when `flex(1)` + `textAlignRight()` stretches the frame past `GetLongestLine()`.
- Measure still Layouts once at the Yoga constraint width (with `textAlign` already applied).
- After Kotlin applies flex / `styleWidth` / `minWidth`, if the node width differs from that constraint, OHOS rebuilds a **new** Typography on the context thread (`relayoutToWidth`) and delivers it via `SetShadow`. Wrap-content / `minWidth` right-align therefore paints inside the node box, without mutating the old object on the draw thread.
- Column `alignItems` stretch is skipped: the stretched frame already matches the measure constraint, so rebuilding at the natural width would be wrong.
- Left-align wrap-content skips the second build (glyphs start at x=0).

## Test plan

- [ ] HarmonyOS 6: `flexDirectionRow` + left label + right `Text { flex(1f); textAlignRight() }` multiline Chinese — no missing glyphs
- [ ] Wrap-content `textAlignRight()` short text (e.g. `市价`) in a row — text stays inside the node, not painted at the parent constraint
- [ ] `minWidth` larger than natural text width + `textAlignRight()`
- [ ] Column + default stretch + `textAlignRight()` — still uses parent width
- [ ] Same DSL on HarmonyOS 5 / iOS / Android — no regression
- [ ] Rotate / split-screen: text still updates via remasure + SetShadow