### PR TITLE
fix(compose): pin Lazy exact contentSize after last item is visible

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/lazy/LazyList.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/lazy/LazyList.kt
@@ -271,7 +271,7 @@ private fun rememberLazyListMeasurePolicy(
             if (itemsCount < state.kuiklyInfo.cachedTotalItems) {
                 state.kuiklyInfo.offsetDirty = true
             } else if (itemsCount > state.kuiklyInfo.cachedTotalItems) {
-                state.kuiklyInfo.realContentSize = null
+                state.kuiklyInfo.clearExactContentSize()
                 state.tryExpandStartSizeNoScroll()
             }
         }
@@ -282,6 +282,19 @@ private fun rememberLazyListMeasurePolicy(
             containerConstraints.maxHeight - totalVerticalPadding
         } else {
             containerConstraints.maxWidth - totalHorizontalPadding
+        }
+        val prevViewport = if (isVertical) {
+            state.layoutInfo.viewportSize.height
+        } else {
+            state.layoutInfo.viewportSize.width
+        }
+        val newViewport = if (isVertical) {
+            containerConstraints.maxHeight
+        } else {
+            containerConstraints.maxWidth
+        }
+        if (prevViewport > 0 && prevViewport != newViewport) {
+            state.kuiklyInfo.clearExactContentSize()
         }
         val visualItemOffset = if (!reverseLayout || mainAxisAvailableSize > 0) {
             IntOffset(startPadding, topPadding)
@@ -332,7 +345,7 @@ private fun rememberLazyListMeasurePolicy(
                 val oldHeight = state.kuiklyInfo.itemMainSpaceCache[itemResult.key]
                 // 高度扩大了
                 if ((oldHeight ?: 0) < itemResult.mainAxisSizeWithSpacings && !state.isScrollInProgress ) {
-                    state.kuiklyInfo.realContentSize = null
+                    state.kuiklyInfo.clearExactContentSize()
                     state.tryExpandStartSizeNoScroll()
                 }
                 state.kuiklyInfo.itemMainSpaceCache[itemResult.key] = itemResult.mainAxisSizeWithSpacings

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/lazy/grid/LazyGrid.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/lazy/grid/LazyGrid.kt
@@ -230,13 +230,16 @@ private fun rememberLazyGridMeasurePolicy(
             }.spacing
         }
         val spaceBetweenLines = spaceBetweenLinesDp.roundToPx()
+        if (state.slotsPerLine > 0 && state.slotsPerLine != slotsPerLine) {
+            state.kuiklyInfo.clearExactContentSize()
+        }
         val itemsCount = itemProvider.itemCount
 
         if (state.kuiklyInfo.cachedTotalItems > 0) {
             if (itemsCount < state.kuiklyInfo.cachedTotalItems) {
                 state.kuiklyInfo.offsetDirty = true
             } else if (itemsCount > state.kuiklyInfo.cachedTotalItems) {
-                state.kuiklyInfo.realContentSize = null
+                state.kuiklyInfo.clearExactContentSize()
                 state.tryExpandStartSizeNoScroll()
             }
         }
@@ -247,6 +250,19 @@ private fun rememberLazyGridMeasurePolicy(
             containerConstraints.maxHeight - totalVerticalPadding
         } else {
             containerConstraints.maxWidth - totalHorizontalPadding
+        }
+        val prevViewport = if (isVertical) {
+            state.layoutInfo.viewportSize.height
+        } else {
+            state.layoutInfo.viewportSize.width
+        }
+        val newViewport = if (isVertical) {
+            containerConstraints.maxHeight
+        } else {
+            containerConstraints.maxWidth
+        }
+        if (prevViewport > 0 && prevViewport != newViewport) {
+            state.kuiklyInfo.clearExactContentSize()
         }
         val visualItemOffset = if (!reverseLayout || mainAxisAvailableSize > 0) {
             IntOffset(startPadding, topPadding)
@@ -322,7 +338,7 @@ private fun rememberLazyGridMeasurePolicy(
                 val oldLineHeight = state.kuiklyInfo.itemMainSpaceCache[lineKey]
                 // 行高度扩大了
                 if ((oldLineHeight ?: 0) < lineResult.mainAxisSizeWithSpacings && !state.isScrollInProgress) {
-                    state.kuiklyInfo.realContentSize = null
+                    state.kuiklyInfo.clearExactContentSize()
                     state.tryExpandStartSizeNoScroll()
                 }
                 state.kuiklyInfo.itemMainSpaceCache[lineKey] = lineResult.mainAxisSizeWithSpacings

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/lazy/staggeredgrid/LazyStaggeredGridMeasure.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/foundation/lazy/staggeredgrid/LazyStaggeredGridMeasure.kt
@@ -239,7 +239,7 @@ internal class LazyStaggeredGridMeasureContext(
             val oldItemHeight = state.kuiklyInfo.itemMainSpaceCache[itemKey]
             // Item height has expanded
             if ((oldItemHeight ?: 0) < itemResult.mainAxisSizeWithSpacings && !state.isScrollInProgress) {
-                state.kuiklyInfo.realContentSize = null
+                state.kuiklyInfo.clearExactContentSize()
                 state.tryExpandStartSizeNoScroll()
             }
             state.kuiklyInfo.itemMainSpaceCache[itemKey] = itemResult.mainAxisSizeWithSpacings
@@ -251,6 +251,12 @@ internal class LazyStaggeredGridMeasureContext(
     val laneInfo = state.laneInfo
 
     val laneCount = resolvedSlots.sizes.size
+
+    init {
+        if (state.laneCount > 0 && state.laneCount != laneCount) {
+            state.kuiklyInfo.clearExactContentSize()
+        }
+    }
 
     fun LazyStaggeredGridItemProvider.isFullSpan(itemIndex: Int): Boolean =
         spanProvider.isFullSpan(itemIndex)
@@ -284,7 +290,7 @@ private fun LazyStaggeredGridMeasureContext.measure(
             if (itemCount < state.kuiklyInfo.cachedTotalItems) {
                 state.kuiklyInfo.offsetDirty = true
             } else if (itemCount > state.kuiklyInfo.cachedTotalItems) {
-                state.kuiklyInfo.realContentSize = null
+                state.kuiklyInfo.clearExactContentSize()
                 state.tryExpandStartSizeNoScroll()
             }
         }

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/gestures/KuiklyScrollInfo.kt
@@ -85,6 +85,14 @@ class KuiklyScrollInfo {
     var realContentSize: Int? = null
 
     /**
+     * Clear the pinned exact size so the next scroll can recompute it
+     * after a real layout change.
+     */
+    internal fun clearExactContentSize() {
+        realContentSize = null
+    }
+
+    /**
      * Whether the offset has deviation
      */
     var offsetDirty = false

--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ContentSizeExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ContentSizeExtensions.kt
@@ -40,6 +40,7 @@ import kotlin.math.roundToInt
  * Calculate content size
  */
 internal fun ScrollableState.calculateContentSize(): Int {
+    val previousExact = kuiklyInfo.realContentSize
     kuiklyInfo.realContentSize = null
     val density = kuiklyInfo.getDensity()
     val minSize = (ScrollableStateConstants.DEFAULT_CONTENT_SIZE * density).toInt()
@@ -62,8 +63,15 @@ internal fun ScrollableState.calculateContentSize(): Int {
         val viewportDelta = viewportSize - composeViewport
         // Compensate for contentPadding which does not affect viewportSize but is excluded from totalContentSize
         val contentPaddingCompensation = (contentPadding.totalPadding(kuiklyInfo.orientation).value * density).roundToInt()
-        kuiklyInfo.realContentSize = realContentSize + viewportDelta + contentPaddingCompensation
-        return kuiklyInfo.realContentSize!!
+        var exact = realContentSize + viewportDelta + contentPaddingCompensation
+        // lastItem.offset is viewport-relative. After a fling reaches the last item,
+        // a stale offset can inflate contentSize and skip native bounce.
+        // Measure clears the pin when layout actually changes.
+        if (previousExact != null && exact > previousExact && this.isLazyListOrGrid()) {
+            exact = previousExact
+        }
+        kuiklyInfo.realContentSize = exact
+        return exact
     }
 
     val bottomOffset = kuiklyInfo.composeOffset.toInt() + viewportSize
@@ -347,4 +355,8 @@ internal fun ScrollableState.tryExpandStartSizeNoScroll(forceExpand: Boolean = f
             }
         }
     }
+}
+
+private fun ScrollableState.isLazyListOrGrid(): Boolean {
+    return this is LazyListState || this is LazyGridState || this is LazyStaggeredGridState
 }


### PR DESCRIPTION
## Summary

- After the last Lazy item is visible, `calculateContentSize()` can still grow because `lastItem.offset` is viewport-relative. Native then no longer treats the scroller as at the end, so bounce/rubber-band is skipped.
- Pin Lazy List / Grid / Staggered exact `contentSize` so it cannot grow once an exact value exists (it can still shrink).
- Clear the pinned exact size only when measure actually changes: item count, un-scrolled item/row height, viewport, Grid `slotsPerLine`, or Staggered `laneCount`.

Pager / `ScrollState` are unchanged.

## Test plan

- [ ] Scroll a LazyColumn / LazyVerticalGrid to the last item and release: bounce/rubber-band should trigger
- [ ] Add/remove items or change item height while not scrolling: content size should update
- [ ] Pager and non-Lazy scrollers should keep current content-size behavior

Made with [Cursor](https://cursor.com)