### PR TITLE
fix(ohos): rebuild text typography at final width

### DIFF
--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
@@ -28,6 +28,7 @@
 #include <multimedia/image_framework/image/image_source_native.h>
 #include <multimedia/image_framework/image/pixelmap_native.h>
 
+#include <cmath>
 #include <codecvt>
 #include <thread>
 #include <unordered_set>
@@ -110,6 +111,11 @@ KRAnyValue KRRichTextShadow::Call(const std::string &method_name, const std::str
         return SpanRect(NewKRRenderValue(params)->toInt());
     } else if(method_name == "isLineBreakMargin"){
         return NewKRRenderValue(did_exceed_max_lines_ && OH_Drawing_DestroyTextLines? "1" : "0");
+    } else if (method_name == "relayoutToWidth") {
+        if (RelayoutToWidth(NewKRRenderValue(params)->toFloat())) {
+            return NewKRRenderValue(kuikly::util::ConvertSizeToString(context_measure_size_));
+        }
+        return NewKRRenderValue("");
     }
     return KRRenderValue::Make(nullptr);
 }
@@ -121,6 +127,7 @@ KRAnyValue KRRichTextShadow::Call(const std::string &method_name, const std::str
  * @return
  */
 KRSize KRRichTextShadow::CalculateRenderViewSize(double constraint_width, double constraint_height) {
+    context_thread_constraint_height_ = static_cast<float>(constraint_height);
     if(StyledStringEnabled()){
         KRSize sz = CalculateRenderViewSizeWithStyledString(constraint_width, constraint_height);
         return sz;
@@ -130,6 +137,28 @@ KRSize KRRichTextShadow::CalculateRenderViewSize(double constraint_width, double
     ReleaseLastTypography();
     BuildTextTypography(constraint_width, constraint_height);
     return context_measure_size_;
+}
+
+bool KRRichTextShadow::RelayoutToWidth(float width_vp) {
+    constexpr float kLayoutWidthEpsilonVp = 1.0f;
+    if (width_vp <= 0 || StyledStringEnabled() || !context_thread_typography_) {
+        return false;
+    }
+    if (context_thread_layout_width_ > 0 &&
+        std::fabs(width_vp - context_thread_layout_width_) <= kLayoutWidthEpsilonVp) {
+        return false;
+    }
+    if (context_thread_text_align_ == TEXT_ALIGN_LEFT &&
+        width_vp + kLayoutWidthEpsilonVp >= context_measure_size_.width &&
+        width_vp <= context_thread_layout_width_ + kLayoutWidthEpsilonVp) {
+        return false;
+    }
+
+    const double constraint_height = context_thread_constraint_height_;
+    auto previous_typography = context_thread_typography_;
+    // 走虚函数，确保 KRGradientRichTextShadow 仍执行其两阶段渐变尺寸计算。
+    CalculateRenderViewSize(width_vp, constraint_height);
+    return context_thread_typography_ && context_thread_typography_ != previous_typography;
 }
 
 KRSize KRRichTextShadow::CalculateRenderViewSizeWithStyledString(double constraint_width, double constraint_height) {
@@ -199,13 +228,24 @@ KRSchedulerTask KRRichTextShadow::TaskToMainQueueWhenWillSetShadowToView() {
     auto offsetX = context_thread_drawOffsetX_;
     auto measure_size = context_measure_size_;
     auto text_align = context_thread_text_align_;
-    return [self, typography, offsetY, offsetX, measure_size, text_align] {
+    auto text_content = text_content_;
+    auto span_offsets = span_offsets_;
+    auto image_draw_records = image_draw_records_;
+    auto did_exceed_max_lines = did_exceed_max_lines_;
+    auto styled_string_enabled = StyledStringEnabled();
+    return [self, typography, offsetY, offsetX, measure_size, text_align, text_content,
+            span_offsets, image_draw_records, did_exceed_max_lines, styled_string_enabled] {
         KRRichTextShadow *shadow = reinterpret_cast<KRRichTextShadow *>(self.get());
         shadow->SetMainThreadTypography(typography);
         shadow->main_thread_drawOffsetY_ = offsetY;
         shadow->main_thread_drawOffsetX_ = offsetX;
         shadow->main_thread_text_align_ = text_align;
         shadow->main_measure_size_ = measure_size;
+        shadow->main_thread_text_content_ = text_content;
+        shadow->main_thread_span_offsets_ = span_offsets;
+        shadow->main_thread_image_draw_records_ = image_draw_records;
+        shadow->main_thread_did_exceed_max_lines_ = did_exceed_max_lines;
+        shadow->main_thread_styled_string_enabled_ = styled_string_enabled;
     };
 }
 
@@ -665,6 +705,7 @@ OH_Drawing_Typography *KRRichTextShadow::BuildTextTypography(double constraint_w
     }
     double maxWidth = constraint_width * dpi;
     OH_Drawing_TypographyLayout(typography_raw, maxWidth);
+    context_thread_layout_width_ = static_cast<float>(constraint_width);
     did_exceed_max_lines_ = OH_Drawing_TypographyDidExceedMaxLines(typography_raw);
     // 获取文本布局结果的宽高
     auto height = OH_Drawing_TypographyGetHeight(typography_raw);
@@ -706,6 +747,7 @@ void KRRichTextShadow::ReleaseLastTypography() {
     context_thread_drawOffsetX_ = 0;
     context_thread_text_align_ = TEXT_ALIGN_LEFT;
     context_measure_size_ = KRSize(0, 0);
+    context_thread_layout_width_ = -1.0f;
 }
 
 // ===== Phase 3: image span 异步预加载（委托 KRCustomEmojiPixmapCache） =====
@@ -792,10 +834,11 @@ int KRRichTextShadow::SpanIndexAt(float spanX, float spanY) {
     if (main_typo_raw == nullptr) {
         return resultIndex;
     }
-    for (int index = 0; index < span_offsets_.size(); ++index) {
-        int lastSpanIndex = std::get<0>(span_offsets_[index]);
-        int lastSpanBegin = std::get<1>(span_offsets_[index]);
-        int lastSpanEnd = std::get<2>(span_offsets_[index]);
+    const auto &span_offsets = main_thread_span_offsets_;
+    for (int index = 0; index < span_offsets.size(); ++index) {
+        int lastSpanIndex = std::get<0>(span_offsets[index]);
+        int lastSpanBegin = std::get<1>(span_offsets[index]);
+        int lastSpanEnd = std::get<2>(span_offsets[index]);
         OH_Drawing_TextBox *box = OH_Drawing_TypographyGetRectsForRange(
             main_typo_raw, lastSpanBegin, lastSpanEnd, RECT_HEIGHT_STYLE_MAX, RECT_WIDTH_STYLE_MAX);
         int n = OH_Drawing_GetSizeOfTextBox(box);

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.cpp
@@ -140,7 +140,7 @@ KRSize KRRichTextShadow::CalculateRenderViewSize(double constraint_width, double
 }
 
 bool KRRichTextShadow::RelayoutToWidth(float width_vp) {
-    constexpr float kLayoutWidthEpsilonVp = 1.0f;
+    constexpr float kLayoutWidthEpsilonVp = 0.01f;
     if (width_vp <= 0 || StyledStringEnabled() || !context_thread_typography_) {
         return false;
     }
@@ -149,7 +149,7 @@ bool KRRichTextShadow::RelayoutToWidth(float width_vp) {
         return false;
     }
     if (context_thread_text_align_ == TEXT_ALIGN_LEFT &&
-        width_vp + kLayoutWidthEpsilonVp >= context_measure_size_.width &&
+        width_vp >= context_measure_size_.width &&
         width_vp <= context_thread_layout_width_ + kLayoutWidthEpsilonVp) {
         return false;
     }

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextShadow.h
@@ -185,13 +185,19 @@ class KRRichTextShadow : public IKRRenderShadowExport {
     std::string GetTextContent() const {
         return text_content_;
     }
+    const std::string &MainThreadTextContent() const {
+        return main_thread_text_content_;
+    }
+    const std::vector<std::tuple<int, int, int>> &MainThreadSpanOffsets() const {
+        return main_thread_span_offsets_;
+    }
 
     KRSize MainMeasureSize() {
         return main_measure_size_;
     }
     
     bool DidExceedMaxLines(){
-        return did_exceed_max_lines_;
+        return main_thread_did_exceed_max_lines_;
     }
     
     OH_Drawing_Array *GetTextLines();
@@ -242,7 +248,7 @@ class KRRichTextShadow : public IKRRenderShadowExport {
         float height_vp = 0.0f;
     };
     const std::vector<KRImageDrawRecord> &GetImageDrawRecords() const {
-        return image_draw_records_;
+        return main_thread_image_draw_records_;
     }
 
     // ===== Phase 3↔4 桥接：image span 解码完成通知 view markDirty =====
@@ -261,6 +267,12 @@ class KRRichTextShadow : public IKRRenderShadowExport {
     bool HasImageSpans() const {
         return !image_draw_records_.empty();
     }
+    bool MainThreadHasImageSpans() const {
+        return !main_thread_image_draw_records_.empty();
+    }
+    bool MainThreadStyledStringEnabled() const {
+        return main_thread_styled_string_enabled_;
+    }
 
  private:
     void DestroyCachedTextLines();
@@ -273,10 +285,13 @@ class KRRichTextShadow : public IKRRenderShadowExport {
     void TriggerImagePrefetchIfNeed();
  private:
     std::string text_content_;
+    std::string main_thread_text_content_;
     KRRenderValue::Map props_;
     KRRenderValue::Array values_;
     OH_Drawing_Array *text_lines_ = nullptr;
     bool did_exceed_max_lines_ = false;
+    bool main_thread_did_exceed_max_lines_ = false;
+    bool main_thread_styled_string_enabled_ = false;
     // 持有 typography 的两个槽位：
     //  - main_thread_typography_:    主线程使用（Paint/SpanIndex 等）；
     //  - context_thread_typography_: context 线程使用（Layout/SpanRect 计算）。
@@ -294,17 +309,22 @@ class KRRichTextShadow : public IKRRenderShadowExport {
 
     KRSize context_measure_size_;
     KRSize main_measure_size_;
+    // 最近一次 TypographyLayout 使用的约束宽，以及对应的测量高度约束（单位 vp）。
+    float context_thread_layout_width_ = -1.0f;
+    float context_thread_constraint_height_ = -1.0f;
     std::unordered_map<int, int> placeholder_index_map_;
     std::vector<std::tuple<int, int, int>> span_offsets_;  // span, begin, end
+    std::vector<std::tuple<int, int, int>> main_thread_span_offsets_;
     std::shared_ptr<KRParagraph> paragraph_;
     KRSpinLock paragraph_lock_;
     std::shared_ptr<kuikly::util::KRLinearGradientParser> text_linearGradient_;
 
     // ===== Phase 4: image span 绘制相关 =====
-    // image_draw_records_ 仅由 BuildTextTypography 在 context 线程构造，主线程读取（OnForegroundDraw）。
-    // 重建（SetProp("values") -> Measure -> BuildTextTypography）时整体覆盖，无并发改写问题。
+    // context 线程构造 image_draw_records_；SetShadow 任务将快照复制到
+    // main_thread_image_draw_records_，供 OnForegroundDraw 使用。
     // pixmap 缓存已迁移至 KRCustomEmojiPixmapCache（进程级单例 + LRU 128）。
     std::vector<KRImageDrawRecord> image_draw_records_;
+    std::vector<KRImageDrawRecord> main_thread_image_draw_records_;
     std::mutex image_loaded_callback_mutex_;
     ImageLoadedCallback image_loaded_callback_;
 
@@ -318,6 +338,11 @@ class KRRichTextShadow : public IKRRenderShadowExport {
      * 使用，生命周期由 context_thread_typography_ 管理）。
      */
     OH_Drawing_Typography *BuildTextTypography(double constraint_width, double constraint_height);
+    /**
+     * context 线程：按最终节点宽创建新的 Typography，不复用已经 Layout 的对象。
+     * 返回 true 表示 context_thread_typography_ 已被替换。
+     */
+    bool RelayoutToWidth(float width_vp);
 
     void ReleaseLastTypography();
     /**

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.cpp
@@ -110,9 +110,9 @@ void KRRichTextView::SetShadow(const std::shared_ptr<IKRRenderShadowExport> &sha
     // 决策 6C：image span（由 PostProcessor("richtext") 拆段产生）只在 V1（老 typography）
     // OnForegroundDraw 路径下能被绘制——因为 V2 的 StyledString 是交给 ArkUI 节点直接
     // 渲染，SDK 当前没暴露插入图片绘制 hook 的入口。这个判定已收敛到
-    // shadow->StyledStringEnabled()（含 image span 时返 false），本处只读一个结果。
-    bool use_styled_string = textShadow && textShadow->StyledStringEnabled();
-    bool has_image_span = textShadow && textShadow->HasImageSpans();
+    // context 线程已把 StyledString / image span 状态随 Typography 一起快照到主线程。
+    bool use_styled_string = textShadow && textShadow->MainThreadStyledStringEnabled();
+    bool has_image_span = textShadow && textShadow->MainThreadHasImageSpans();
     if(use_styled_string){
         ArkUI_AttributeItem item;
         if(std::shared_ptr<KRParagraph> paragraph = std::dynamic_pointer_cast<KRRichTextShadow>(shadow)->GetParagraph()){
@@ -158,7 +158,6 @@ void KRRichTextView::DidRemoveFromParentView() {
     IKRRenderViewExport::DidRemoveFromParentView();
     shadow_ = nullptr;
     paragraph_ = nullptr;
-    last_draw_frame_width_ = -1.0;
 }
 
 void KRRichTextView::OnForegroundDraw(ArkUI_NodeCustomEvent *event) {
@@ -196,27 +195,12 @@ void KRRichTextView::OnForegroundDraw(ArkUI_NodeCustomEvent *event) {
         return;
     }
     double drawOffsetY = richTextShadow->DrawOffsetY();
-    OH_Drawing_TextAlign textAlign = richTextShadow->TextAlign();
-    auto textTypoSize = richTextShadow->MainMeasureSize();
     // 在容器前景上绘制额外图形，实现图形显示在子组件之上。
     auto *drawContext = OH_ArkUI_NodeCustomEvent_GetDrawContextInDraw(event);
     auto *drawingHandle = reinterpret_cast<OH_Drawing_Canvas *>(OH_ArkUI_DrawContext_GetCanvas(drawContext));
     auto frameWidth = GetFrame().width;
-    bool needReLayout = false;
-    if (last_draw_frame_width_ > 0 && fabs(last_draw_frame_width_ - frameWidth) > 0.01) {
-        needReLayout = true;
-    }
-    if (fabs(textTypoSize.width - frameWidth) > 1 || textAlign != TEXT_ALIGN_LEFT) {
-        needReLayout = true;
-    }
-    if (needReLayout) {
-        auto dpi = KRConfig::GetDpi();
-        OH_Drawing_TypographyLayout(textTypo, frameWidth * dpi);
-        last_draw_frame_width_ = frameWidth;
-        if (textAlign != TEXT_ALIGN_LEFT) {
-            richTextShadow->ResetTextAlign();
-        }
-    }
+    // Typography 已在 context 线程按最终 frame 宽度构建。绘制期不能对同一对象再次
+    // TypographyLayout；HarmonyOS 6 上该重入会破坏多行中文的 glyph run。
 
     if (!selection_rects_.selection_rects.empty()) {
         double density = KRConfig::GetDpi();
@@ -694,9 +678,9 @@ KRParagraphInfo KRRichTextView::GetParagraphInfo() {
     paragraph_info.width_ = frame.width;
     paragraph_info.height_ = frame.height;
 
-    std::string text_content = textShadow->GetTextContent();
+    std::string text_content = textShadow->MainThreadTextContent();
     paragraph_info.text_content_ = text_content;
-    paragraph_info.span_offsets_ = textShadow->span_offsets_;
+    paragraph_info.span_offsets_ = textShadow->MainThreadSpanOffsets();
     size_t lineCount = OH_Drawing_TypographyGetLineCount(textTypo);
     for (size_t i = 0; i < lineCount; ++i) {
         KRLineInfo line_info;

--- a/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.h
+++ b/core-render-ohos/src/main/cpp/libohos_render/expand/components/richtext/KRRichTextView.h
@@ -157,7 +157,7 @@ class KRRichTextView : public IKRRenderViewExport {
         return selection_rects_.selection_rects.empty() ? KRRect() : selection_rects_.selection_rects.back();
     }
     std::string GetTextContent() {
-        return std::dynamic_pointer_cast<KRRichTextShadow>(shadow_)->GetTextContent();
+        return std::dynamic_pointer_cast<KRRichTextShadow>(shadow_)->MainThreadTextContent();
     }
     std::string GetSelectedContent(std::string &pre, std::string &post);
     bool IsTextView() override {
@@ -169,7 +169,6 @@ class KRRichTextView : public IKRRenderViewExport {
  private:
     std::shared_ptr<KRParagraph> paragraph_;
     std::shared_ptr<IKRRenderShadowExport> shadow_;
-    float last_draw_frame_width_ = -1.0;
     float line_break_margin_ = 0;
     KRParagraphSelectionInfo selection_rects_;
     void OnForegroundDraw(ArkUI_NodeCustomEvent *event);

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/RichTextView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/RichTextView.kt
@@ -228,19 +228,37 @@ open class RichTextView : DeclarativeBaseView<RichTextAttr, RichTextEvent>(),
         if (shadow?.calculateFromCache != true) {
             renderView?.setShadow()
         }
+        scheduleOhosTypographyRelayout()
         measureOutput.width = size!!.width
         measureOutput.height = size!!.height
         dispatchPlaceholderSpanLayoutEventIfNeed()
         tryFireLineBreakMarginEvent()
     }
 
+    private fun scheduleOhosTypographyRelayout() {
+        val pager = getPager()
+        if (!pager.pageData.isOhOs) {
+            return
+        }
+        pager.addTaskWhenPagerDidCalculateLayout {
+            shadow?.relayoutToWidthIfNeeded(flexNode.layoutFrame.width)?.let { heightChanged ->
+                renderView?.setShadow()
+                if (heightChanged && flexNode.styleHeight.isUndefined()) {
+                    flexNode.markDirty()
+                }
+            }
+        }
+    }
+
     private fun tryFireLineBreakMarginEvent() {
         if (attr.getProp(TextConst.LINE_BREAK_MARGIN) != null) {
             getPager().addTaskWhenPagerDidCalculateLayout {
-                val isLineBreakMargin =
-                    shadow?.callMethod(TextConst.SHADOW_METHOD_IS_LINE_BREAK_MARGIN, "") == "1"
-                if (isLineBreakMargin) {
-                    onFireEvent(TextEvent.TextEventConst.ON_LINE_BREAK_MARGIN, null)
+                if (!flexNode.isDirty) {
+                    val isLineBreakMargin =
+                        shadow?.callMethod(TextConst.SHADOW_METHOD_IS_LINE_BREAK_MARGIN, "") == "1"
+                    if (isLineBreakMargin) {
+                        onFireEvent(TextEvent.TextEventConst.ON_LINE_BREAK_MARGIN, null)
+                    }
                 }
             }
         }

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextView.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/TextView.kt
@@ -135,6 +135,7 @@ open class TextView : DeclarativeBaseView<TextAttr, TextEvent>(), MeasureFunctio
         didLayout = true
 
         updateShadow()
+        scheduleOhosTypographyRelayout()
         measureOutput.width = size?.width ?: 0f
         measureOutput.height = size?.height ?: 0f
         tryFireLineBreakMarginEvent()
@@ -143,10 +144,27 @@ open class TextView : DeclarativeBaseView<TextAttr, TextEvent>(), MeasureFunctio
     private fun tryFireLineBreakMarginEvent() {
         if (attr.getProp(TextConst.LINE_BREAK_MARGIN) != null) {
             getPager().addTaskWhenPagerDidCalculateLayout {
-                val isLineBreakMargin =
-                    shadow?.callMethod(TextConst.SHADOW_METHOD_IS_LINE_BREAK_MARGIN, "") == "1"
-                if (isLineBreakMargin) {
-                    onFireEvent(TextEvent.TextEventConst.ON_LINE_BREAK_MARGIN, null)
+                if (!flexNode.isDirty) {
+                    val isLineBreakMargin =
+                        shadow?.callMethod(TextConst.SHADOW_METHOD_IS_LINE_BREAK_MARGIN, "") == "1"
+                    if (isLineBreakMargin) {
+                        onFireEvent(TextEvent.TextEventConst.ON_LINE_BREAK_MARGIN, null)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun scheduleOhosTypographyRelayout() {
+        val pager = getPager()
+        if (!pager.pageData.isOhOs) {
+            return
+        }
+        pager.addTaskWhenPagerDidCalculateLayout {
+            shadow?.relayoutToWidthIfNeeded(flexNode.layoutFrame.width)?.let { heightChanged ->
+                renderView?.setShadow()
+                if (heightChanged && flexNode.styleHeight.isUndefined()) {
+                    flexNode.markDirty()
                 }
             }
         }

--- a/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/shadow/TextShadow.kt
+++ b/core/src/commonMain/kotlin/com/tencent/kuikly/core/views/shadow/TextShadow.kt
@@ -17,6 +17,7 @@ package com.tencent.kuikly.core.views.shadow
 
 import com.tencent.kuikly.core.base.Shadow
 import com.tencent.kuikly.core.base.Size
+import kotlin.math.abs
 
 open class TextShadow(pagerId: String, viewRef: Int, viewName: String) : Shadow(
     pagerId, viewRef,
@@ -53,6 +54,27 @@ open class TextShadow(pagerId: String, viewRef: Int, viewName: String) : Shadow(
         return size
     }
 
+    /**
+     * OHOS V1：按布局完成后的节点宽创建新的 Typography，避免在绘制期对同一对象
+     * 再次 Layout。返回 null 表示无需重建；非 null 值表示重建后文本高度是否变化。
+     */
+    fun relayoutToWidthIfNeeded(nodeWidth: Float): Boolean? {
+        if (nodeWidth <= 0f) {
+            return null
+        }
+        val sizeParts = callMethod(SHADOW_METHOD_RELAYOUT_TO_WIDTH, nodeWidth.toString()).split('|')
+        if (sizeParts.size != 2) {
+            return null
+        }
+        val relayoutWidth = sizeParts[0].toFloatOrNull() ?: return null
+        val relayoutHeight = sizeParts[1].toFloatOrNull() ?: return null
+        val cachedSize = lastSize
+        val heightChanged = cachedSize != null &&
+            abs(cachedSize.height - relayoutHeight) > LAYOUT_SIZE_EPSILON
+        lastSize = Size(cachedSize?.width ?: relayoutWidth, relayoutHeight)
+        return heightChanged
+    }
+
     fun markDirty() {
         if (isDirty) {
             return
@@ -63,5 +85,10 @@ open class TextShadow(pagerId: String, viewRef: Int, viewName: String) : Shadow(
 
     private fun markNotDirty() {
         isDirty = false
+    }
+
+    companion object {
+        private const val LAYOUT_SIZE_EPSILON = 0.01f
+        private const val SHADOW_METHOD_RELAYOUT_TO_WIDTH = "relayoutToWidth"
     }
 }


### PR DESCRIPTION
## 修复问题

修复 HarmonyOS 6 上 Kuikly V1 自绘 Text 在 `flex(1f) + textAlignRight()` 场景中，多行中文可能出现漏字、错行或字形模糊的问题。

根因是绘制阶段对已经排版过的同一个 `OH_Drawing_Typography` 再次调用 `TypographyLayout`，导致 glyph run 状态异常。

## 主要改动

- 移除绘制阶段的重复 `TypographyLayout`，绘制时只执行 Paint。
- Yoga 完成布局后，使用最终节点宽度检查排版结果。
- 宽度确实变化时，在 context 线程创建新的 Typography，而非重排旧对象。
- 文本高度变化时触发一次受限的二次布局。
- 将 Typography、文本、Span、图片和截断状态一起同步到主线程，保证数据一致。
- 仅影响 HarmonyOS V1 自绘路径，其他平台及 V2 StyledString 不受影响。