### PR TITLE
fix(compose): release Lazy exact contentSize pin after programmatic jump

### DIFF
--- a/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ContentSizeExtensions.kt
+++ b/compose/src/commonMain/kotlin/com/tencent/kuikly/compose/scroller/ContentSizeExtensions.kt
@@ -67,8 +67,13 @@ internal fun ScrollableState.calculateContentSize(): Int {
         // lastItem.offset is viewport-relative. After a fling reaches the last item,
         // a stale offset can inflate contentSize and skip native bounce.
         // Measure clears the pin when layout actually changes.
+        // After a programmatic jump, composeOffset can already exceed the pinned size;
+        // that pin is stale and must be released. At the true end, composeOffset is
+        // clamped to exact-viewport, so it never exceeds previousExact and the pin holds.
         if (previousExact != null && exact > previousExact && this.isLazyListOrGrid()) {
-            exact = previousExact
+            if (kuiklyInfo.composeOffset.toInt() <= previousExact) {
+                exact = previousExact
+            }
         }
         kuiklyInfo.realContentSize = exact
         return exact


### PR DESCRIPTION
## Summary

- Follow-up to #1734. Pinning Lazy exact `contentSize` so it cannot grow is still needed after a fling reaches the last item (`lastItem.offset` is viewport-relative and can inflate height, which skips bounce).
- After `scrollToItem` / `ignoreScrollOffset`, `composeOffset` can already be past the pinned size. Keeping the pin then leaves Native content too short and produces a blank region.
- Release the pin when `composeOffset > previousExact`. At the true end, `composeOffset` is clamped to `exact - viewport`, so it never exceeds the pinned size and bounce behavior from #1734 is unchanged.

## Test plan

- [ ] Open a Lazy list/grid, jump to a non-zero index (`scrollToItem`), then scroll: content should keep filling, no blank region
- [ ] Scroll a LazyColumn / LazyVerticalGrid to the last item and release: bounce/rubber-band should still trigger
- [ ] Pager and non-Lazy scrollers should keep current content-size behavior

Made with [Cursor](https://cursor.com)